### PR TITLE
Fix typos, wordings and URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,27 +2,57 @@
 
 # Overview
 
-Sipi is a high-performance media server developed by the [Digital Humanities Lab](http://www.dhlab.unibas.ch) at the
-[University of Basel](https://www.unibas.ch/en.html). It is designed to be used by archives,
-libraries, and other institutions that need to preserve high-quality images
-while making them available online.
+SIPI is a multihreaded, high-performance, IIIF compatible media server developed by
+the [Data and Service Center for the Humanities](https://dasch.swiss) at the
+[University of Basel](https://www.unibas.ch/en.html). It is designed to
+be used by archives, libraries, and other institutions that need to
+preserve high-quality images while making them available online.
 
-Sipi implements the [International Image Interoperability Framework (IIIF)](http://iiif.io/),
-and efficiently converts between image formats, preserving metadata contained
-in image files. In particular, if images are stored in [JPEG 2000](https://jpeg.org/jpeg2000/) format,
-Sipi can convert them on the fly to formats that are commonly used on the
-Internet. Sipi offers a flexible framework for specifying authentication and
-authorization logic in [Lua](https://www.lua.org/) scripts, and supports restricted access to images,
-either by reducing image dimensions or by adding watermarks. It can easily be
-integrated with [Knora](http://www.knora.org).
+SIPI implements the Image API 3.0 of the International Image Interoperability Framework
+([IIIF](http://iiif.io/)), and efficiently converts between image
+formats, preserving metadata contained in image files. In particular, if
+images are stored in [JPEG 2000](https://jpeg.org/jpeg2000/) format,
+Sipi can convert them on the fly to formats that are commonly used on
+the Internet. SIPI offers a flexible framework for specifying
+authentication and authorization logic in [Lua](https://www.lua.org/)
+scripts, and supports restricted access to images, either by reducing
+image dimensions or by adding watermarks. It can easily be integrated
+with [Knora](http://www.knora.org/). In addition SIPI preserves most of
+the [EXIF](http://www.exif.org),
+[IPTC](https://iptc.org/standards/photo-metadata/iptc-standard/) and
+[XMP](http://www.adobe.com/products/xmp.html) metadata and can preserve
+or transform [ICC](https://en.wikipedia.org/wiki/ICC_profile) color
+profiles.
 
-Sipi is [free software](http://www.gnu.org/philosophy/free-sw.en.html),
-released under the [GNU Affero General Public License](http://www.gnu.org/licenses/agpl-3.0.en.html).
+In addition, a simple webserver is integrated. The server is able to
+serve most common file types. In addition Lua scripts and embedded Lua
+(i.e., Lua embedded into HTML pages using the tags
+&lt;lua&gt;…&lt;/lua&gt; are supported.
+
+SIPI can also be used from the command line to convert images to/from
+TIFF-, [JPEG 2000](https://jpeg.org/jpeg2000/), JPEG- and PNG-
+formats. For all these conversion, Sipi tries to preserve all embedded
+metadata such as
+- [IPTC](https://iptc.org/standards/photo-metadata/iptc-standard/)
+- [EXIF](http://www.exif.org)
+- [XMP](http://www.adobe.com/products/xmp.html)
+- [ICC](https://en.wikipedia.org/wiki/ICC_profile) color profiles.
+However, due to the limitations of some file formats, it cannot be
+guaranteed that all metadata and ICC profiles are preserved.
+- [JPEG2000](https://jpeg.org/jpeg2000/) (J2k) does not allow all types of ICC profiles
+  profiles. Unsupported profile types will be added to the J2k header as comment and will be
+
+SIPI is a [free software](http://www.gnu.org/philosophy/free-sw.en.html),
+released under the [GNU Affero General Public
+License](http://www.gnu.org/licenses/agpl-3.0.en.html). It is written in
+C++ and runs on Linux and macOS. Note: In order to compile SIPI, the user has
+to provide a licensed source of the [kakadu software](https://kakadusoftware.com).
 
 It is written in C++ and runs on Linux (including Debian, Ubuntu, and CentOS) and
-Mac OS X.
+macOS.
 
-Freely distributable binary releases will be available soon.
+Freely distributable binary releases are available
+[daschswiss/sipi](https://hub.docker.com/r/daschswiss/sipi) as docker image.
 
 # Documentation
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Overview
 
-SIPI is a multihreaded, high-performance, IIIF compatible media server developed by
+SIPI is a multithreaded, high-performance, IIIF compatible media server developed by
 the [Data and Service Center for the Humanities](https://dasch.swiss) at the
 [University of Basel](https://www.unibas.ch/en.html). It is designed to
 be used by archives, libraries, and other institutions that need to

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,10 +1,10 @@
-# Building Sipi from Source Code
+# Building SIPI from Source Code
 
 
 ## Prerequisites
 
 
-To build Sipi from source code, you must have
+To build SIPI from source code, you must have
 [Kakadu](http://kakadusoftware.com/), a JPEG 2000 development toolkit
 that is not provided with Sipi and must be licensed separately. The
 Kakadu source code archive `v8_0_5-01727L.zip` must be placed in the
@@ -21,9 +21,9 @@ assumed to be installed by default on macOS Sierra),
 [ImageMagick](http://www.imagemagick.org/). Instructions for installing
 these prerequisites are given below.
 
-The build process downloads and builds Sipi's other prerequisites.
+The build process downloads and builds SIPI's other prerequisites.
 
-Sipi uses the Adobe ICC Color profiles, which are automatically
+SIPI uses the Adobe ICC Color profiles, which are automatically
 downloaded by the build process into the file `icc.zip`. The user is
 responsible for reading and agreeing with Adobe's license conditions,
 which are specified in the file `Color Profile EULA.pdf`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Overview
 
-SIPI is a multihreaded, high-performance, IIIF compatible media server developed by
+SIPI is a multithreaded, high-performance, IIIF compatible media server developed by
 the [Data and Service Center for the Humanities](https://dasch.swiss) at the
 [University of Basel](https://www.unibas.ch/en.html). It is designed to
 be used by archives, libraries, and other institutions that need to

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,17 @@
 # Overview
 
-Sipi is a multihreaded, high-performance, IIIF compatible media server developed by
+SIPI is a multihreaded, high-performance, IIIF compatible media server developed by
 the [Data and Service Center for the Humanities](https://dasch.swiss) at the
 [University of Basel](https://www.unibas.ch/en.html). It is designed to
 be used by archives, libraries, and other institutions that need to
 preserve high-quality images while making them available online.
 
-Sipi implements the International Image Interoperability Framework
+SIPI implements the Image API 3.0 of the International Image Interoperability Framework
 ([IIIF](http://iiif.io/)), and efficiently converts between image
 formats, preserving metadata contained in image files. In particular, if
 images are stored in [JPEG 2000](https://jpeg.org/jpeg2000/) format,
 Sipi can convert them on the fly to formats that are commonly used on
-the Internet. Sipi offers a flexible framework for specifying
+the Internet. SIPI offers a flexible framework for specifying
 authentication and authorization logic in [Lua](https://www.lua.org/)
 scripts, and supports restricted access to images, either by reducing
 image dimensions or by adding watermarks. It can easily be integrated
@@ -19,7 +19,7 @@ with [Knora](http://www.knora.org/). In addition SIPI preserves most of
 the [EXIF](http://www.exif.org),
 [IPTC](https://iptc.org/standards/photo-metadata/iptc-standard/) and
 [XMP](http://www.adobe.com/products/xmp.html) metadata and can preserve
-or transform [ICC](https://en.wikipedia.org/wiki/ICC_profile) colour
+or transform [ICC](https://en.wikipedia.org/wiki/ICC_profile) color
 profiles.
 
 In addition, a simple webserver is integrated. The server is able to
@@ -27,7 +27,7 @@ serve most common file types. In addition Lua scripts and embedded Lua
 (i.e., Lua embedded into HTML pages using the tags
 &lt;lua&gt;…&lt;/lua&gt; are supported.
 
-Sipi can also be used from the command line to convert images to/from
+SIPI can also be used from the command line to convert images to/from
 TIFF-, [JPEG 2000](https://jpeg.org/jpeg2000/), JPEG- and PNG-
 formats. For all these conversion, Sipi tries to preserve all embedded
 metadata such as
@@ -41,11 +41,14 @@ guaranteed that all metadata and ICC profiles are preserved.
   profiles. Unsupported profile types will be added to the J2k header as comment and will be
 reinstated if the J2k file is converted back to the TIFF-format.
 
-Sipi is [free software](http://www.gnu.org/philosophy/free-sw.en.html),
+SIPI is a [free software](http://www.gnu.org/philosophy/free-sw.en.html),
 released under the [GNU Affero General Public
 License](http://www.gnu.org/licenses/agpl-3.0.en.html). It is written in
-C++ and runs on Linux and Mac OS X. Note: In order to compile SIPI, the user has
+C++ and runs on Linux and macOS. Note: In order to compile SIPI, the user has
 to provide a licensed source of the [kakadu software](https://kakadusoftware.com).
+
+It is written in C++ and runs on Linux (including Debian, Ubuntu, and CentOS) and
+macOS.
 
 Freely distributable binary releases are available
 [daschswiss/sipi](https://hub.docker.com/r/daschswiss/sipi) as docker image.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,11 +1,11 @@
 # Simple Image Presentation Interface (SIPI) - Introduction
 ## What is SIPI?
 ### 1. A IIIF Image API V3 level 2 conformant image server
-- SIPI is a full multithreaded, high performance, level2 conformant [IIIF](https://iiif.io) written in C++. For the
+- SIPI is a full multithreaded, high performance, level2 compliant [IIIF Image API 3.0](https://iiif.io/api/image/3.0) written in C++. For the
   JPEG2000 implementation, it relies on the commercial [kakadu-library](https://kakadusoftware.com), but otherwise it is
-  completely open source on [github](https://github.com/dasch-swiss/sipi). It offers special support for multipage PDF's
+  completely open source on [GitHub](https://github.com/dasch-swiss/sipi). It offers special support for multipage PDFs
   (through a SIPI-specific extensions to the IIIF Image API).
-- SIPI has been designed with long term preservation for images regarded as cultural heritage in mind. Thus it offers
+- SIPI has been designed for the long term preservation of images, intended for the needs of the cultural heritage field. Thus it offers
   some unique features for this purpose:
   - all file format conversions try to preserve all metadata (EXIF, XMP, IPTC etc.). These functionality is based
     on the open source [exiv2 library](https://www.exiv2.org).

--- a/docs/sipi.md
+++ b/docs/sipi.md
@@ -12,10 +12,10 @@ The parts do have the following meaning:
 
 - `{server}`: The DNS name of the server, eg. `iiif.dasch.swiss`. The server may include a portnumber,
   eg. `iiif2.dasch.swiss:8080`.
-- `{identifier}`: The identifier of the requested image. By default, it is the filename and its extension.
 - `{prefix}`: A path (that may include `/`'s) to organize the assets. Usually the prefix reflect the internal
   directory or folder hierarchy. However this can be overridden using special features of SIPI (see pre-flight-script
   and sipi configuration file).
+- `{identifier}`: The identifier of the requested image. By default, it is the filename and its extension.
 - `{region}`: a region of interest that should be displayed. `full` indicates that the whole image is being requested.
   For more details see [IIIF regions](https://iiif.io/api/image/3.0/#41-region)
 - `{size}`: The size of the displayed image (part). `max` indicates the the "natural" maximal resolution should be used.


### PR DESCRIPTION
- Normalise the way SIPI is written
- Mac OS --> macOS
- Order of the parameters in the Image API URI Syntax in the description (`identifier`, after `prefix`)
- Update README.MD to reflect what is mostly on https://sipi.io (Overview)