### PR TITLE
V2 to V3 Image API Request URI Syntax

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -125,8 +125,8 @@ to install a certificate; see `config/sipi.config.lua` for instructions.
 
 ### IIIF Prefixes
 
-Sipi supports [IIIF image
-URLs](http://iiif.io/api/image/2.1/#image-request-uri-syntax).
+Sipi supports [IIIF Image API
+URLs](https://iiif.io/api/image/3.0/#21-image-request-uri-syntax).
 
 If the configuration property `prefix_as_path` is set to `true`, the
 IIIF `prefix` portion of the URL is interpreted as a subdirectory of


### PR DESCRIPTION
Correct link to the version 3 of the API