### PR TITLE
fix: memory leaks (DEV-237)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,6 @@ build
 build-linux
 Dockerfile
 README.md
-**/*.pyc
 **/__pycache__/
 wheels/
 pip-log.txt

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,9 @@
+.git
+.gitignore
+build
+build-linux
+Dockerfile
+README.md
 **/*.pyc
 **/__pycache__/
 wheels/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,11 +29,11 @@ jobs:
           python-version: 3.9
       - name: install requirements
         run: make install-requirements
-      - name: run build
+      - name: compile
         run: make compile-ci
-      - name: run test
+      - name: test
         run: make test-ci
-      - name: run integration tests
+      - name: integration tests
         run: make test-integration
 
   # build documentation

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
 
   # publish only on release
   publish-images:
-    name: Publish Images to Dockerhub
+    name: Build and Publish Images to Dockerhub
     needs: [unit, integration]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags')
@@ -97,7 +97,7 @@ jobs:
 
   # build documentation
   docs:
-    name: Build Docs
+    name: Build Docs Testrun
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
@@ -117,7 +117,7 @@ jobs:
 
   # publish documentation when merged into main branch
   publish-docs:
-    name: Publish Docs
+    name: Build and Publish Docs
     needs: [docs]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
           path: ci
       - name: Copy ci-assets
         run: |
-          cp $GITHUB_WORKSPACE/ci/kakadu/v8_0_5-01727L.zip $GITHUB_WORKSPACE/vendor/v8_0_5-01727L.zip
+          cp $GITHUB_WORKSPACE/ci/kakadu/v8_2_1-01727L.zip $GITHUB_WORKSPACE/vendor/v8_2_1-01727L.zip
       - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
@@ -85,7 +85,7 @@ jobs:
           path: ci
       - name: copy ci-assets
         run: |
-          cp $GITHUB_WORKSPACE/ci/kakadu/v8_0_5-01727L.zip $GITHUB_WORKSPACE/vendor/v8_0_5-01727L.zip
+          cp $GITHUB_WORKSPACE/ci/kakadu/v8_2_1-01727L.zip $GITHUB_WORKSPACE/vendor/v8_2_1-01727L.zip
       - name: build and publish production image
         run: |
           echo ${{ secrets.DOCKER_HUB_TOKEN }} | docker login -u ${{ secrets.DOCKER_USER }} --password-stdin

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,10 +86,14 @@ jobs:
       - name: copy ci-assets
         run: |
           cp $GITHUB_WORKSPACE/ci/kakadu/v8_0_5-01727L.zip $GITHUB_WORKSPACE/vendor/v8_0_5-01727L.zip
-      - name: build and publish image
+      - name: build and publish production image
         run: |
           echo ${{ secrets.DOCKER_HUB_TOKEN }} | docker login -u ${{ secrets.DOCKER_USER }} --password-stdin
           make docker-publish
+      - name: build and publish debug image
+        run: |
+          echo ${{ secrets.DOCKER_HUB_TOKEN }} | docker login -u ${{ secrets.DOCKER_USER }} --password-stdin
+          make docker-publish-debug
       - name: Update release notes
         uses: lakto/gren-action@v1.1.0
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,10 @@ jobs:
       - name: test
         run: make test-ci
       - name: integration tests
-        run: make test-integration
+        run: |
+          ls chmod -R 777 $GITHUB_WORKSPACE/build-linux/extsrcs
+          chmod -R 777 $GITHUB_WORKSPACE/build-linux/extsrcs/v8_2_1-01727L
+          make test-integration
 
   # build documentation
   docs-build-test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,8 @@ jobs:
         run: make compile-ci
       - name: test
         run: make test-ci
+      - name: build docker image
+        run: make docker-build
       - name: integration tests
         run: |
           ls $GITHUB_WORKSPACE/build-linux/extsrcs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,10 +60,7 @@ jobs:
       - name: build docker image
         run: make docker-build
       - name: integration tests
-        run: |
-          ls $GITHUB_WORKSPACE/build-linux/extsrcs
-          chmod -R 777 $GITHUB_WORKSPACE/build-linux/extsrcs/v8_2_1-01727L
-          make test-integration
+        run: make test-integration
 
   # publish only on release
   publish-images:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
         run: make test-ci
       - name: integration tests
         run: |
-          ls chmod -R 777 $GITHUB_WORKSPACE/build-linux/extsrcs
+          ls $GITHUB_WORKSPACE/build-linux/extsrcs
           chmod -R 777 $GITHUB_WORKSPACE/build-linux/extsrcs/v8_2_1-01727L
           make test-integration
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,8 +6,8 @@ on:
     types: [published]
 
 jobs:
-  test:
-    name: Build and Test
+  unit:
+    name: Run Unit Tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
@@ -33,6 +33,30 @@ jobs:
         run: make compile-ci
       - name: test
         run: make test-ci
+
+  integration:
+    name: Run Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 50
+      - name: Checkout private ci-assets
+        uses: actions/checkout@v2
+        with:
+          repository: dasch-swiss/dsp-ci-assets
+          token: ${{ secrets.DASCHBOT_PAT }} # `GitHub_PAT` is a secret that contains your PAT
+          path: ci
+      - name: Copy ci-assets
+        run: |
+          cp $GITHUB_WORKSPACE/ci/kakadu/v8_2_1-01727L.zip $GITHUB_WORKSPACE/vendor/v8_2_1-01727L.zip
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: install requirements
+        run: make install-requirements
       - name: build docker image
         run: make docker-build
       - name: integration tests
@@ -41,40 +65,10 @@ jobs:
           chmod -R 777 $GITHUB_WORKSPACE/build-linux/extsrcs/v8_2_1-01727L
           make test-integration
 
-  # build documentation
-  docs-build-test:
-    name: Docs Build Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-      - name: Disk Free
-        run: |
-          df -h
-          docker system df
-          docker system prune --all --force --volumes
-          df -h
-      - name: run docs build
-        run: make docs-build
-      - name: Disk Free After
-        run: |
-          df -h
-          docker system df
-
   # publish only on release
-  publish:
-    name: Publish to Dockerhub
-    needs: test
+  publish-images:
+    name: Publish Images to Dockerhub
+    needs: [unit, integration]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags')
     steps:
@@ -104,10 +98,30 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
-  # deploy documentation when merged into main branch
-  deploy-docs:
-    name: Deploy docs
-    needs: [docs-build-test]
+  # build documentation
+  docs:
+    name: Build Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: run docs build
+        run: make docs-build
+
+  # publish documentation when merged into main branch
+  publish-docs:
+    name: Publish Docs
+    needs: [docs]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:
@@ -118,7 +132,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           REQUIREMENTS: requirements.txt
-      - name: Disk Free After
-        run: |
-          df -h
-          docker system df

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
-# STAGE 1: Build
-FROM daschswiss/sipi-base:2.4.2 as builder
+# Expose global variables
+ARG BUILD_TYPE=production
+
+# STAGE 1: Build production
+FROM daschswiss/sipi-base:2.4.2 as builder-production
 
 WORKDIR /sipi
 
@@ -12,8 +15,22 @@ RUN mkdir -p /sipi/build-linux && \
     cmake -DMAKE_DEBUG:BOOL=OFF .. && \
     make
 
-# STAGE 2: Setup
-FROM ubuntu:20.04
+# STAGE 1: Build debug
+FROM daschswiss/sipi-base:2.4.2 as builder-debug
+
+WORKDIR /sipi
+
+# Add everything to image.
+COPY . .
+
+# Build SIPI.
+RUN mkdir -p /sipi/build-linux && \
+    cd /sipi/build-linux && \
+    cmake -DMAKE_DEBUG:BOOL=ON .. && \
+    make
+
+# STAGE 2: Setup production
+FROM ubuntu:20.04 as production
 
 MAINTAINER Ivan Subotic <400790+subotic@users.noreply.github.com>
 
@@ -57,11 +74,70 @@ RUN mkdir -p /sipi/images/knora && \
     mkdir -p /sipi/cache
 
 # Copy Sipi binary and other files from the build stage
-COPY --from=builder /sipi/build-linux/sipi /sipi/sipi
-COPY --from=builder /sipi/config/sipi.config.lua /sipi/config/sipi.config.lua
-COPY --from=builder /sipi/config/sipi.init.lua /sipi/config/sipi.init.lua
-COPY --from=builder /sipi/server/test.html /sipi/server/test.html
+COPY --from=builder-production /sipi/build-linux/sipi /sipi/sipi
+COPY --from=builder-production /sipi/config/sipi.config.lua /sipi/config/sipi.config.lua
+COPY --from=builder-production /sipi/config/sipi.init.lua /sipi/config/sipi.init.lua
+COPY --from=builder-production /sipi/server/test.html /sipi/server/test.html
 
 ENTRYPOINT [ "/sipi/sipi" ]
 
 CMD ["--config=/sipi/config/sipi.config.lua"]
+
+# STAGE 2: Setup debug
+FROM ubuntu:20.04 as debug
+
+MAINTAINER Ivan Subotic <400790+subotic@users.noreply.github.com>
+
+# Silence debconf messages
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN sed -i 's/# \(.*multiverse$\)/\1/g' /etc/apt/sources.list && \
+    apt-get clean && apt-get -qq update && apt-get -y install \
+    ca-certificates \
+    gnupg2
+
+# Install build dependencies.
+RUN sed -i 's/# \(.*multiverse$\)/\1/g' /etc/apt/sources.list && \
+    echo 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main' | tee -a /etc/apt/sources.list && \
+    echo 'deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main' | tee -a /etc/apt/sources.list && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421 && \
+    apt-get clean && apt-get -qq update && apt-get -y install \
+    ca-certificates \
+    byobu curl git htop man vim wget unzip \
+    libllvm11 llvm-11-runtime \
+    openssl \
+    libidn11-dev \
+    locales \
+    uuid \
+    ffmpeg \
+    at \
+    valgrind
+
+# add locales
+RUN locale-gen en_US.UTF-8 && \
+    locale-gen sr_RS.UTF-8
+
+ENV LC_ALL=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US.UTF-8
+
+WORKDIR /sipi
+
+EXPOSE 1024
+
+RUN mkdir -p /sipi/images/knora && \
+    mkdir -p /sipi/cache
+
+# Copy Sipi binary and other files from the build stage
+COPY --from=builder-debug /sipi/build-linux/sipi /sipi/sipi
+COPY --from=builder-debug /sipi/config/sipi.config.lua /sipi/config/sipi.config.lua
+COPY --from=builder-debug /sipi/config/sipi.init.lua /sipi/config/sipi.init.lua
+COPY --from=builder-debug /sipi/server/test.html /sipi/server/test.html
+
+ENTRYPOINT [ "/sipi/sipi" ]
+
+CMD ["--config=/sipi/config/sipi.config.lua"]
+
+#
+# Stage 3: The final build type specific image
+FROM $BUILD_TYPE

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ARG BUILD_TYPE=production
 
 # STAGE 1: Build production
-FROM daschswiss/sipi-base:2.4.2 as builder-production
+FROM daschswiss/sipi-base:2.5.0 as builder-production
 
 WORKDIR /sipi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,10 @@
-# Expose global variables
+# Expose (global) variables (ARGs before FROM can only be used on FROM lines and not afterwards)
 ARG BUILD_TYPE=production
-
-# STAGE 1: Build production
-FROM daschswiss/sipi-base:2.5.0 as builder-production
-
-WORKDIR /sipi
-
-# Add everything to image.
-COPY . .
-
-# Build SIPI.
-RUN mkdir -p /sipi/build-linux && \
-    cd /sipi/build-linux && \
-    cmake -DMAKE_DEBUG:BOOL=OFF .. && \
-    make
+ARG SIPI_BASE=daschswiss/sipi-base:2.5.0
+ARG UBUNTU_BASE=ubuntu:20.04
 
 # STAGE 1: Build debug
-FROM daschswiss/sipi-base:2.4.2 as builder-debug
+FROM $SIPI_BASE as builder-debug
 
 WORKDIR /sipi
 
@@ -29,62 +17,22 @@ RUN mkdir -p /sipi/build-linux && \
     cmake -DMAKE_DEBUG:BOOL=ON .. && \
     make
 
-# STAGE 2: Setup production
-FROM ubuntu:20.04 as production
-
-MAINTAINER Ivan Subotic <400790+subotic@users.noreply.github.com>
-
-# Silence debconf messages
-ARG DEBIAN_FRONTEND=noninteractive
-
-RUN sed -i 's/# \(.*multiverse$\)/\1/g' /etc/apt/sources.list && \
-    apt-get clean && apt-get -qq update && apt-get -y install \
-    ca-certificates \
-    gnupg2
-
-# Install build dependencies.
-RUN sed -i 's/# \(.*multiverse$\)/\1/g' /etc/apt/sources.list && \
-    echo 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main' | tee -a /etc/apt/sources.list && \
-    echo 'deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main' | tee -a /etc/apt/sources.list && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421 && \
-    apt-get clean && apt-get -qq update && apt-get -y install \
-    ca-certificates \
-    byobu curl git htop man vim wget unzip \
-    libllvm11 llvm-11-runtime \
-    openssl \
-    libidn11-dev \
-    locales \
-    uuid \
-    ffmpeg \
-    at
-
-# add locales
-RUN locale-gen en_US.UTF-8 && \
-    locale-gen sr_RS.UTF-8
-
-ENV LC_ALL=en_US.UTF-8
-ENV LANG=en_US.UTF-8
-ENV LANGUAGE=en_US.UTF-8
+# STAGE 1: Build production
+FROM $SIPI_BASE as builder-production
 
 WORKDIR /sipi
 
-EXPOSE 1024
+# Add everything to image.
+COPY . .
 
-RUN mkdir -p /sipi/images/knora && \
-    mkdir -p /sipi/cache
-
-# Copy Sipi binary and other files from the build stage
-COPY --from=builder-production /sipi/build-linux/sipi /sipi/sipi
-COPY --from=builder-production /sipi/config/sipi.config.lua /sipi/config/sipi.config.lua
-COPY --from=builder-production /sipi/config/sipi.init.lua /sipi/config/sipi.init.lua
-COPY --from=builder-production /sipi/server/test.html /sipi/server/test.html
-
-ENTRYPOINT [ "/sipi/sipi" ]
-
-CMD ["--config=/sipi/config/sipi.config.lua"]
+# Build SIPI.
+RUN mkdir -p /sipi/build-linux && \
+    cd /sipi/build-linux && \
+    cmake -DMAKE_DEBUG:BOOL=OFF .. && \
+    make
 
 # STAGE 2: Setup debug
-FROM ubuntu:20.04 as debug
+FROM $UBUNTU_BASE as debug
 
 MAINTAINER Ivan Subotic <400790+subotic@users.noreply.github.com>
 
@@ -133,6 +81,60 @@ COPY --from=builder-debug /sipi/build-linux/sipi /sipi/sipi
 COPY --from=builder-debug /sipi/config/sipi.config.lua /sipi/config/sipi.config.lua
 COPY --from=builder-debug /sipi/config/sipi.init.lua /sipi/config/sipi.init.lua
 COPY --from=builder-debug /sipi/server/test.html /sipi/server/test.html
+
+ENTRYPOINT [ "/sipi/sipi" ]
+
+CMD ["--config=/sipi/config/sipi.config.lua"]
+
+# STAGE 2: Setup production
+FROM $UBUNTU_BASE as production
+
+MAINTAINER Ivan Subotic <400790+subotic@users.noreply.github.com>
+
+# Silence debconf messages
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN sed -i 's/# \(.*multiverse$\)/\1/g' /etc/apt/sources.list && \
+    apt-get clean && apt-get -qq update && apt-get -y install \
+    ca-certificates \
+    gnupg2
+
+# Install build dependencies.
+RUN sed -i 's/# \(.*multiverse$\)/\1/g' /etc/apt/sources.list && \
+    echo 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main' | tee -a /etc/apt/sources.list && \
+    echo 'deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main' | tee -a /etc/apt/sources.list && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421 && \
+    apt-get clean && apt-get -qq update && apt-get -y install \
+    ca-certificates \
+    byobu curl git htop man vim wget unzip \
+    libllvm11 llvm-11-runtime \
+    openssl \
+    libidn11-dev \
+    locales \
+    uuid \
+    ffmpeg \
+    at
+
+# add locales
+RUN locale-gen en_US.UTF-8 && \
+    locale-gen sr_RS.UTF-8
+
+ENV LC_ALL=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US.UTF-8
+
+WORKDIR /sipi
+
+EXPOSE 1024
+
+RUN mkdir -p /sipi/images/knora && \
+    mkdir -p /sipi/cache
+
+# Copy Sipi binary and other files from the build stage
+COPY --from=builder-production /sipi/build-linux/sipi /sipi/sipi
+COPY --from=builder-production /sipi/config/sipi.config.lua /sipi/config/sipi.config.lua
+COPY --from=builder-production /sipi/config/sipi.init.lua /sipi/config/sipi.init.lua
+COPY --from=builder-production /sipi/server/test.html /sipi/server/test.html
 
 ENTRYPOINT [ "/sipi/sipi" ]
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ CURRENT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 include vars.mk
 
 # Version of the base Docker image
-SIPI_BASE_VERSION := 2.4.2
+SIPI_BASE_VERSION := 2.5.0
 
 .PHONY: docs-build
 docs-build: ## build docs into the local 'site' folder
@@ -51,7 +51,7 @@ compile-ci: ## compile SIPI inside Docker (no it)
 
 .PHONY: compile-debug
 compile-debug: ## compile SIPI inside Docker with Debug symbols
-	docker run --rm -v ${PWD}:/sipi daschswiss/sipi-base:$(SIPI_BASE_VERSION) /bin/sh -c "mkdir -p /sipi/build-linux && cd /sipi/build-linux && cmake -DMAKE_DEBUG:BOOL=OFF .. && make"
+	docker run --rm -v ${PWD}:/sipi daschswiss/sipi-base:$(SIPI_BASE_VERSION) /bin/sh -c "mkdir -p /sipi/build-linux && cd /sipi/build-linux && cmake -DMAKE_DEBUG:BOOL=ON .. && make"
 
 .PHONY: test
 test: ## compile and run tests inside Docker

--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,19 @@ install-requirements: ## install requirements for documentation
 
 .PHONY: docker-build
 docker-build: ## build and publish Sipi Docker image locally
-	docker buildx build --platform linux/amd64 -t $(DOCKER_IMAGE) -t $(DOCKER_REPO):latest --load .
+	docker buildx build --platform linux/amd64 --build-arg BUILD_TYPE=production -t $(DOCKER_IMAGE) -t $(DOCKER_REPO):latest --load .
+
+.PHONY: docker-build-debug
+docker-build-debug: ## build and publish Sipi Docker image locally with debugging enabled
+	docker buildx build --platform linux/amd64 --build-arg BUILD_TYPE=debug -t $(DOCKER_IMAGE)-debug --load .
 
 .PHONY: docker-publish
 docker-publish: ## publish Sipi Docker image to Docker-Hub
-	docker buildx build --platform linux/amd64 -t $(DOCKER_IMAGE) -t $(DOCKER_REPO):latest --push .
+	docker buildx build --platform linux/amd64 --build-arg BUILD_TYPE=production -t $(DOCKER_IMAGE) -t $(DOCKER_REPO):latest --push .
+
+.PHONY: docker-publish-debug
+docker-publish-debug: ## publish Sipi Docker image to Docker-Hub with debugging enabled
+	docker buildx build --platform linux/amd64 --build-arg BUILD_TYPE=debug -t $(DOCKER_IMAGE)-debug --push .
 
 .PHONY: compile
 compile: ## compile SIPI inside Docker
@@ -40,6 +48,10 @@ compile: ## compile SIPI inside Docker
 .PHONY: compile-ci
 compile-ci: ## compile SIPI inside Docker (no it)
 	docker run --rm -v ${PWD}:/sipi daschswiss/sipi-base:$(SIPI_BASE_VERSION) /bin/sh -c "mkdir -p /sipi/build-linux && cd /sipi/build-linux && cmake .. && make"
+
+.PHONY: compile-debug
+compile-debug: ## compile SIPI inside Docker with Debug symbols
+	docker run --rm -v ${PWD}:/sipi daschswiss/sipi-base:$(SIPI_BASE_VERSION) /bin/sh -c "mkdir -p /sipi/build-linux && cd /sipi/build-linux && cmake -DMAKE_DEBUG:BOOL=OFF .. && make"
 
 .PHONY: test
 test: ## compile and run tests inside Docker
@@ -61,19 +73,18 @@ run: docker-build ## run SIPI inside Docker
 	docker run -it --rm --workdir "/sipi" --expose "1024" --expose "1025" -p 1024:1024 -p 1025:1025 daschswiss/sipi:latest
 
 .PHONY: cmdline
-cmdline: ## run SIPI inside Docker (does not compile)
+cmdline: ## open shell inside Docker container
 	@mkdir -p ${CURRENT_DIR}/images
 	docker run -it --rm -v ${PWD}:/sipi --workdir "/sipi" --expose "1024" --expose "1025" -p 1024:1024 -p 1025:1025 dhlabbasel/sipi-base:18.04 /bin/sh
 
-.PHONY: cmdline-debug
-cmdline-debug: ## run SIPI inside Docker (does not compile)
+.PHONY: shell
+shell: ## open shell inside privileged Docker container (does not compile)
 	@mkdir -p ${CURRENT_DIR}/images
-	docker run -it --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --security-opt apparmor=unconfined --rm -v ${PWD}:/sipi --workdir "/sipi" --expose "1024" --expose "1025" -p 1024:1024 -p 1025:1025 dhlabbasel/sipi-base:18.04 /bin/sh
+	docker run -it --privileged --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --security-opt apparmor=unconfined --rm -v ${PWD}:/sipi --workdir "/sipi" --expose "1024" --expose "1025" -p 1024:1024 -p 1025:1025 -p 1234:1234 -p 1235:1235 daschswiss/sipi-base:${SIPI_BASE_VERSION} /bin/bash
 
-.PHONY: debug
-debug: ## run SIPI inside Docker (does not compile)
-	@mkdir -p ${PWD}/images
-	docker run -it --privileged --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --security-opt apparmor=unconfined --rm -v ${PWD}:/sipi --workdir "/sipi" --expose "1024" --expose "1025" -p 1024:1024 -p 1025:1025 -p 1234:1234 -p 1235:1235 dhlabbasel/sipi-base:18.04 /bin/sh
+.PHONY: valgrind
+valgrind: ## start SIPI with Valgrind (needs to be started inside Docker container, e.g., 'make shell')
+	valgrind --leak-check=yes ./build-linux/sipi --config=/sipi/config/sipi.config.lua
 
 .PHONY: clean
 clean: ## cleans the project directory

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ shell: ## open shell inside privileged Docker container (does not compile)
 
 .PHONY: valgrind
 valgrind: ## start SIPI with Valgrind (needs to be started inside Docker container, e.g., 'make shell')
-	valgrind --leak-check=yes ./build-linux/sipi --config=/sipi/config/sipi.config.lua
+	valgrind --leak-check=yes --track-origins=yes ./build-linux/sipi --config=/sipi/config/sipi.config.lua
 
 .PHONY: clean
 clean: ## cleans the project directory

--- a/Makefile
+++ b/Makefile
@@ -42,26 +42,22 @@ docker-publish-debug: ## publish Sipi Docker image to Docker-Hub with debugging 
 	docker buildx build --platform linux/amd64 --build-arg BUILD_TYPE=debug -t $(DOCKER_IMAGE)-debug --push .
 
 .PHONY: compile
-compile: ## compile SIPI inside Docker
-	docker run -it --rm -v ${PWD}:/sipi daschswiss/sipi-base:$(SIPI_BASE_VERSION) /bin/sh -c "mkdir -p /sipi/build-linux && cd /sipi/build-linux && cmake .. && make"
+compile: ## compile SIPI inside Docker with Debug symbols
+	docker run -it --rm -v ${PWD}:/sipi daschswiss/sipi-base:$(SIPI_BASE_VERSION) /bin/sh -c "mkdir -p /sipi/build-linux && cd /sipi/build-linux && cmake -DMAKE_DEBUG:BOOL=ON .. && make"
 
 .PHONY: compile-ci
 compile-ci: ## compile SIPI inside Docker (no it)
-	docker run --rm -v ${PWD}:/sipi daschswiss/sipi-base:$(SIPI_BASE_VERSION) /bin/sh -c "mkdir -p /sipi/build-linux && cd /sipi/build-linux && cmake .. && make"
-
-.PHONY: compile-debug
-compile-debug: ## compile SIPI inside Docker with Debug symbols
 	docker run --rm -v ${PWD}:/sipi daschswiss/sipi-base:$(SIPI_BASE_VERSION) /bin/sh -c "mkdir -p /sipi/build-linux && cd /sipi/build-linux && cmake -DMAKE_DEBUG:BOOL=ON .. && make"
 
 .PHONY: test
 test: ## compile and run tests inside Docker
 	@mkdir -p ${PWD}/images
-	docker run -it --rm -v ${PWD}:/sipi daschswiss/sipi-base:$(SIPI_BASE_VERSION) /bin/sh -c "mkdir -p /sipi/build-linux && cd /sipi/build-linux && cmake .. && make && ctest --verbose"
+	docker run -it --rm -v ${PWD}:/sipi daschswiss/sipi-base:$(SIPI_BASE_VERSION) /bin/sh -c "mkdir -p /sipi/build-linux && cd /sipi/build-linux && cmake -DMAKE_DEBUG:BOOL=ON .. && make && ctest --verbose"
 
 .PHONY: test-ci
 test-ci: ## compile and run tests inside Docker (no it)
 	@mkdir -p ${CURRENT_DIR}/images
-	docker run --rm -v ${PWD}:/sipi daschswiss/sipi-base:$(SIPI_BASE_VERSION) /bin/sh -c "mkdir -p /sipi/build-linux && cd /sipi/build-linux && cmake .. && make && ctest --verbose"
+	docker run --rm -v ${PWD}:/sipi daschswiss/sipi-base:$(SIPI_BASE_VERSION) /bin/sh -c "mkdir -p /sipi/build-linux && cd /sipi/build-linux && cmake -DMAKE_DEBUG:BOOL=ON .. && make && ctest --verbose"
 
 .PHONY: test-integration
 test-integration: docker-build ## run tests against locally published Sipi Docker image

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ install-requirements: ## install requirements for documentation
 .PHONY: docker-build
 docker-build: ## build and publish Sipi Docker image locally
 	docker buildx build \
+		--progress auto \
 		--platform linux/amd64 \
 		--build-arg BUILD_TYPE=production \
 		--build-arg SIPI_BASE=$(SIPI_BASE) \
@@ -38,6 +39,7 @@ docker-build: ## build and publish Sipi Docker image locally
 .PHONY: docker-build-debug
 docker-build-debug: ## build and publish Sipi Docker image locally with debugging enabled
 	docker buildx build \
+		--progress auto \
 		--platform linux/amd64 \
 		--build-arg BUILD_TYPE=debug \
 		--build-arg SIPI_BASE=$(SIPI_BASE) \
@@ -47,6 +49,7 @@ docker-build-debug: ## build and publish Sipi Docker image locally with debuggin
 .PHONY: docker-publish
 docker-publish: ## publish Sipi Docker image to Docker-Hub
 	docker buildx build \
+		--progress auto \
 		--platform linux/amd64 \
 		--build-arg BUILD_TYPE=production \
 		--build-arg SIPI_BASE=$(SIPI_BASE) \
@@ -56,6 +59,7 @@ docker-publish: ## publish Sipi Docker image to Docker-Hub
 .PHONY: docker-publish-debug
 docker-publish-debug: ## publish Sipi Docker image to Docker-Hub with debugging enabled
 	docker buildx build \
+		--progress auto \
 		--platform linux/amd64 \
 		--build-arg BUILD_TYPE=debug \
 		--build-arg SIPI_BASE=$(SIPI_BASE) \

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ CURRENT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 include vars.mk
 
+# Version of the base Docker image
+SIPI_BASE_VERSION := 2.4.2
+
 .PHONY: docs-build
 docs-build: ## build docs into the local 'site' folder
 	mkdocs build
@@ -32,21 +35,21 @@ docker-publish: ## publish Sipi Docker image to Docker-Hub
 
 .PHONY: compile
 compile: ## compile SIPI inside Docker
-	docker run -it --rm -v ${PWD}:/sipi daschswiss/sipi-base:2.4 /bin/sh -c "mkdir -p /sipi/build-linux && cd /sipi/build-linux && cmake .. && make"
+	docker run -it --rm -v ${PWD}:/sipi daschswiss/sipi-base:$(SIPI_BASE_VERSION) /bin/sh -c "mkdir -p /sipi/build-linux && cd /sipi/build-linux && cmake .. && make"
 
 .PHONY: compile-ci
 compile-ci: ## compile SIPI inside Docker (no it)
-	docker run --rm -v ${PWD}:/sipi daschswiss/sipi-base:2.4 /bin/sh -c "mkdir -p /sipi/build-linux && cd /sipi/build-linux && cmake .. && make"
+	docker run --rm -v ${PWD}:/sipi daschswiss/sipi-base:$(SIPI_BASE_VERSION) /bin/sh -c "mkdir -p /sipi/build-linux && cd /sipi/build-linux && cmake .. && make"
 
 .PHONY: test
 test: ## compile and run tests inside Docker
 	@mkdir -p ${PWD}/images
-	docker run -it --rm -v ${PWD}:/sipi daschswiss/sipi-base:2.4 /bin/sh -c "mkdir -p /sipi/build-linux && cd /sipi/build-linux && cmake .. && make && ctest --verbose"
+	docker run -it --rm -v ${PWD}:/sipi daschswiss/sipi-base:$(SIPI_BASE_VERSION) /bin/sh -c "mkdir -p /sipi/build-linux && cd /sipi/build-linux && cmake .. && make && ctest --verbose"
 
 .PHONY: test-ci
 test-ci: ## compile and run tests inside Docker (no it)
 	@mkdir -p ${CURRENT_DIR}/images
-	docker run --rm -v ${PWD}:/sipi daschswiss/sipi-base:2.4 /bin/sh -c "mkdir -p /sipi/build-linux && cd /sipi/build-linux && cmake .. && make && ctest --verbose"
+	docker run --rm -v ${PWD}:/sipi daschswiss/sipi-base:$(SIPI_BASE_VERSION) /bin/sh -c "mkdir -p /sipi/build-linux && cd /sipi/build-linux && cmake .. && make && ctest --verbose"
 
 .PHONY: test-integration
 test-integration: docker-build ## run tests against locally published Sipi Docker image

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ CURRENT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 include vars.mk
 
 # Version of the base Docker image
-SIPI_BASE_VERSION := 2.5.0
+SIPI_BASE := daschswiss/sipi-base:2.5.0
+UBUNTU_BASE := ubuntu:20.04
 
 .PHONY: docs-build
 docs-build: ## build docs into the local 'site' folder
@@ -27,37 +28,69 @@ install-requirements: ## install requirements for documentation
 
 .PHONY: docker-build
 docker-build: ## build and publish Sipi Docker image locally
-	docker buildx build --platform linux/amd64 --build-arg BUILD_TYPE=production -t $(DOCKER_IMAGE) -t $(DOCKER_REPO):latest --load .
+	docker buildx build \
+		--platform linux/amd64 \
+		--build-arg BUILD_TYPE=production \
+		--build-arg SIPI_BASE=$(SIPI_BASE) \
+		--build-arg UBUNTU_BASE=$(UBUNTU_BASE) \
+		-t $(DOCKER_IMAGE) -t $(DOCKER_REPO):latest --load .
 
 .PHONY: docker-build-debug
 docker-build-debug: ## build and publish Sipi Docker image locally with debugging enabled
-	docker buildx build --platform linux/amd64 --build-arg BUILD_TYPE=debug -t $(DOCKER_IMAGE)-debug --load .
+	docker buildx build \
+		--platform linux/amd64 \
+		--build-arg BUILD_TYPE=debug \
+		--build-arg SIPI_BASE=$(SIPI_BASE) \
+        --build-arg UBUNTU_BASE=$(UBUNTU_BASE) \
+		-t $(DOCKER_IMAGE)-debug --load .
 
 .PHONY: docker-publish
 docker-publish: ## publish Sipi Docker image to Docker-Hub
-	docker buildx build --platform linux/amd64 --build-arg BUILD_TYPE=production -t $(DOCKER_IMAGE) -t $(DOCKER_REPO):latest --push .
+	docker buildx build \
+		--platform linux/amd64 \
+		--build-arg BUILD_TYPE=production \
+		--build-arg SIPI_BASE=$(SIPI_BASE) \
+        --build-arg UBUNTU_BASE=$(UBUNTU_BASE) \
+		-t $(DOCKER_IMAGE) -t $(DOCKER_REPO):latest --push .
 
 .PHONY: docker-publish-debug
 docker-publish-debug: ## publish Sipi Docker image to Docker-Hub with debugging enabled
-	docker buildx build --platform linux/amd64 --build-arg BUILD_TYPE=debug -t $(DOCKER_IMAGE)-debug --push .
+	docker buildx build \
+		--platform linux/amd64 \
+		--build-arg BUILD_TYPE=debug \
+		--build-arg SIPI_BASE=$(SIPI_BASE) \
+        --build-arg UBUNTU_BASE=$(UBUNTU_BASE) \
+		-t $(DOCKER_IMAGE)-debug --push .
 
 .PHONY: compile
 compile: ## compile SIPI inside Docker with Debug symbols
-	docker run -it --rm -v ${PWD}:/sipi daschswiss/sipi-base:$(SIPI_BASE_VERSION) /bin/sh -c "mkdir -p /sipi/build-linux && cd /sipi/build-linux && cmake -DMAKE_DEBUG:BOOL=ON .. && make"
+	docker run \
+		-it --rm \
+		-v ${PWD}:/sipi \
+		$(SIPI_BASE) /bin/sh -c "mkdir -p /sipi/build-linux && cd /sipi/build-linux && cmake -DMAKE_DEBUG:BOOL=ON .. && make"
 
 .PHONY: compile-ci
-compile-ci: ## compile SIPI inside Docker (no it)
-	docker run --rm -v ${PWD}:/sipi daschswiss/sipi-base:$(SIPI_BASE_VERSION) /bin/sh -c "mkdir -p /sipi/build-linux && cd /sipi/build-linux && cmake -DMAKE_DEBUG:BOOL=ON .. && make"
+compile-ci: ## compile SIPI inside Docker with Debug symbols (no it)
+	docker run \
+		--rm \
+		-v ${PWD}:/sipi \
+		$(SIPI_BASE) /bin/sh -c "mkdir -p /sipi/build-linux && cd /sipi/build-linux && cmake -DMAKE_DEBUG:BOOL=ON .. && make"
 
 .PHONY: test
-test: ## compile and run tests inside Docker
+test: ## compile and run tests inside Docker with Debug symbols
 	@mkdir -p ${PWD}/images
-	docker run -it --rm -v ${PWD}:/sipi daschswiss/sipi-base:$(SIPI_BASE_VERSION) /bin/sh -c "mkdir -p /sipi/build-linux && cd /sipi/build-linux && cmake -DMAKE_DEBUG:BOOL=ON .. && make && ctest --verbose"
+	docker run \
+		-it --rm \
+		-v ${PWD}:/sipi \
+		$(SIPI_BASE) /bin/sh -c "mkdir -p /sipi/build-linux && cd /sipi/build-linux && cmake -DMAKE_DEBUG:BOOL=ON .. && make && ctest --verbose"
 
 .PHONY: test-ci
-test-ci: ## compile and run tests inside Docker (no it)
+test-ci: ## compile and run tests inside Docker with Debug symbols (no it)
 	@mkdir -p ${CURRENT_DIR}/images
-	docker run --rm -v ${PWD}:/sipi daschswiss/sipi-base:$(SIPI_BASE_VERSION) /bin/sh -c "mkdir -p /sipi/build-linux && cd /sipi/build-linux && cmake -DMAKE_DEBUG:BOOL=ON .. && make && ctest --verbose"
+	docker run \
+		--rm \
+		-v ${PWD}:/sipi \
+		$(SIPI_BASE) /bin/sh -c "mkdir -p /sipi/build-linux && cd /sipi/build-linux && cmake -DMAKE_DEBUG:BOOL=ON .. && make && ctest --verbose"
 
 .PHONY: test-integration
 test-integration: docker-build ## run tests against locally published Sipi Docker image
@@ -66,17 +99,45 @@ test-integration: docker-build ## run tests against locally published Sipi Docke
 .PHONY: run
 run: docker-build ## run SIPI inside Docker
 	@mkdir -p ${CURRENT_DIR}/images
-	docker run -it --rm --workdir "/sipi" --expose "1024" --expose "1025" -p 1024:1024 -p 1025:1025 daschswiss/sipi:latest
+	docker run \
+		-it --rm \
+		--workdir "/sipi" \
+		--expose "1024" \
+		--expose "1025" \
+		-p 1024:1024 \
+		-p 1025:1025 \
+		daschswiss/sipi:latest
 
 .PHONY: cmdline
 cmdline: ## open shell inside Docker container
 	@mkdir -p ${CURRENT_DIR}/images
-	docker run -it --rm -v ${PWD}:/sipi --workdir "/sipi" --expose "1024" --expose "1025" -p 1024:1024 -p 1025:1025 dhlabbasel/sipi-base:18.04 /bin/sh
+	docker run -it --rm \
+		-v ${PWD}:/sipi \
+		--workdir "/sipi" \
+		--expose "1024" \
+		--expose "1025" \
+		-p 1024:1024 \
+		-p 1025:1025 \
+		${SIPI_BASE} /bin/bash
 
 .PHONY: shell
 shell: ## open shell inside privileged Docker container (does not compile)
 	@mkdir -p ${CURRENT_DIR}/images
-	docker run -it --privileged --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --security-opt apparmor=unconfined --rm -v ${PWD}:/sipi --workdir "/sipi" --expose "1024" --expose "1025" -p 1024:1024 -p 1025:1025 -p 1234:1234 -p 1235:1235 daschswiss/sipi-base:${SIPI_BASE_VERSION} /bin/bash
+	docker run \
+		-it --rm \
+		--privileged \
+		--cap-add=SYS_PTRACE \
+		--security-opt seccomp=unconfined \
+		--security-opt apparmor=unconfined \
+		-v ${PWD}:/sipi \
+		--workdir "/sipi" \
+		--expose "1024" \
+		--expose "1025" \
+		-p 1024:1024 \
+		-p 1025:1025 \
+		-p 1234:1234 \
+		-p 1235:1235 \
+		${SIPI_BASE} /bin/bash
 
 .PHONY: valgrind
 valgrind: ## start SIPI with Valgrind (needs to be started inside Docker container, e.g., 'make shell')

--- a/ext/fontconfig/CMakeLists.txt
+++ b/ext/fontconfig/CMakeLists.txt
@@ -21,7 +21,7 @@ ExternalProject_Add(project_fontconfig
         CONFIGURE_COMMAND   ${COMMON_SRCS}/fontconfig-2.13.1/configure
                             --prefix=${COMMON_LOCAL}
                             FREETYPE_CFLAGS=-I${CONFIGURE_INCDIR}/freetype2
-                            FREETYPE_LIBS="-L${CONFIGURE_LIBDIR} -lfreetype -lbz2 -lm -lharfbuzz -lpng -lz"
+                            FREETYPE_LIBS="-L${CONFIGURE_LIBDIR} -lfreetype -lbz2 -lharfbuzz -lpng -lz -lm"
                             --disable-shared
                             --enable-static
         BUILD_COMMAND make

--- a/ext/kakadu/CMakeLists.txt
+++ b/ext/kakadu/CMakeLists.txt
@@ -10,12 +10,12 @@ message(STATUS ${CONFIGURE_LIBDIR})
 ExternalProject_Add(
         project_kakadu
         INSTALL_DIR ${COMMON_LOCAL}
-        DOWNLOAD_COMMAND unzip -o -d ${COMMON_SRCS} ${COMMON_VENDOR}/v8_0_5-01727L.zip
+        DOWNLOAD_COMMAND unzip -o -d ${COMMON_SRCS} ${COMMON_VENDOR}/v8_2_1-01727L.zip
         CONFIGURE_COMMAND ""
-        BUILD_COMMAND make --directory=${COMMON_SRCS}/v8_0_5-01727L/make/ -f ${KDU_MAKE} all_but_jni
-        INSTALL_COMMAND ${CMAKE_COMMAND} -E copy_directory ${COMMON_SRCS}/v8_0_5-01727L/lib/${KDU_ARCH} ${CONFIGURE_LIBDIR}
-        COMMAND ${CMAKE_COMMAND} -E copy_directory ${COMMON_SRCS}/v8_0_5-01727L/bin/${KDU_ARCH} ${COMMON_LOCAL}/bin
-        COMMAND ${CMAKE_COMMAND} -E copy_directory ${COMMON_SRCS}/v8_0_5-01727L/managed/all_includes ${COMMON_LOCAL}/include
+        BUILD_COMMAND make --directory=${COMMON_SRCS}/v8_2_1-01727L/make/ -f ${KDU_MAKE} all_but_jni
+        INSTALL_COMMAND ${CMAKE_COMMAND} -E copy_directory ${COMMON_SRCS}/v8_2_1-01727L/lib/${KDU_ARCH} ${CONFIGURE_LIBDIR}
+        COMMAND ${CMAKE_COMMAND} -E copy_directory ${COMMON_SRCS}/v8_2_1-01727L/bin/${KDU_ARCH} ${COMMON_LOCAL}/bin
+        COMMAND ${CMAKE_COMMAND} -E copy_directory ${COMMON_SRCS}/v8_2_1-01727L/managed/all_includes ${COMMON_LOCAL}/include
 )
 
 ExternalProject_Get_Property(project_kakadu install_dir)

--- a/include/SipiIO.h
+++ b/include/SipiIO.h
@@ -87,6 +87,7 @@ namespace Sipi {
         J2K_Stiles,
         J2K_rates
     } SipiCompressionParamName;
+
     typedef std::unordered_map<int, std::string> SipiCompressionParams;
 
     class SipiImage; //!< forward declaration of class SipiImage
@@ -96,7 +97,7 @@ namespace Sipi {
      */
     class SipiIO {
     public:
-        virtual ~SipiIO() {};
+        virtual ~SipiIO() = default;;
 
 
         /*!
@@ -109,9 +110,36 @@ namespace Sipi {
          * to read only half the resolution. [default: 0]
          * \param force_bps_8 Convert the file to 8 bits/sample on reading thus enforcing an 8 bit image
          */
-        virtual bool read(SipiImage *img, std::string filepath, int pagenum, std::shared_ptr<SipiRegion> region,
+        virtual bool read(SipiImage *img, const std::string &filepath, int pagenum, std::shared_ptr<SipiRegion> region,
                           std::shared_ptr<SipiSize> size, bool force_bps_8,
                           ScalingQuality scaling_quality) = 0;
+
+        bool read(SipiImage *img, const std::string &filepath) {
+            return read(img, filepath, 0, nullptr, nullptr, false,
+                        {HIGH, HIGH, HIGH, HIGH});
+        }
+
+        bool read(SipiImage *img, const std::string &filepath, int pagenum) {
+            return read(img, filepath, pagenum, nullptr, nullptr, false,
+                        {HIGH, HIGH, HIGH, HIGH});
+        }
+
+        bool read(SipiImage *img, const std::string &filepath, int pagenum, std::shared_ptr<SipiRegion> region) {
+            return read(img, filepath, pagenum, region, nullptr, false,
+                        {HIGH, HIGH, HIGH, HIGH});
+        }
+
+        bool read(SipiImage *img, const std::string &filepath, int pagenum, std::shared_ptr<SipiRegion> region,
+                  std::shared_ptr<SipiSize> size) {
+            return read(img, filepath, pagenum, region, size, false,
+                        {HIGH, HIGH, HIGH, HIGH});
+        }
+
+        bool read(SipiImage *img, const std::string &filepath, int pagenum, std::shared_ptr<SipiRegion> region,
+                  std::shared_ptr<SipiSize> size, bool force_bps_8) {
+            return read(img, filepath, pagenum, region, size, force_bps_8,
+                 {HIGH, HIGH, HIGH, HIGH});
+        }
 
         /*!
          * Get the dimension of the image
@@ -120,7 +148,11 @@ namespace Sipi {
          * \param[out] width Width of the image in pixels
          * \param[out] height Height of the image in pixels
          */
-        virtual SipiImgInfo getDim(std::string filepath, int pagenum) = 0;
+        virtual SipiImgInfo getDim(const std::string &filepath, int pagenum) = 0;
+
+        SipiImgInfo getDim(const std::string &filepath) {
+            return getDim(filepath, 0)    ;
+        }
 
         /*!
          * Write an image for a file using the given file format implemented by the subclass
@@ -130,7 +162,11 @@ namespace Sipi {
          * - "-" means to write the image data to stdout
          * - "HTTP" means to write the image data to the HTTP-server output
          */
-        virtual void write(SipiImage *img, std::string filepath, const SipiCompressionParams *params = nullptr) = 0;
+        virtual void write(SipiImage *img, const std::string &filepath, const SipiCompressionParams *params) = 0;
+
+        void write(SipiImage *img, const std::string &filepath) {
+            write(img, filepath, nullptr);
+        }
     };
 
 }

--- a/include/SipiImage.h
+++ b/include/SipiImage.h
@@ -232,29 +232,29 @@ class SipiImageError : public std::exception {
         /*!
          * Getter for nx
          */
-        inline size_t getNx() { return nx; };
+        inline size_t getNx() const { return nx; };
 
 
         /*!
          * Getter for ny
          */
-        inline size_t getNy() { return ny; };
+        inline size_t getNy() const { return ny; };
 
         /*!
          * Getter for nc (includes alpha channels!)
          */
-        inline size_t getNc() { return nc; };
+        inline size_t getNc() const { return nc; };
 
         /*!
          * Getter for number of alpha channels
          */
-        inline size_t getNalpha() { return es.size(); }
+        inline size_t getNalpha() const { return es.size(); }
 
         /*!
          * Get bits per sample of image
          * @return bis per sample (bps)
          */
-        inline size_t getBps() { return bps; }
+        inline size_t getBps() const { return bps; }
 
         /*! Destructor
          *
@@ -323,7 +323,7 @@ class SipiImageError : public std::exception {
          *
          * \returns Pointer to connection data
          */
-        inline shttps::Connection *connection() { return conobj; };
+        inline shttps::Connection *connection() const { return conobj; };
 
         inline void essential_metadata(const SipiEssentials &emdata_p) { emdata = emdata_p; }
 
@@ -401,7 +401,7 @@ class SipiImageError : public std::exception {
          * \param[in] pagenum Page that is to be used (for PDF's and multipage TIF's only, first page is 1)
          * \return Info about image (see SipiImgInfo)
          */
-        SipiImgInfo getDim(std::string filepath, int pagenum = 0);
+        SipiImgInfo getDim(const std::string &filepath, int pagenum = 0) const;
 
         /*!
          * Get the dimension of the image object
@@ -409,7 +409,7 @@ class SipiImageError : public std::exception {
          * @param[out] width Width of the image in pixels
          * @param[out] height Height of the image in pixels
          */
-        void getDim(size_t &width, size_t &height);
+        void getDim(size_t &width, size_t &height) const;
 
         /*!
          * Write an image to somewhere
@@ -425,13 +425,13 @@ class SipiImageError : public std::exception {
          * - "png" for PNG files
          * \param[in] filepath String containing the path/filename
          */
-        void write(std::string ftype, std::string filepath, const SipiCompressionParams *params = nullptr);
+        void write(const std::string &ftype, const std::string &filepath, const SipiCompressionParams *params = nullptr);
 
 
         /*!
          * Convert full range YCbCr (YCC) to RGB colors
          */
-        void convertYCC2RGB(void);
+        void convertYCC2RGB();
 
 
         /*!
@@ -468,7 +468,7 @@ class SipiImageError : public std::exception {
          * \param[in] width Width of the region. If the region goes beyond the image dimensions, it's adjusted.
          * \param[in] height Height of the region. If the region goes beyond the image dimensions, it's adjusted
          */
-        bool crop(std::shared_ptr<SipiRegion> region);
+        bool crop(const std::shared_ptr<SipiRegion> &region);
 
         /*!
          * Resize an image using a high speed algorithm which may result in poor image quality
@@ -511,7 +511,7 @@ class SipiImageError : public std::exception {
          *
          * \returns Returns true on success, false on error
          */
-        bool to8bps(void);
+        bool to8bps();
 
         /*!
          * Convert an image to a bitonal representation using Steinberg-Floyd dithering.
@@ -521,14 +521,14 @@ class SipiImageError : public std::exception {
          *
          * \returns Returns true on success, false on error
          */
-        bool toBitonal(void);
+        bool toBitonal();
 
         /*!
          * Add a watermark to a file...
          *
          * \param[in] wmfilename Path to watermakfile (which must be a TIFF file at the moment)
          */
-        bool add_watermark(std::string wmfilename);
+        bool add_watermark(const std::string &wmfilename);
 
 
         /*!

--- a/include/formats/SipiIOJ2k.h
+++ b/include/formats/SipiIOJ2k.h
@@ -40,7 +40,7 @@ namespace Sipi {
     class SipiIOJ2k : public SipiIO {
     private:
     public:
-        virtual ~SipiIOJ2k() {};
+        ~SipiIOJ2k() override = default;;
         /*!
          * Method used to read an image file
          *
@@ -50,9 +50,8 @@ namespace Sipi {
          * only reads part of the data returning an image with reduces resolution.
          * If the value is 1, only half the resolution is returned. If it is 2, only one forth etc.
          */
-        bool read(SipiImage *img, std::string filepath, int pagenum = 0, std::shared_ptr<SipiRegion> region = nullptr,
-                  std::shared_ptr<SipiSize> size = nullptr, bool force_bps_8 = false,
-                  ScalingQuality scaling_quality = {HIGH, HIGH, HIGH, HIGH}) override;
+        bool read(SipiImage *img, const std::string &filepath, int pagenum, std::shared_ptr<SipiRegion> region,
+                  std::shared_ptr<SipiSize> size, bool force_bps_8, ScalingQuality scaling_quality) override;
 
         /*!
          * Get the dimension of the image
@@ -61,7 +60,7 @@ namespace Sipi {
          * \param[out] width Width of the image in pixels
          * \param[out] height Height of the image in pixels
          */
-        Sipi::SipiImgInfo getDim(std::string filepath, int pagenum = 0) override;
+        Sipi::SipiImgInfo getDim(const std::string &filepath, int pagenum) override;
 
         /*!
          * Write a TIFF image to a file, stdout or to a memory buffer
@@ -69,7 +68,7 @@ namespace Sipi {
          * \param *img Pointer to SipiImage instance
          * \param filepath Name of the image file to be written.
          */
-        void write(SipiImage *img, std::string filepath, const SipiCompressionParams *params = nullptr) override;
+        void write(SipiImage *img, const std::string &filepath, const SipiCompressionParams *params) override;
     };
 }
 

--- a/include/formats/SipiIOJpeg.h
+++ b/include/formats/SipiIOJpeg.h
@@ -35,10 +35,10 @@ namespace Sipi {
     /*! Class which implements the JPEG2000-reader/writer */
     class SipiIOJpeg : public SipiIO {
     private:
-        void parse_photoshop(SipiImage *img, char *data, int length);
+        static void parse_photoshop(SipiImage *img, char *data, int length);
 
     public:
-        virtual ~SipiIOJpeg() {};
+        ~SipiIOJpeg() override = default;;
 
         /*!
          * Method used to read an image file
@@ -49,9 +49,8 @@ namespace Sipi {
          * only reads part of the data returning an image with reduces resolution.
          * If the value is 1, only half the resolution is returned. If it is 2, only one forth etc.
          */
-        bool read(SipiImage *img, std::string filepath, int pagenum = 0, std::shared_ptr<SipiRegion> region = nullptr,
-                  std::shared_ptr<SipiSize> size = nullptr, bool force_bps_8 = false,
-                  ScalingQuality scaling_quality = {HIGH, HIGH, HIGH, HIGH}) override;
+        bool read(SipiImage *img, const std::string &filepath, int pagenum, std::shared_ptr<SipiRegion> region,
+                  std::shared_ptr<SipiSize> size, bool force_bps_8, ScalingQuality scaling_quality) override;
 
         /*!
          * Get the dimension of the image
@@ -60,7 +59,7 @@ namespace Sipi {
          * \param[out] width Width of the image in pixels
          * \param[out] height Height of the image in pixels
          */
-        Sipi::SipiImgInfo getDim(std::string filepath, int pagenum = 0) override;
+        Sipi::SipiImgInfo getDim(const std::string &filepath, int pagenum) override;
 
 
         /*!
@@ -69,8 +68,7 @@ namespace Sipi {
          * \param *img Pointer to SipiImage instance
          * \param filepath Name of the image file to be written.
          */
-        void write(SipiImage *img, std::string filepath, const SipiCompressionParams *params = nullptr) override;
-
+        void write(SipiImage *img, const std::string &filepath, const SipiCompressionParams *params) override;
     };
 
 }

--- a/include/formats/SipiIOPdf.h
+++ b/include/formats/SipiIOPdf.h
@@ -34,15 +34,15 @@ namespace Sipi {
     private:
 
     public:
-        virtual ~SipiIOPdf() = default;
+        ~SipiIOPdf() override = default;
 
-        virtual bool read(SipiImage *img, std::string filepath, int pagenum = 0, std::shared_ptr<SipiRegion> region = nullptr,
-                  std::shared_ptr<SipiSize> size = nullptr, bool force_bps_8 = true,
-                  ScalingQuality scaling_quality = {HIGH, HIGH, HIGH, HIGH}) override;
+        bool read(SipiImage *img, const std::string &filepath, int pagenum, std::shared_ptr<SipiRegion> region,
+                  std::shared_ptr<SipiSize> size, bool force_bps_8, ScalingQuality scaling_quality) override;
 
-        virtual SipiImgInfo getDim(std::string filepath, int pagenum = 0) override;
+        SipiImgInfo getDim(const std::string &filepath, int pagenum) override;
 
-        virtual void write(SipiImage *img, std::string filepath, const SipiCompressionParams *params = nullptr) override;
+        void write(SipiImage *img, const std::string &filepath, const SipiCompressionParams *params) override;
+
     };
 }
 

--- a/include/formats/SipiIOPng.h
+++ b/include/formats/SipiIOPng.h
@@ -34,7 +34,7 @@ namespace Sipi {
 
     class SipiIOPng : public SipiIO {
     public:
-        virtual ~SipiIOPng() {};
+        ~SipiIOPng() override = default;;
 
         /*!
          * Method used to read an image file
@@ -43,9 +43,8 @@ namespace Sipi {
          * \param filepath Image file path
          * \param reduce Reducing factor. Not used reading TIFF files
          */
-        bool read(SipiImage *img, std::string filepath, int pagenum = 0, std::shared_ptr<SipiRegion> region = nullptr,
-                  std::shared_ptr<SipiSize> size = nullptr, bool force_bps_8 = true,
-                  ScalingQuality scaling_quality = {HIGH, HIGH, HIGH, HIGH}) override;
+        bool read(SipiImage *img, const std::string &filepath, int pagenum, std::shared_ptr<SipiRegion> region,
+                  std::shared_ptr<SipiSize> size, bool force_bps_8, ScalingQuality scaling_quality) override;
 
         /*!
          * Get the dimension of the image
@@ -54,7 +53,7 @@ namespace Sipi {
          * \param[out] width Width of the image in pixels
          * \param[out] height Height of the image in pixels
          */
-        Sipi::SipiImgInfo getDim(std::string filepath, int pagenum = 0) override;
+        Sipi::SipiImgInfo getDim(const std::string &filepath, int pagenum) override;
 
 
         /*!
@@ -69,7 +68,8 @@ namespace Sipi {
          * - "-" means to write the image data to stdout
          * - "HTTP" means to write the image data to the HTTP-server output
          */
-        void write(SipiImage *img, std::string filepath, const SipiCompressionParams *params = nullptr) override;
+        void write(SipiImage *img, const std::string &filepath, const SipiCompressionParams *params) override;
+
     };
 }
 

--- a/include/formats/SipiIOTiff.h
+++ b/include/formats/SipiIOTiff.h
@@ -36,7 +36,7 @@
 
 namespace Sipi {
 
-    extern unsigned char *read_watermark(std::string wmfile, int &nx, int &ny, int &nc);
+    unsigned char *read_watermark(const std::string &wmfile, int &nx, int &ny, int &nc);
 
     /*! Class which implements the TIFF-reader/writer */
     class SipiIOTiff : public SipiIO {
@@ -94,9 +94,9 @@ namespace Sipi {
          * \param filepath Image file path
          * \param reduce Reducing factor. Not used reading TIFF files
          */
-        bool read(SipiImage *img, std::string filepath, int pagenum = 0, std::shared_ptr<SipiRegion> region = nullptr,
-                  std::shared_ptr<SipiSize> size = nullptr, bool force_bps_8 = true,
-                  ScalingQuality scaling_quality = {HIGH, HIGH, HIGH, HIGH}) override;
+        bool read(SipiImage *img, const std::string &filepath, int pagenum, std::shared_ptr<SipiRegion> region,
+                  std::shared_ptr<SipiSize> size, bool force_bps_8,
+                  ScalingQuality scaling_quality) override;
 
         /*!
         * Get the dimension of the image
@@ -104,8 +104,7 @@ namespace Sipi {
         * \param[in] filepath Pathname of the image file
         * \return Image information
         */
-        SipiImgInfo getDim(std::string filepath, int pagenum) override;
-
+        SipiImgInfo getDim(const std::string &filepath, int pagenum) override;
 
         /*!
          * Write a TIFF image to a file, stdout or to a memory buffer
@@ -119,8 +118,7 @@ namespace Sipi {
          * - "-" means to write the image data to stdout
          * - "HTTP" means to write the image data to the HTTP-server output
          */
-        void write(SipiImage *img, std::string filepath, const SipiCompressionParams *params = nullptr) override;
-
+        void write(SipiImage *img, const std::string &filepath, const SipiCompressionParams *params) override;
     };
 }
 

--- a/include/iiifparser/SipiSize.h
+++ b/include/iiifparser/SipiSize.h
@@ -26,6 +26,7 @@
 #define __sipi_size_h
 
 #include <string>
+#include <utility>
 
 namespace Sipi {
 
@@ -37,11 +38,11 @@ namespace Sipi {
         int http_code;
         std::string description;
     public:
-        inline SipiSizeError(int http_code, const std::string &description) : http_code(http_code), description(description) {};
+        inline SipiSizeError(int http_code, std::string description) : http_code(http_code), description(std::move(description)) {};
 
-        inline int getHttpCode(void) { return http_code; }
+        inline int getHttpCode() const { return http_code; }
 
-        inline std::string getDescription(void) { return description; }
+        inline std::string getDescription() { return description; }
 
         inline std::string to_string() const {
             return "SipiSizeError: " + description;
@@ -90,28 +91,28 @@ namespace Sipi {
         /*!
          * Default constructor (full size)
          */
-        SipiSize() : size_type(SizeType::UNDEFINED), upscaling(false), percent(0.0F), reduce(0), nx(0), ny(0), w(0), h(0), canonical_ok(false) {}
+        SipiSize() : size_type(SizeType::UNDEFINED), upscaling(false), percent(0.0F), reduce(0), redonly(false), nx(0), ny(0), w(0), h(0), canonical_ok(false) {}
 
         /*!
          * Constructor with reduce parameter (reduce=0: full image, reduce=1: 1/2, reduce=2: 1/4,…)
          *
          * \param[in] reduce_p Reduce parameter
          */
-        SipiSize(int reduce_p) : size_type(SizeType::REDUCE), reduce(reduce_p) {}
+        explicit SipiSize(int reduce_p) : size_type(SizeType::REDUCE), upscaling(false), percent(0.0F), reduce(reduce_p), redonly(false), nx(0), ny(0), w(0), h(0), canonical_ok(false) {}
 
         /*!
          * Constructor with percentage parameter
          *
          * \param[in] percent_p Percentage parameter
          */
-        SipiSize(float percent_p) : size_type(SizeType::PERCENTS), percent(percent_p) {}
+        explicit SipiSize(float percent_p) : size_type(SizeType::PERCENTS), upscaling(false), percent(percent_p), reduce(false), redonly(false), nx(0), ny(0), w(0), h(0), canonical_ok(false) {}
 
         /*!
          * Construcor taking size/scale part of IIIF url as parameter
          *
          * \param[in] str String with the IIIF url part containing the size/scaling information
          */
-        SipiSize(std::string str);
+        explicit SipiSize(std::string str);
 
         /*!
          * Comparison operator ">"

--- a/include/metadata/SipiIcc.h
+++ b/include/metadata/SipiIcc.h
@@ -62,7 +62,7 @@ namespace Sipi {
      */
     class SipiIcc {
     private:
-        cmsHPROFILE icc_profile;            //!< Handle of the littleCMS profile data
+        cmsHPROFILE icc_profile{};            //!< Handle of the littleCMS profile data
         PredefinedProfiles profile_type;    //!< Profile type that is represented
 
     public:
@@ -91,13 +91,13 @@ namespace Sipi {
          * Constructor using littleCMS profile
          * \param[in] icc_profile_p LittleCMS profile
          */
-        SipiIcc(cmsHPROFILE &icc_profile_p);
+        explicit SipiIcc(cmsHPROFILE &icc_profile_p);
 
         /**
          * Constructor to create a predefined profile
          * \param[in] predef Desired predefined profile
          */
-        SipiIcc(PredefinedProfiles predef);
+        explicit SipiIcc(PredefinedProfiles predef);
 
         /**
          * Constructor of an ICC RGB profile using white point, primaries and transfer function (if available),
@@ -107,8 +107,8 @@ namespace Sipi {
          * \param[in] tfunc Transfer function tables as retrieved by libtiff with either (1 << bitspersample) or 3*(1 << bitspersample) entries
          * \param[in] Length of tranfer function table
          */
-        SipiIcc(float white_point_p[], float primaries_p[], const unsigned short *tfunc = NULL,
-                const int tfunc_len = 0);
+        SipiIcc(float white_point_p[], float primaries_p[], const unsigned short *tfunc = nullptr,
+                int tfunc_len = 0);
 
         /**
          * Destructor
@@ -144,7 +144,7 @@ namespace Sipi {
          * Get the profile type
          * \retruns Gives the predefined profile type
          */
-        inline const PredefinedProfiles getProfileType() const { return profile_type; };
+        inline PredefinedProfiles getProfileType() const { return profile_type; };
 
         /*!
          * returns a littleCMS formatter with the given bits/sample

--- a/shttps/Connection.cpp
+++ b/shttps/Connection.cpp
@@ -607,13 +607,13 @@ namespace shttps {
 
                                     if (opts.count("form-data") == 0) {
                                         // something is wrong!
-                                        //cerr << __file__ << " #" << __LINE__ << endl;
+                                        //cerr << thisSourceFile << " #" << __LINE__ << endl;
                                         //cerr << "LINE=" << line << endl;
                                     }
 
                                     if (opts.count("name") == 0) {
                                         // something wrong
-                                        //cerr << __file__ << " #" << __LINE__ << endl;
+                                        //cerr << thisSourceFile << " #" << __LINE__ << endl;
                                         //cerr << "LINE=" << line << endl;
                                         //cerr << "VALUE=" << value << endl;
                                     }

--- a/shttps/Connection.h
+++ b/shttps/Connection.h
@@ -137,7 +137,8 @@ namespace shttps {
          * \param[in] name_p Name of the cookie
          * \param[in] value_p Value of the Cookie
          */
-        inline Cookie(const std::string &name_p, const std::string value_p) : _name(name_p), _value(value_p) {}
+        inline Cookie(const std::string &name_p, const std::string value_p) : _name(name_p), _value(value_p),
+        _secure(true), _http_only(false) {}
 
         /*!
          * Getter for the name

--- a/shttps/LuaServer.cpp
+++ b/shttps/LuaServer.cpp
@@ -2112,6 +2112,7 @@ namespace shttps {
 
         json_t *root = subtable(L, 1);
         char *jsonstr = json_dumps(root, JSON_INDENT(3));
+        json_decref(root);
 
         if (jwt_new(&jwt) != 0) {
             lua_settop(L, 0); // clear stack
@@ -2128,6 +2129,7 @@ namespace shttps {
 
         lua_pushboolean(L, true);
         lua_pushstring(L, token);
+        free(jsonstr);
 
         return 2;
     }
@@ -2169,10 +2171,12 @@ namespace shttps {
         char *tokendata;
 
         if ((tokendata = jwt_dump_str(jwt, false)) == nullptr) {
+            jwt_free(jwt);
             lua_pushboolean(L, false);
             lua_pushstring(L, "'server.decode_jwt(token)': Error in decoding token! (2)");
             return 2;
         }
+        jwt_free(jwt);
 
         std::string tokenstr = tokendata;
         free(tokendata);
@@ -2185,6 +2189,7 @@ namespace shttps {
         try {
             lua_jsonobj(L, jsonobj);
         } catch (std::string &errorMsg) {
+
             lua_settop(L, 0); // clear stack
             lua_pushboolean(L, false);
             std::string tmpstr = std::string("'server.decode_jwt(token)': Error in decoding token: ") + errorMsg;

--- a/shttps/LuaServer.cpp
+++ b/shttps/LuaServer.cpp
@@ -3137,7 +3137,7 @@ namespace shttps {
 
         if (!lua_istable(L, -1)) {
             //return keyvalstores;
-            throw Error(__file__, __LINE__, "Value '" + table + "' in config file must be a table");
+            throw Error(thisSourceFile, __LINE__, "Value '" + table + "' in config file must be a table");
         }
 
         lua_pushnil(L);
@@ -3145,7 +3145,7 @@ namespace shttps {
             const char *profile_name = lua_tostring(L, -2);
 
             if (!lua_istable(L, -1)) {
-                throw Error(__file__, __LINE__, "Value '" + std::string(profile_name) + "' in config file must be a table");
+                throw Error(thisSourceFile, __LINE__, "Value '" + std::string(profile_name) + "' in config file must be a table");
             }
             LuaKeyValStore kvstore;
             lua_pushnil(L);
@@ -3169,13 +3169,13 @@ namespace shttps {
                     std::ostringstream errStream;
                     errStream << "Table contained returned nil";
                     std::string errorMsg = errStream.str();
-                    throw Error(__file__, __LINE__, errorMsg);
+                    throw Error(thisSourceFile, __LINE__, errorMsg);
                 } else {
                     std::string luaTypeName = std::string(lua_typename(L, -1));
                     std::ostringstream errMsg;
                     errMsg << "Table contained a value of type " << luaTypeName
                            << ", which is not supported";
-                    throw Error(__file__, __LINE__, errMsg.str());
+                    throw Error(thisSourceFile, __LINE__, errMsg.str());
                 }
                 kvstore[param_name] = tmplv;
                 lua_pop(L, 1);

--- a/shttps/Parsing.cpp
+++ b/shttps/Parsing.cpp
@@ -176,9 +176,9 @@ namespace shttps {
                 throw Error(__file__, __LINE__, magic_error(handle));
             }
 
-            // magic_close(handle);
 
             std::string mimestr(magic_file(handle, fpath.c_str()));
+            magic_close(handle);
             return parseMimetype(mimestr);
         }
         //=============================================================================================================

--- a/shttps/Server.cpp
+++ b/shttps/Server.cpp
@@ -722,7 +722,6 @@ namespace shttps {
      * @return
      */
     static int close_socket(const SocketControl::SocketInfo &sockid) {
-        std::cerr << "******** close_socket" << std::endl;
 #ifdef SHTTPS_ENABLE_SSL
         if (sockid.ssl_sid != nullptr) {
             int sstat;

--- a/shttps/Server.cpp
+++ b/shttps/Server.cpp
@@ -22,11 +22,7 @@
  */
 
 #include <algorithm>
-#include <functional>
-#include <cctype>
 #include <iostream>
-#include <fstream>
-#include <sstream>
 #include <string>
 #include <cstring>      // Needed for memset
 #include <utility>
@@ -34,16 +30,15 @@
 
 #include <sys/types.h>
 #include <sys/select.h>
-#include <sys/errno.h>
+#include <cerrno>
 #include <sys/stat.h>
 #include <sys/socket.h>
-#include <signal.h>
+#include <csignal>
 #include <poll.h>
 #include <netinet/in.h>
 #include <arpa/inet.h> //inet_addr
 #include <unistd.h>    //write
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include <fcntl.h>
 #include <pthread.h>
 #include <pwd.h>
@@ -53,7 +48,6 @@
 //#include "openssl/applink.c"
 
 
-#include "Global.h"
 #include "SockStream.h"
 #include "Server.h"
 #include "LuaServer.h"
@@ -68,25 +62,12 @@ namespace shttps {
 
     const char loggername[] = "Sipi"; // see Global.h !!
 
-    typedef struct {
-        int sock;
-#ifdef SHTTPS_ENABLE_SSL
-        SSL *cSSL;
-#endif
-        std::string peer_ip;
-        int peer_port;
-        int commpipe_read;
-        Server *serv;
-    } TData;
-    //=========================================================================
-
-
     /*!
      * Starts a thread just to catch all signals sent to the server process.
      * If it receives SIGINT or SIGTERM, tells the server to stop.
      */
     static void *sig_thread(void *arg) {
-        Server *serverptr = static_cast<Server *>(arg);
+        auto *serverptr = static_cast<Server *>(arg);
         sigset_t set;
         sigemptyset(&set);
         sigaddset(&set, SIGPIPE);
@@ -132,8 +113,7 @@ namespace shttps {
         }
 
         syslog(LOG_WARNING, "No handler available! Host: %s Uri: %s", conn.host().c_str(), conn.uri().c_str());
-        return;
-    }
+   }
     //=========================================================================
 
     /**
@@ -317,7 +297,7 @@ namespace shttps {
             return;
         }
 
-        struct stat s;
+        struct stat s{};
 
         if (stat(infile.c_str(), &s) == 0) {
             if (!(s.st_mode & S_IFREG)) { // we have not a regular file, do nothing!
@@ -439,7 +419,7 @@ namespace shttps {
                 //
                 // first we get the filesize and time using fstat
                 //
-                struct stat fstatbuf;
+                struct stat fstatbuf{};
 
                 if (stat(infile.c_str(), &fstatbuf) != 0) {
                     throw Error(__file__, __LINE__, "Cannot fstat file!");

--- a/shttps/Server.cpp
+++ b/shttps/Server.cpp
@@ -722,6 +722,7 @@ namespace shttps {
      * @return
      */
     static int close_socket(const SocketControl::SocketInfo &sockid) {
+        std::cerr << "******** close_socket" << std::endl;
 #ifdef SHTTPS_ENABLE_SSL
         if (sockid.ssl_sid != nullptr) {
             int sstat;
@@ -931,6 +932,7 @@ namespace shttps {
                 }
 
                 SSL_free(cSSL);
+                SSL_CTX_free(sslctx);
                 cSSL = nullptr;
             }
         }

--- a/shttps/Server.cpp
+++ b/shttps/Server.cpp
@@ -731,6 +731,7 @@ namespace shttps {
                        __file__, __LINE__, SSL_get_error(sockid.ssl_sid, sstat));
             }
             SSL_free(sockid.ssl_sid);
+            SSL_CTX_free(sockid.sslctx);
         }
 #endif
         if (shutdown(sockid.sid, SHUT_RDWR) < 0) {
@@ -876,9 +877,9 @@ namespace shttps {
         }
 #ifdef SHTTPS_ENABLE_SSL
         SSL *cSSL = nullptr;
+        SSL_CTX *sslctx = nullptr;
 
         if (ssl) {
-            SSL_CTX *sslctx;
             try {
                 if ((sslctx = SSL_CTX_new(SSLv23_server_method())) == nullptr) {
                     syslog(LOG_ERR, "OpenSSL error: SSL_CTX_new() failed");
@@ -934,6 +935,7 @@ namespace shttps {
             }
         }
         socket_id.ssl_sid = cSSL;
+        socket_id.sslctx = sslctx;
 #endif
         return socket_id;
     }

--- a/shttps/SockStream.cpp
+++ b/shttps/SockStream.cpp
@@ -50,6 +50,7 @@ SockStream::SockStream(int sock_p, int in_bufsize_p, int out_bufsize_p, int putb
     setg(end, end, end);
 
     out_buf = new char[out_bufsize];
+    memset(out_buf, 0, out_bufsize);
     setp(out_buf, out_buf + out_bufsize);
 }
 
@@ -67,6 +68,7 @@ SockStream::SockStream(SSL *cSSL_p, int in_bufsize_p, int out_bufsize_p, int put
     setg(end, end, end);
 
     out_buf = new char[out_bufsize];
+    memset(out_buf, 0, out_bufsize);
     setp(out_buf, out_buf + out_bufsize);
 
 }

--- a/shttps/SocketControl.cpp
+++ b/shttps/SocketControl.cpp
@@ -123,6 +123,7 @@ namespace shttps {
         data.sid = msg.sid;
 #ifdef SHTTPS_ENABLE_SSL
         data.ssl_sid = msg.ssl_sid;
+        data.sslctx = msg.sslctx;
 #endif
         for (int i = 0; i < INET6_ADDRSTRLEN; ++i) {
             data.peer_ip[i] = msg.peer_ip[i];

--- a/shttps/SocketControl.cpp
+++ b/shttps/SocketControl.cpp
@@ -33,7 +33,7 @@ namespace shttps {
             throw Error(thisSourceFile, __LINE__, "Adding stop socket not allowed after adding dynamic sockets!");
         }
         generic_open_sockets.emplace_back(NOOP, STOP_SOCKET, sid);
-        stop_sock_id = generic_open_sockets.size() - 1;
+        stop_sock_id = static_cast<int>(generic_open_sockets.size() - 1);
     }
     //=========================================================================
 
@@ -43,7 +43,7 @@ namespace shttps {
             throw Error(thisSourceFile, __LINE__, "Adding HTTP socket not allowed after adding dynamic sockets!");
         }
         generic_open_sockets.emplace_back(NOOP, HTTP_SOCKET, sid);
-        http_sock_id = generic_open_sockets.size() - 1;
+        http_sock_id = static_cast<int>(generic_open_sockets.size() - 1);
     }
     //=========================================================================
 
@@ -53,7 +53,7 @@ namespace shttps {
             throw Error(thisSourceFile, __LINE__, "Adding SSL socket not allowed after adding dynamic sockets!");
         }
         generic_open_sockets.emplace_back(NOOP, SSL_SOCKET, sid, nullptr);
-        ssl_sock_id = generic_open_sockets.size() - 1;
+        ssl_sock_id = static_cast<int>(generic_open_sockets.size() - 1);
     }
     //=========================================================================
 
@@ -63,7 +63,7 @@ namespace shttps {
         sockid.socket_type = DYN_SOCKET;
         generic_open_sockets.push_back(sockid);
         if (dyn_socket_base == -1) {
-            dyn_socket_base = generic_open_sockets.size() - 1;
+            dyn_socket_base = static_cast<int>(generic_open_sockets.size() - 1);
         }
     }
     //=========================================================================
@@ -106,7 +106,7 @@ namespace shttps {
 
     bool SocketControl::get_waiting(SocketInfo &sockid) {
         std::unique_lock<std::mutex> mutex_guard(sockets_mutex);
-        if (waiting_sockets.size() > 0) {
+        if (!waiting_sockets.empty()) {
             sockid = waiting_sockets.front();
             waiting_sockets.pop();
             return true;
@@ -140,7 +140,7 @@ namespace shttps {
             data.type = ERROR;
             std::cerr << "==> receive_control_message: received only " << n << " bytes!!" << std::endl;
         }
-        return {data};
+        return SocketInfo(data);
     }
     //=========================================================================§
 

--- a/shttps/SocketControl.h
+++ b/shttps/SocketControl.h
@@ -53,6 +53,7 @@ namespace shttps {
             int sid;
 #ifdef SHTTPS_ENABLE_SSL
             SSL *ssl_sid;
+            SSL_CTX *sslctx;
 #endif
             char peer_ip[INET6_ADDRSTRLEN]{};
             int peer_port;
@@ -65,6 +66,7 @@ namespace shttps {
             int sid;
 #ifdef SHTTPS_ENABLE_SSL
             SSL *ssl_sid;
+            SSL_CTX *sslctx;
 #endif
             char peer_ip[INET6_ADDRSTRLEN]{};
             int peer_port;
@@ -72,11 +74,14 @@ namespace shttps {
             explicit SocketInfo(ControlMessageType type = NOOP,
                                 SocketType socket_type = CONTROL_SOCKET,
                                 int sid = -1,
+#ifdef SHTTPS_ENABLE_SSL
                                 SSL * ssl_sid = nullptr,
+                                SSL_CTX *sslctx = nullptr,
+#endif
                                 char *_peer_ip = nullptr,
                                 int peer_port = -1) :
 #ifdef SHTTPS_ENABLE_SSL
-                                type(type), socket_type(socket_type), sid(sid), ssl_sid(ssl_sid), peer_port(peer_port)
+                                type(type), socket_type(socket_type), sid(sid), ssl_sid(ssl_sid), sslctx(sslctx), peer_port(peer_port)
 #else
                                 type(type), socket_type(socket_type), sid(sid),  peer_port(peer_port)
 #endif
@@ -95,6 +100,7 @@ namespace shttps {
                 sid = si.sid;
 #ifdef SHTTPS_ENABLE_SSL
                 ssl_sid = si.ssl_sid;
+                sslctx = si.sslctx;
 #endif
                 for (int i = 0; i < INET6_ADDRSTRLEN; i++) peer_ip[i] = si.peer_ip[i];
                 peer_port = si.peer_port;
@@ -106,6 +112,7 @@ namespace shttps {
                 sid = data.sid;
 #ifdef SHTTPS_ENABLE_SSL
                 ssl_sid = data.ssl_sid;
+                sslctx = data.sslctx;
 #endif
                 for (int i = 0; i < INET6_ADDRSTRLEN; i++) peer_ip[i] = data.peer_ip[i];
                 peer_port = data.peer_port;
@@ -119,6 +126,7 @@ namespace shttps {
                 sid = si.sid;
 #ifdef SHTTPS_ENABLE_SSL
                 ssl_sid = si.ssl_sid;
+                sslctx = si.sslctx;
 #endif
                 for (int i = 0; i < INET6_ADDRSTRLEN; i++) peer_ip[i] = si.peer_ip[i];
                 peer_port = si.peer_port;

--- a/shttps/SocketControl.h
+++ b/shttps/SocketControl.h
@@ -48,15 +48,15 @@ namespace shttps {
         };
 
         struct SIData{
-            ControlMessageType type;
-            SocketType socket_type;
-            int sid;
+            ControlMessageType type{NOOP};
+            SocketType socket_type{CONTROL_SOCKET};
+            int sid{};
 #ifdef SHTTPS_ENABLE_SSL
-            SSL *ssl_sid;
-            SSL_CTX *sslctx;
+            SSL *ssl_sid{};
+            SSL_CTX *sslctx{};
 #endif
             char peer_ip[INET6_ADDRSTRLEN]{};
-            int peer_port;
+            int peer_port{};
         };
 
         class SocketInfo {
@@ -106,7 +106,7 @@ namespace shttps {
                 peer_port = si.peer_port;
             }
 
-            SocketInfo(const SIData &data) {
+            explicit SocketInfo(const SIData &data) {
                 type = data.type;
                 socket_type = data.socket_type;
                 sid = data.sid;
@@ -163,7 +163,7 @@ namespace shttps {
 
         pollfd *get_sockets_arr();
 
-        int get_sockets_size() const { return generic_open_sockets.size(); }
+        int get_sockets_size() const { return static_cast<int>(generic_open_sockets.size()); }
 
         int get_n_msg_sockets() const { return n_msg_sockets; }
 
@@ -183,9 +183,9 @@ namespace shttps {
 
         int get_dyn_socket_base() const { return dyn_socket_base; }
 
-        int size() { return generic_open_sockets.size(); }
+        int size() { return static_cast<int>(generic_open_sockets.size()); }
 
-        const pollfd &operator[](int index);
+        inline const pollfd &operator[](int index) { return open_sockets[index]; };
 
         void remove(int pos, SocketInfo &sockid);
 

--- a/shttps/SocketControl.h
+++ b/shttps/SocketControl.h
@@ -12,6 +12,7 @@
 #include <mutex>
 #include <csignal>
 #include <iostream>
+#include <cstring>
 
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -20,7 +21,6 @@
 #include <unistd.h>
 #include <syslog.h>
 #include <poll.h>
-#include <string.h>
 
 #ifdef SHTTPS_ENABLE_SSL
 
@@ -47,6 +47,17 @@ namespace shttps {
             CONTROL_SOCKET, STOP_SOCKET, HTTP_SOCKET, SSL_SOCKET, DYN_SOCKET
         };
 
+        struct SIData{
+            ControlMessageType type;
+            SocketType socket_type;
+            int sid;
+#ifdef SHTTPS_ENABLE_SSL
+            SSL *ssl_sid;
+#endif
+            char peer_ip[INET6_ADDRSTRLEN]{};
+            int peer_port;
+        };
+
         class SocketInfo {
         public:
             ControlMessageType type;
@@ -55,18 +66,23 @@ namespace shttps {
 #ifdef SHTTPS_ENABLE_SSL
             SSL *ssl_sid;
 #endif
-            char peer_ip[INET6_ADDRSTRLEN];
+            char peer_ip[INET6_ADDRSTRLEN]{};
             int peer_port;
 
-            SocketInfo(ControlMessageType type = NOOP,
-                       SocketType socket_type = CONTROL_SOCKET,
-                       int sid = -1,
-                       SSL * ssl_sid = nullptr,
-                       char *_peer_ip = nullptr,
-                       int peer_port = -1) : type(type), socket_type(socket_type), sid(sid), ssl_sid(ssl_sid), peer_port(peer_port)
+            explicit SocketInfo(ControlMessageType type = NOOP,
+                                SocketType socket_type = CONTROL_SOCKET,
+                                int sid = -1,
+                                SSL * ssl_sid = nullptr,
+                                char *_peer_ip = nullptr,
+                                int peer_port = -1) :
+#ifdef SHTTPS_ENABLE_SSL
+                                type(type), socket_type(socket_type), sid(sid), ssl_sid(ssl_sid), peer_port(peer_port)
+#else
+                                type(type), socket_type(socket_type), sid(sid),  peer_port(peer_port)
+#endif
             {
                 if (_peer_ip == nullptr) {
-                    for (int i = 0; i < INET6_ADDRSTRLEN; i++) peer_ip[i] = '\0';
+                    for (char & i : peer_ip) i = '\0';
                 } else {
                     strncpy(peer_ip, _peer_ip, INET6_ADDRSTRLEN - 1);
                     peer_ip[INET6_ADDRSTRLEN - 1] = '\0';
@@ -74,6 +90,8 @@ namespace shttps {
             }
 
             SocketInfo(const SocketInfo &si) {
+                type = si.type;
+                socket_type = si.socket_type;
                 sid = si.sid;
 #ifdef SHTTPS_ENABLE_SSL
                 ssl_sid = si.ssl_sid;
@@ -82,8 +100,22 @@ namespace shttps {
                 peer_port = si.peer_port;
             }
 
+            SocketInfo(const SIData &data) {
+                type = data.type;
+                socket_type = data.socket_type;
+                sid = data.sid;
+#ifdef SHTTPS_ENABLE_SSL
+                ssl_sid = data.ssl_sid;
+#endif
+                for (int i = 0; i < INET6_ADDRSTRLEN; i++) peer_ip[i] = data.peer_ip[i];
+                peer_port = data.peer_port;
+            }
 
-            SocketInfo operator=(const SocketInfo &si) {
+
+            SocketInfo &operator=(const SocketInfo &si) {
+                if (this == &si) return *this;
+                type = si.type;
+                socket_type = si.socket_type;
                 sid = si.sid;
 #ifdef SHTTPS_ENABLE_SSL
                 ssl_sid = si.ssl_sid;
@@ -94,13 +126,6 @@ namespace shttps {
             }
 
         };
-
-        struct socket_info_hash {
-            size_t operator()(SocketInfo const &sockid) const noexcept {
-                return (sockid.sid);
-            }
-        };
-
 
     private:
         std::mutex sockets_mutex; //!> protecting mutex
@@ -126,29 +151,29 @@ namespace shttps {
          * sockets for the internal communication with the threads. The Initial sockets
          * are added to the idling sockets pool
          */
-        SocketControl(ThreadControl &thread_control);
+        explicit SocketControl(ThreadControl &thread_control);
 
         pollfd *get_sockets_arr();
 
-        int get_sockets_size() { return generic_open_sockets.size(); }
+        int get_sockets_size() const { return generic_open_sockets.size(); }
 
-        int get_n_msg_sockets() { return n_msg_sockets; }
+        int get_n_msg_sockets() const { return n_msg_sockets; }
 
         void add_stop_socket(int sid);
 
-        int get_stop_socket_id() { return stop_sock_id; }
+        int get_stop_socket_id() const { return stop_sock_id; }
 
         void add_http_socket(int sid);
 
-        int get_http_socket_id() { return http_sock_id; }
+        int get_http_socket_id() const { return http_sock_id; }
 
         void add_ssl_socket(int sid);
 
-        int get_ssl_socket_id() { return ssl_sock_id; }
+        int get_ssl_socket_id() const { return ssl_sock_id; }
 
         void add_dyn_socket(SocketInfo sockid);
 
-        int get_dyn_socket_base() { return dyn_socket_base; }
+        int get_dyn_socket_base() const { return dyn_socket_base; }
 
         int size() { return generic_open_sockets.size(); }
 
@@ -157,19 +182,12 @@ namespace shttps {
         void remove(int pos, SocketInfo &sockid);
 
 
-        /*!
-         *
-         * @param offset
-         * @param sockid
-         * @return
-         */
-        bool open_pop(int offset, SocketInfo &sockid);
 
         void move_to_waiting(int pos);
 
         bool get_waiting(SocketInfo &sockid);
 
-        static int send_control_message(int pipe_id, const SocketInfo &msg);
+        static ssize_t send_control_message(int pipe_id, const SocketInfo &msg);
 
         static SocketInfo receive_control_message(int pipe_id);
 

--- a/src/SipiHttpServer.cpp
+++ b/src/SipiHttpServer.cpp
@@ -1455,9 +1455,9 @@ static void knora_send_info(Connection &conn_obj, SipiHttpServer *serv, shttps::
                         numpages = info.numpages;
                     }
 
-                    size_t tmp_r_w, tmp_r_h;
-                    int tmp_red;
-                    bool tmp_ro;
+                    size_t tmp_r_w {0L}, tmp_r_h {0L};
+                    int tmp_red {0};
+                    bool tmp_ro {false};
                     try {
                         size->get_size(img_w, img_h, tmp_r_w, tmp_r_h, tmp_red, tmp_ro);
                         restriction_size->get_size(img_w, img_h, tmp_r_w, tmp_r_h, tmp_red, tmp_ro);

--- a/src/SipiHttpServer.cpp
+++ b/src/SipiHttpServer.cpp
@@ -991,7 +991,7 @@ static void knora_send_info(Connection &conn_obj, SipiHttpServer *serv, shttps::
             parts.push_back(shttps::urldecode(uri.substr(old_pos, std::string::npos)));
         }
 
-        if (parts.size() < 1) {
+        if (parts.empty()) {
             send_error(conn_obj, Connection::BAD_REQUEST, "No parameters/path given");
             return;
         }
@@ -1007,7 +1007,7 @@ static void knora_send_info(Connection &conn_obj, SipiHttpServer *serv, shttps::
         std::string region_ex = "^(full)|(square)|([0-9]+,[0-9]+,[0-9]+,[0-9]+)|(pct:[0-9]*\\.?[0-9]*,[0-9]*\\.?[0-9]*,[0-9]*\\.?[0-9]*,[0-9]*\\.?[0-9]*)$";
 
         bool qualform_ok = false;
-        if (parts.size() > 0) qualform_ok = std::regex_match(parts[parts.size() - 1], std::regex(qualform_ex));
+        if (!parts.empty()) qualform_ok = std::regex_match(parts[parts.size() - 1], std::regex(qualform_ex));
 
         bool rotation_ok = false;
         if (parts.size() > 1) rotation_ok = std::regex_match(parts[parts.size() - 2], std::regex(rotation_ex));

--- a/src/SipiHttpServer.cpp
+++ b/src/SipiHttpServer.cpp
@@ -819,9 +819,9 @@ static void knora_send_info(Connection &conn_obj, SipiHttpServer *serv, shttps::
         char canonical_region[canonical_len + 1];
         char canonical_size[canonical_len + 1];
 
-        int tmp_r_x, tmp_r_y, tmp_red;
-        size_t tmp_r_w, tmp_r_h;
-        bool tmp_ro;
+        int tmp_r_x = 0, tmp_r_y = 0, tmp_red = 0;
+        size_t tmp_r_w = 0, tmp_r_h = 0;
+        bool tmp_ro = false;
 
         if (region->getType() != SipiRegion::FULL) {
             region->crop_coords(tmp_w, tmp_h, tmp_r_x, tmp_r_y, tmp_r_w, tmp_r_h);

--- a/src/SipiImage.cpp
+++ b/src/SipiImage.cpp
@@ -351,7 +351,7 @@ namespace Sipi {
     }
     //============================================================================
 
-    SipiImgInfo SipiImage::getDim(std::string filepath, int pagenum) {
+    SipiImgInfo SipiImage::getDim(const std::string &filepath, int pagenum) const {
         size_t pos = filepath.find_last_of('.');
         std::string fext = filepath.substr(pos + 1);
         std::string _fext;
@@ -390,27 +390,27 @@ namespace Sipi {
     //============================================================================
 
 
-    void SipiImage::getDim(size_t &width, size_t &height) {
+    void SipiImage::getDim(size_t &width, size_t &height) const {
         width = getNx();
         height = getNy();
     }
     //============================================================================
 
-    void SipiImage::write(std::string ftype, std::string filepath, const SipiCompressionParams *params) {
+    void SipiImage::write(const std::string &ftype, const std::string &filepath, const SipiCompressionParams *params) {
         io[ftype]->write(this, filepath, params);
    }
     //============================================================================
 
-    void SipiImage::convertYCC2RGB(void) {
+    void SipiImage::convertYCC2RGB() {
         if (bps == 8) {
             byte *inbuf = pixels;
             byte *outbuf = new byte[(size_t) nc * (size_t) nx * (size_t) ny];
 
             for (size_t j = 0; j < ny; j++) {
                 for (size_t i = 0; i < nx; i++) {
-                    double Y = (double) inbuf[nc * (j * nx + i) + 2];
-                    double Cb = (double) inbuf[nc * (j * nx + i) + 1];;
-                    double Cr = (double) inbuf[nc * (j * nx + i) + 0];
+                    auto Y = (double) inbuf[nc * (j * nx + i) + 2];
+                    auto Cb = (double) inbuf[nc * (j * nx + i) + 1];;
+                    auto Cr = (double) inbuf[nc * (j * nx + i) + 0];
 
                     int r = (int) (Y + 1.40200 * (Cr - 0x80));
                     int g = (int) (Y - 0.34414 * (Cb - 0x80) - 0.71414 * (Cr - 0x80));
@@ -431,13 +431,13 @@ namespace Sipi {
         } else if (bps == 16) {
             word *inbuf = (word *) pixels;
             size_t nnc = nc - 1;
-            unsigned short *outbuf = new unsigned short[nnc * nx * ny];
+            auto *outbuf = new unsigned short[nnc * nx * ny];
 
             for (size_t j = 0; j < ny; j++) {
                 for (size_t i = 0; i < nx; i++) {
-                    double Y = (double) inbuf[nc * (j * nx + i) + 2];
-                    double Cb = (double) inbuf[nc * (j * nx + i) + 1];;
-                    double Cr = (double) inbuf[nc * (j * nx + i) + 0];
+                    auto Y = (double) inbuf[nc * (j * nx + i) + 2];
+                    auto Cb = (double) inbuf[nc * (j * nx + i) + 1];;
+                    auto Cr = (double) inbuf[nc * (j * nx + i) + 0];
 
                     int r = (int) (Y + 1.40200 * (Cr - 0x80));
                     int g = (int) (Y - 0.34414 * (Cb - 0x80) - 0.71414 * (Cr - 0x80));
@@ -555,7 +555,7 @@ namespace Sipi {
             throw SipiImageError(__file__, __LINE__, msg);
         }
 
-        if (es.size() > 0) {
+        if (!es.empty()) {
             if (nc < 3) {
                 es.clear(); // no more alpha channel
             } else if (nc > 3) { // it's probably an alpha channel
@@ -591,7 +591,7 @@ namespace Sipi {
         } else if (bps == 16) {
             word *inbuf = (word *) pixels;
             size_t nnc = nc - 1;
-            unsigned short *outbuf = new unsigned short[nnc * nx * ny];
+            auto *outbuf = new unsigned short[nnc * nx * ny];
 
             for (size_t j = 0; j < ny; j++) {
                 for (size_t i = 0; i < nx; i++) {
@@ -685,7 +685,7 @@ namespace Sipi {
     //============================================================================
 
 
-    bool SipiImage::crop(std::shared_ptr<SipiRegion> region) {
+    bool SipiImage::crop(const std::shared_ptr<SipiRegion> &region) {
         int x, y;
         size_t width, height;
         if (region->getType() == SipiRegion::FULL) return true; // we do not have to crop;
@@ -1265,7 +1265,7 @@ namespace Sipi {
     }
     //============================================================================
 
-    bool SipiImage::to8bps(void) {
+    bool SipiImage::to8bps() {
         // little-endian architecture assumed
         //
         // we just use the shift-right operater (>> 8) to devide the values by 256 (2^8)!
@@ -1297,7 +1297,7 @@ namespace Sipi {
     //============================================================================
 
 
-    bool SipiImage::toBitonal(void) {
+    bool SipiImage::toBitonal() {
         if ((photo != MINISBLACK) && (photo != MINISWHITE)) {
             convertToIcc(SipiIcc(icc_GRAY_D50), 8);
         }
@@ -1311,7 +1311,7 @@ namespace Sipi {
         if (!doit) return true; // we have to do nothing, it's already bitonal
 
         // must be signed!! Error propagation my result in values < 0 or > 255
-        short *outbuf = new(std::nothrow) short[nx * ny];
+        auto *outbuf = new(std::nothrow) short[nx * ny];
 
         if (outbuf == nullptr) return false; // TODO: throw an error with a reasonable error message
 
@@ -1338,7 +1338,7 @@ namespace Sipi {
     //============================================================================
 
 
-    bool SipiImage::add_watermark(std::string wmfilename) {
+    bool SipiImage::add_watermark(const std::string &wmfilename) {
         int wm_nx, wm_ny, wm_nc;
         byte *wmbuf = read_watermark(wmfilename, wm_nx, wm_ny, wm_nc);
         if (wmbuf == nullptr) {
@@ -1452,7 +1452,7 @@ namespace Sipi {
 
             default: {
                 delete[] diffbuf;
-                if (new_rhs != nullptr) delete new_rhs;
+                delete new_rhs;
                 throw SipiImageError(__file__, __LINE__, "Bits per pixels not supported");
             }
         }
@@ -1503,12 +1503,12 @@ namespace Sipi {
 
             default: {
                 delete[] diffbuf;
-                if (new_rhs != nullptr) delete new_rhs;
+                delete new_rhs;
                 throw SipiImageError(__file__, __LINE__, "Bits per pixels not supported");
             }
         }
 
-        if (new_rhs != nullptr) delete new_rhs;
+        delete new_rhs;
 
         delete[] diffbuf;
         return *this;
@@ -1517,7 +1517,7 @@ namespace Sipi {
     /*==========================================================================*/
 
     SipiImage &SipiImage::operator-(const SipiImage &rhs) {
-        SipiImage *lhs = new SipiImage(*this);
+        auto *lhs = new SipiImage(*this);
         *lhs -= rhs;
         return *lhs;
     }
@@ -1581,7 +1581,7 @@ namespace Sipi {
 
             default: {
                 delete[] diffbuf;
-                if (new_rhs != nullptr) delete new_rhs;
+                delete new_rhs;
                 throw SipiImageError(__file__, __LINE__, "Bits per pixels not supported");
             }
         }
@@ -1627,7 +1627,7 @@ namespace Sipi {
 
             default: {
                 delete[] diffbuf;
-                if (new_rhs != nullptr) delete new_rhs;
+                delete new_rhs;
                 throw SipiImageError(__file__, __LINE__, "Bits per pixels not supported");
             }
         }
@@ -1640,7 +1640,7 @@ namespace Sipi {
     /*==========================================================================*/
 
     SipiImage &SipiImage::operator+(const SipiImage &rhs) {
-        SipiImage *lhs = new SipiImage(*this);
+        auto *lhs = new SipiImage(*this);
         *lhs += rhs;
         return *lhs;
     }

--- a/src/SipiImage.cpp
+++ b/src/SipiImage.cpp
@@ -257,9 +257,9 @@ namespace Sipi {
         } catch (std::out_of_range &e) {
             std::stringstream ss;
             ss << "Unsupported file type: \"" << filename;
-            throw SipiImageError(__file__, __LINE__, ss.str());
+            throw SipiImageError(thisSourceFile, __LINE__, ss.str());
         } catch (shttps::Error &err) {
-            throw SipiImageError(__file__, __LINE__, err.to_string());
+            throw SipiImageError(thisSourceFile, __LINE__, err.to_string());
         }
 
         return true;

--- a/src/formats/SipiIOJ2k.cpp
+++ b/src/formats/SipiIOJ2k.cpp
@@ -211,7 +211,7 @@ static bool is_jpx(const char *fname) {
 //=============================================================================
 
 
-bool SipiIOJ2k::read(SipiImage *img, std::string filepath, int pagenum, std::shared_ptr<SipiRegion> region,
+bool SipiIOJ2k::read(SipiImage *img, const std::string &filepath, int pagenum, std::shared_ptr<SipiRegion> region,
                      std::shared_ptr<SipiSize> size, bool force_bps_8,
                      ScalingQuality scaling_quality) {
   if (!is_jpx(filepath.c_str())) return false; // It's not a JPGE2000....
@@ -627,7 +627,7 @@ bool SipiIOJ2k::read(SipiImage *img, std::string filepath, int pagenum, std::sha
 //=============================================================================
 
 
-SipiImgInfo SipiIOJ2k::getDim(std::string filepath, int pagenum) {
+SipiImgInfo SipiIOJ2k::getDim(const std::string &filepath, int pagenum) {
   SipiImgInfo info;
   if (!is_jpx(filepath.c_str())) {
     info.success = SipiImgInfo::FAILURE;
@@ -666,10 +666,10 @@ SipiImgInfo SipiIOJ2k::getDim(std::string filepath, int pagenum) {
   siz_params *siz = codestream.access_siz();
   int tmp_height;
   siz->get(Ssize, 0, 0, tmp_height);
-  info.height = (size_t) tmp_height;
+  info.height = tmp_height;
   int tmp_width;
   siz->get(Ssize, 0, 1, tmp_width);
-  info.width = (size_t) tmp_width;
+  info.width = tmp_width;
   info.success = SipiImgInfo::DIMS;
 
   int __tnx, __tny;
@@ -747,7 +747,7 @@ static long get_bpp_dims(kdu_codestream &codestream) {
   return ((long) max_height) * ((long) max_width);
 }
 
-void SipiIOJ2k::write(SipiImage *img, std::string filepath, const SipiCompressionParams *params) {
+void SipiIOJ2k::write(SipiImage *img, const std::string &filepath, const SipiCompressionParams *params) {
   kdu_customize_warnings(&kdu_sipi_warn);
   kdu_customize_errors(&kdu_sipi_error);
 
@@ -1259,6 +1259,5 @@ void SipiIOJ2k::write(SipiImage *img, std::string filepath, const SipiCompressio
     throw SipiImageError(__file__, __LINE__, "Problem writing a JPEG2000 image!");
   }
 
-  return;
-}
+  }
 } // namespace Sipi

--- a/src/formats/SipiIOJpeg.cpp
+++ b/src/formats/SipiIOJpeg.cpp
@@ -118,7 +118,7 @@ namespace Sipi {
             int tmp_n = write(file_buffer->file_id, file_buffer->buffer + nn, n);
             if (tmp_n < 0) {
                 throw JpegError("Couldn't write to file!");
-                //throw SipiImageError(__file__, __LINE__, "Couldn't write to file!");
+                //throw SipiImageError(thisSourceFile, __LINE__, "Couldn't write to file!");
                 //return false; // and create an error message!!
             } else {
                 n -= tmp_n;

--- a/src/formats/SipiIOPdf.cpp
+++ b/src/formats/SipiIOPdf.cpp
@@ -52,7 +52,7 @@ static const char __file__[] = __FILE__;
 static const int DPI = 300; // TODO: submitted parameter...
 
 namespace Sipi {
-    bool SipiIOPdf::read(SipiImage *img, std::string filepath, int pagenum, std::shared_ptr<SipiRegion> region,
+    bool SipiIOPdf::read(SipiImage *img, const std::string &filepath, int pagenum, std::shared_ptr<SipiRegion> region,
               std::shared_ptr<SipiSize> size, bool force_bps_8,
               ScalingQuality scaling_quality) {
 
@@ -147,7 +147,7 @@ namespace Sipi {
         return true;
     };
 
-    SipiImgInfo SipiIOPdf::getDim(std::string filepath, int pagenum) {
+    SipiImgInfo SipiIOPdf::getDim(const std::string &filepath, int pagenum) {
         SipiImgInfo info;
 
         //
@@ -183,7 +183,7 @@ namespace Sipi {
         return info;
     };
 
-    void SipiIOPdf::write(SipiImage *img, std::string filepath, const SipiCompressionParams *params) {
+    void SipiIOPdf::write(SipiImage *img, const std::string &filepath, const SipiCompressionParams *params) {
         if (img->bps == 16) img->to8bps();
 
         //

--- a/src/formats/SipiIOPng.cpp
+++ b/src/formats/SipiIOPng.cpp
@@ -20,8 +20,8 @@
  * You should have received a copy of the GNU Affero General Public
  * License along with Sipi.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <assert.h>
-#include <stdlib.h>
+#include <cassert>
+#include <cstdlib>
 #include <arpa/inet.h>
 
 #include <string>
@@ -29,11 +29,11 @@
 #include <iostream>
 #include <fstream>
 #include <cstdio>
-#include <stdio.h>
-#include <math.h>
+#include <cstdio>
+#include <cmath>
 #include <syslog.h>
 
-#include <string.h>
+#include <cstring>
 
 #include "SipiIOPng.h"
 
@@ -74,7 +74,7 @@ namespace Sipi {
 
         inline ~PngTextPtr() { delete[] text_ptr; };
 
-        inline unsigned int num() { return num_text; };
+        inline unsigned int num() const { return num_text; };
 
         inline png_text *ptr() { return text_ptr; };
 
@@ -131,7 +131,7 @@ namespace Sipi {
         std::cerr << "PNG WARNING: " << warning_msg << std::endl;
     }
 
-    bool SipiIOPng::read(SipiImage *img, std::string filepath, int pagenum, std::shared_ptr<SipiRegion> region,
+    bool SipiIOPng::read(SipiImage *img, const std::string &filepath, int pagenum, std::shared_ptr<SipiRegion> region,
                          std::shared_ptr<SipiSize> size, bool force_bps_8,
                          ScalingQuality scaling_quality)
     {
@@ -294,7 +294,7 @@ namespace Sipi {
         }
 
         if (img->bps == 16) {
-            unsigned short *tmp = (unsigned short *) buffer;
+            auto *tmp = (unsigned short *) buffer;
             for (int i = 0; i < img->nx*img->ny*img->nc; i++) {
                 tmp[i] = ntohs(tmp[i]);
             }
@@ -338,7 +338,7 @@ namespace Sipi {
     /*==========================================================================*/
 
 
-    SipiImgInfo SipiIOPng::getDim(std::string filepath, int pagenum) {
+    SipiImgInfo SipiIOPng::getDim(const std::string &filepath, int pagenum) {
         FILE *infile;
         SipiImgInfo info;
         unsigned char header[8];
@@ -429,7 +429,7 @@ namespace Sipi {
 
     /*==========================================================================*/
 
-    void SipiIOPng::write(SipiImage *img, std::string filepath, const SipiCompressionParams *params) {
+    void SipiIOPng::write(SipiImage *img, const std::string &filepath, const SipiCompressionParams *params) {
         FILE *outfile = nullptr;
         png_structp png_ptr;
 
@@ -475,7 +475,7 @@ namespace Sipi {
             color_type = PNG_COLOR_TYPE_RGB_ALPHA;
         }
         else if (img->nc == 4) {
-            img->convertToIcc(icc_sRGB, 8);
+            img->convertToIcc(SipiIcc(Sipi::PredefinedProfiles::icc_sRGB), 8);
             color_type = PNG_COLOR_TYPE_RGB;
             img->nc = 3;
             img->bps = 8;
@@ -495,7 +495,7 @@ namespace Sipi {
         SipiEssentials es = img->essential_metadata();
         if ((img->icc != nullptr) || es.use_icc()) {
             if ((img->icc != nullptr) && (img->icc->getProfileType() == icc_LAB)) {
-                img->convertToIcc(Sipi::icc_sRGB, img->bps);
+                img->convertToIcc(SipiIcc(Sipi::PredefinedProfiles::icc_sRGB), img->bps);
             }
             std::vector<unsigned char> icc_buf;
             try {

--- a/src/formats/SipiIOTiff.cpp
+++ b/src/formats/SipiIOTiff.cpp
@@ -272,7 +272,7 @@ static ExifTag_type exiftag_list[] = {{EXIFTAG_EXPOSURETIME,             EXIF_DT
                                       {EXIFTAG_FLASH,                    EXIF_DT_UINT16,     0L,  {0l}},
                                       {EXIFTAG_FOCALLENGTH,              EXIF_DT_RATIONAL,   0L,  {0l}},
                                       {EXIFTAG_SUBJECTAREA,              EXIF_DT_UINT16_PTR, 0L,  {0L}}, //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! ARRAY OF SHORTS
-                                      {EXIFTAG_MAKERNOTE,                EXIF_DT_STRING,     0L,  {0L}},
+                                      {EXIFTAG_MAKERNOTE,                EXIF_DT_UNDEFINED,  0L,  {0L}},
                                       {EXIFTAG_USERCOMMENT,              EXIF_DT_PTR,        0L,  {0L}},
                                       {EXIFTAG_SUBSECTIME,               EXIF_DT_STRING,     0L,  {0L}},
                                       {EXIFTAG_SUBSECTIMEORIGINAL,       EXIF_DT_STRING,     0L,  {0L}},
@@ -1502,7 +1502,6 @@ namespace Sipi {
 
                 case EXIF_DT_STRING: {
                     std::string tmpstr;
-
                     if (img->exif->getValByKey(exiftag_list[i].tag_id, "Photo", tmpstr)) {
                         TIFFSetField(tif, exiftag_list[i].tag_id, tmpstr.c_str());
                         count++;
@@ -1534,14 +1533,7 @@ namespace Sipi {
 
                     if (img->exif->getValByKey(exiftag_list[i].tag_id, "Photo", vuc)) {
                         int len = vuc.size();
-                        uint8 *uc = new uint8[len];
-
-                        for (int i = 0; i < len; i++) {
-                            uc[i] = vuc[i];
-                        }
-
-                        TIFFSetField(tif, exiftag_list[i].tag_id, len, uc);
-                        delete[] uc;
+                        TIFFSetField(tif, exiftag_list[i].tag_id, len, vuc.data());
                         count++;
                     }
 
@@ -1552,14 +1544,7 @@ namespace Sipi {
                     std::vector<uint16> vus;
                     if (img->exif->getValByKey(exiftag_list[i].tag_id, "Photo", vus)) {
                         int len = vus.size();
-                        uint16 *us = new uint16[len];
-
-                        for (int i = 0; i < len; i++) {
-                            us[i] = vus[i];
-                        }
-
-                        TIFFSetField(tif, exiftag_list[i].tag_id, len, us);
-                        delete[] us;
+                        TIFFSetField(tif, exiftag_list[i].tag_id, len, vus.data());
                         count++;
                     }
                     break;
@@ -1570,14 +1555,7 @@ namespace Sipi {
 
                     if (img->exif->getValByKey(exiftag_list[i].tag_id, "Photo", vui)) {
                         int len = vui.size();
-                        uint32 *ui = new uint32[len];
-
-                        for (int i = 0; i < len; i++) {
-                            ui[i] = vui[i];
-                        }
-
-                        TIFFSetField(tif, exiftag_list[i].tag_id, len, ui);
-                        delete[] ui;
+                        TIFFSetField(tif, exiftag_list[i].tag_id, len, vui.data());
                         count++;
                     }
 
@@ -1589,14 +1567,7 @@ namespace Sipi {
 
                     if (img->exif->getValByKey(exiftag_list[i].tag_id, "Photo", vuc)) {
                         int len = vuc.size();
-                        unsigned char *uc = new unsigned char[len];
-
-                        for (int i = 0; i < len; i++) {
-                            uc[i] = vuc[i];
-                        }
-
-                        TIFFSetField(tif, exiftag_list[i].tag_id, len, uc);
-                        delete[] uc;
+                        TIFFSetField(tif, exiftag_list[i].tag_id, len, vuc.data());
                         count++;
                     }
 
@@ -1604,13 +1575,13 @@ namespace Sipi {
                 }
 
                 default: {
-                    // NO ACTION HERE At THE MOMENT...
+                    // NO ACTION HERE AT THE MOMENT...
                 }
             }
         }
 
         if (count > 0) {
-            uint64 exif_dir_offset = 0;
+            uint64 exif_dir_offset = 0L;
             TIFFWriteCustomDirectory(tif, &exif_dir_offset);
             TIFFSetDirectory(tif, 0);
             TIFFSetField(tif, TIFFTAG_EXIFIFD, exif_dir_offset);

--- a/src/formats/SipiIOTiff.cpp
+++ b/src/formats/SipiIOTiff.cpp
@@ -688,7 +688,7 @@ namespace Sipi {
                     primaries[5] = 0.0600;
                 }
 
-                unsigned short *tfunc= new unsigned short[3 * (1 << img->bps)], *tfunc_ti ;
+                unsigned short *tfunc = new unsigned short[3 * (1 << img->bps)], *tfunc_ti ;
                 unsigned int tfunc_len, tfunc_len_ti;
 
                 if (1 == TIFFGetField(tif, TIFFTAG_TRANSFERFUNCTION, &tfunc_len_ti, &tfunc_ti)) {
@@ -702,6 +702,7 @@ namespace Sipi {
                         tfunc_len = tfunc_len_ti / 3;
                     }
                 } else {
+                    delete[] tfunc;
                     tfunc = nullptr;
                     tfunc_len = 0;
                 }

--- a/src/formats/SipiIOTiff.cpp
+++ b/src/formats/SipiIOTiff.cpp
@@ -956,7 +956,7 @@ namespace Sipi {
                         break;
                     }
                     default: {
-                        throw Sipi::SipiImageError(__file__, __LINE__, "Unsupported bits/sample (" + std::to_string(bps) + ")!");
+                        throw Sipi::SipiImageError(thisSourceFile, __LINE__, "Unsupported bits/sample (" + std::to_string(bps) + ")!");
                     }
                 }
             }
@@ -972,7 +972,7 @@ namespace Sipi {
                         break;
                     }
                     default: {
-                        throw Sipi::SipiImageError(__file__, __LINE__, "Unsupported bits/sample (" + std::to_string(bps) + ")!");
+                        throw Sipi::SipiImageError(thisSourceFile, __LINE__, "Unsupported bits/sample (" + std::to_string(bps) + ")!");
                     }
                 }
             }

--- a/src/metadata/SipiIcc.cpp
+++ b/src/metadata/SipiIcc.cpp
@@ -380,7 +380,7 @@ namespace Sipi {
         cmsGetProfileInfoASCII(rhs.icc_profile, cmsInfoCopyright, cmsNoLanguage, cmsNoCountry, buf.get(), len);
         outstr << "ICC-Copyright     : " << buf.get() << std::endl;
 
-        struct tm datetime;
+        struct tm datetime{};
         if (cmsGetHeaderCreationDateTime(rhs.icc_profile, &datetime)) {
             outstr << "ICC-Date          : " << asctime(&datetime);
         }

--- a/src/metadata/SipiXmp.cpp
+++ b/src/metadata/SipiXmp.cpp
@@ -62,11 +62,11 @@ namespace Sipi {
         try {
             if (Exiv2::XmpParser::decode(xmpData, xmp) != 0) {
                 Exiv2::XmpParser::terminate();
-                throw SipiError(__file__, __LINE__, "Could not parse XMP!");
+                throw SipiError(thisSourceFile, __LINE__, "Could not parse XMP!");
             }
         }
         catch(Exiv2::BasicError<char> &err) {
-            throw SipiError(__file__, __LINE__, err.what());
+            throw SipiError(thisSourceFile, __LINE__, err.what());
         }
          */
     }
@@ -80,11 +80,11 @@ namespace Sipi {
         try {
             if (Exiv2::XmpParser::decode(xmpData, xmp) != 0) {
                 Exiv2::XmpParser::terminate();
-                throw SipiError(__file__, __LINE__, "Could not parse XMP!");
+                throw SipiError(thisSourceFile, __LINE__, "Could not parse XMP!");
             }
         }
         catch(Exiv2::BasicError<char> &err) {
-            throw SipiError(__file__, __LINE__, err.what());
+            throw SipiError(thisSourceFile, __LINE__, err.what());
         }
          */
     }
@@ -99,11 +99,11 @@ namespace Sipi {
         try {
             if (Exiv2::XmpParser::decode(xmpData, buf) != 0) {
                 Exiv2::XmpParser::terminate();
-                throw SipiError(__file__, __LINE__, "Could not parse XMP!");
+                throw SipiError(thisSourceFile, __LINE__, "Could not parse XMP!");
             }
         }
         catch(Exiv2::BasicError<char> &err) {
-            throw SipiError(__file__, __LINE__, err.what());
+            throw SipiError(thisSourceFile, __LINE__, err.what());
         }
          */
     }
@@ -128,11 +128,11 @@ namespace Sipi {
         std::string xmpPacket;
         try {
             if (0 != Exiv2::XmpParser::encode(xmpPacket, xmpData, Exiv2::XmpParser::useCompactFormat)) {
-                throw SipiError(__file__, __LINE__, "Failed to serialize XMP data!");
+                throw SipiError(thisSourceFile, __LINE__, "Failed to serialize XMP data!");
             }
         }
         catch(Exiv2::BasicError<char> &err) {
-            throw SipiError(__file__, __LINE__, err.what());
+            throw SipiError(thisSourceFile, __LINE__, err.what());
         }
         Exiv2::XmpParser::terminate();
 

--- a/src/sipi.cpp
+++ b/src/sipi.cpp
@@ -800,7 +800,7 @@ int main(int argc, char *argv[]) {
       //img.read(optInFile); //convert to bps=8 in case of JPG output
       if (format == "jpg") {
         img.to8bps();
-        img.convertToIcc(Sipi::icc_sRGB, 8);
+        img.convertToIcc(Sipi::SipiIcc(Sipi::PredefinedProfiles::icc_sRGB), 8);
       }
     } catch (Sipi::SipiImageError &err) {
       std::cerr << err << std::endl;
@@ -822,11 +822,11 @@ int main(int argc, char *argv[]) {
     if (!sipiopt.get_option("--icc")->empty()) {
       Sipi::SipiIcc icc;
       switch (optIcc) {
-        case OptIcc::sRGB: icc = Sipi::SipiIcc(Sipi::icc_sRGB);
+          case OptIcc::sRGB: icc = Sipi::SipiIcc(Sipi::PredefinedProfiles::icc_sRGB);
           break;
-        case OptIcc::AdobeRGB: icc = Sipi::SipiIcc(Sipi::icc_AdobeRGB);
+        case OptIcc::AdobeRGB: icc = Sipi::SipiIcc(Sipi::PredefinedProfiles::icc_AdobeRGB);
           break;
-        case OptIcc::GRAY: icc = Sipi::SipiIcc(Sipi::icc_GRAY_D50);
+        case OptIcc::GRAY: icc = Sipi::SipiIcc(Sipi::PredefinedProfiles::icc_GRAY_D50);
           break;
         case OptIcc::none: break;
       }


### PR DESCRIPTION
Running `sipi` (compiled with the `debug` flag) with Valgrind and uploading a few images yield the following output:

```
==1== Memcheck, a memory error detector
==1== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==1== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==1== Command: /sipi/sipi --config=/sipi/config/sipi.knora-docker-config.lua
==1== 
Sipi: BUILD_TIMESTAMP: 2021-12-10 17:36
Sipi: BUILD_SCM_TAG: v3.3.1-4-g3df4eb9
Sipi: BUILD_SCM_REVISION: 3df4eb9f80162ee3968ba03eaae33cda028b4fcd
Sipi: Cache at "/sipi/cache" cachesize=104857600 nfiles=0 hysteresis=0.100000
Sipi: Starting SipiHttpServer::run()
Sipi: Sipi server starting
Sipi: Serving images from /sipi/images
Sipi: In Server::run
Sipi: Starting shttps server with 16 threads
Sipi: Creating thread pool....
Sipi: Added route /upload with script /sipi/scripts/upload.lua
Sipi: Added route /store with script /sipi/scripts/store.lua
Sipi: Added route /delete_temp_file with script /sipi/scripts/delete_temp_file.lua
Sipi: Added route /test_functions with script /sipi/scripts/test_functions.lua
Sipi: Added route /test_file_info with script /sipi/scripts/test_file_info.lua
Sipi: Added route /test_knora_session_cookie with script /sipi/scripts/test_knora_session_cookie.lua
Sipi: Server listening on HTTP port 1024
Ivan was here
BUILD_TIMESTAMP: 2021-12-10 17:36
BUILD_TIMESTAMP: 2021-12-10 17:36
BUILD_SCM_TAG: v3.3.1-4-g3df4eb9
BUILD_SCM_REVISION: 3df4eb9f80162ee3968ba03eaae33cda028b4fcd
Sipi: Accepted connection from 172.22.0.1
==1== Conditional jump or move depends on uninitialised value(s)
==1==    at 0x5E53A6: shttps::Server::run() (shttps/Server.cpp:1023)
==1==    by 0x541556: Sipi::SipiHttpServer::run() (src/SipiHttpServer.cpp:1800)
==1==    by 0x4759A5: main (src/sipi.cpp:1267)
==1== 
Sipi: Accepted connection from 172.22.0.1
==1== Syscall param socketcall.sendto(msg) points to uninitialised byte(s)
==1==    at 0x489377C: __libc_send (send.c:28)
==1==    by 0x489377C: send (send.c:23)
==1==    by 0x5D9A84: shttps::SocketControl::send_control_message(int, shttps::SocketControl::SocketInfo const&) (shttps/SocketControl.cpp:124)
==1==    by 0x5E5AA2: shttps::Server::run() (shttps/Server.cpp:1158)
==1==    by 0x541556: Sipi::SipiHttpServer::run() (src/SipiHttpServer.cpp:1800)
==1==    by 0x4759A5: main (src/sipi.cpp:1267)
==1==  Address 0x1ffeff9a8c is on thread 1's stack
==1==  in frame #2, created by shttps::Server::run() (shttps/Server.cpp:944)
==1== 
Sipi: Socket connection: timeout or socket closed from main
Sipi: upload.lua: wrote image file to /sipi/images/tmp/BJcWQHE0f1t-D9gFYbrRsQa.jp2
...
Sipi: upload.lua: wrote image file to /sipi/images/tmp/Dc1pT0HOV71-AzloQSqGlL2.jp2
==1== Conditional jump or move depends on uninitialised value(s)
==1==    at 0x5E53C5: shttps::Server::run() (shttps/Server.cpp:1024)
==1==    by 0x541556: Sipi::SipiHttpServer::run() (src/SipiHttpServer.cpp:1800)
==1==    by 0x4759A5: main (src/sipi.cpp:1267)
==1== 
==1== Conditional jump or move depends on uninitialised value(s)
==1==    at 0x5E53E4: shttps::Server::run() (shttps/Server.cpp:1024)
==1==    by 0x541556: Sipi::SipiHttpServer::run() (src/SipiHttpServer.cpp:1800)
==1==    by 0x4759A5: main (src/sipi.cpp:1267)
==1== 
Sipi: upload.lua: wrote image file to /sipi/images/tmp/9AdnTT89FIO-CevwuPlCRZ8.jp2
...
Sipi: upload.lua: wrote image file to /sipi/images/tmp/BsDnf0zCqIM-BthrDvzwJdS.jp2
==1== Conditional jump or move depends on uninitialised value(s)
==1==    at 0x5E5B35: shttps::Server::run() (shttps/Server.cpp:1166)
==1==    by 0x541556: Sipi::SipiHttpServer::run() (src/SipiHttpServer.cpp:1800)
==1==    by 0x4759A5: main (src/sipi.cpp:1267)
==1== 
==1== Conditional jump or move depends on uninitialised value(s)
==1==    at 0x5E5E31: shttps::Server::run() (shttps/Server.cpp:1210)
==1==    by 0x541556: Sipi::SipiHttpServer::run() (src/SipiHttpServer.cpp:1800)
==1==    by 0x4759A5: main (src/sipi.cpp:1267)
==1== 
==1== Conditional jump or move depends on uninitialised value(s)
==1==    at 0x5E5E6B: shttps::Server::run() (shttps/Server.cpp:1213)
==1==    by 0x541556: Sipi::SipiHttpServer::run() (src/SipiHttpServer.cpp:1800)
==1==    by 0x4759A5: main (src/sipi.cpp:1267)
==1== 
==1== Conditional jump or move depends on uninitialised value(s)
==1==    at 0x5E5EA5: shttps::Server::run() (shttps/Server.cpp:1216)
==1==    by 0x541556: Sipi::SipiHttpServer::run() (src/SipiHttpServer.cpp:1800)
==1==    by 0x4759A5: main (src/sipi.cpp:1267)
==1== 
==1== Conditional jump or move depends on uninitialised value(s)
==1==    at 0x5E5EDF: shttps::Server::run() (shttps/Server.cpp:1219)
==1==    by 0x541556: Sipi::SipiHttpServer::run() (src/SipiHttpServer.cpp:1800)
==1==    by 0x4759A5: main (src/sipi.cpp:1267)
==1== 
==1== Conditional jump or move depends on uninitialised value(s)
==1==    at 0x5E5F19: shttps::Server::run() (shttps/Server.cpp:1222)
==1==    by 0x541556: Sipi::SipiHttpServer::run() (src/SipiHttpServer.cpp:1800)
==1==    by 0x4759A5: main (src/sipi.cpp:1267)
==1== 
==1== Conditional jump or move depends on uninitialised value(s)
==1==    at 0x5E5F53: shttps::Server::run() (shttps/Server.cpp:1225)
==1==    by 0x541556: Sipi::SipiHttpServer::run() (src/SipiHttpServer.cpp:1800)
==1==    by 0x4759A5: main (src/sipi.cpp:1267)
==1== 
==1== Conditional jump or move depends on uninitialised value(s)
==1==    at 0x5E5F90: shttps::Server::run() (shttps/Server.cpp:1228)
==1==    by 0x541556: Sipi::SipiHttpServer::run() (src/SipiHttpServer.cpp:1800)
==1==    by 0x4759A5: main (src/sipi.cpp:1267)
==1== 
==1== Conditional jump or move depends on uninitialised value(s)
==1==    at 0x5E5FCA: shttps::Server::run() (shttps/Server.cpp:1231)
==1==    by 0x541556: Sipi::SipiHttpServer::run() (src/SipiHttpServer.cpp:1800)
==1==    by 0x4759A5: main (src/sipi.cpp:1267)
==1== 
==1== Conditional jump or move depends on uninitialised value(s)
==1==    at 0x5E6007: shttps::Server::run() (shttps/Server.cpp:1234)
==1==    by 0x541556: Sipi::SipiHttpServer::run() (src/SipiHttpServer.cpp:1800)
==1==    by 0x4759A5: main (src/sipi.cpp:1267)
==1== 
==1== Conditional jump or move depends on uninitialised value(s)
==1==    at 0x5E6044: shttps::Server::run() (shttps/Server.cpp:1237)
==1==    by 0x541556: Sipi::SipiHttpServer::run() (src/SipiHttpServer.cpp:1800)
==1==    by 0x4759A5: main (src/sipi.cpp:1267)
==1== 
Sipi: upload.lua: wrote image file to /sipi/images/tmp/4OBV5F7t5ma-EFy3D0z9JbT.jp2
Sipi: upload.lua: wrote image file to /sipi/images/tmp/HX36n8ScRCI-F3dMWLOlQND.jp2
Sipi: upload.lua: wrote image file to /sipi/images/tmp/58urrdjIcbF-C40uycBKRVO.jp2
Sipi: -->POLLNVAL
Sipi: -->POLLOUT
Sipi: -->POLLRDNORM
Sipi: -->POLLWRBAND
Sipi: -->POLLWRNORM
Sipi: upload.lua: wrote image file to /sipi/images/tmp/1i8vuhjdWnD-E8EKSVLYNTd.jp2
...
Sipi: upload.lua: wrote image file to /sipi/images/tmp/HrAS0dTSP5W-D52Q8Ul2AbM.jp2
Sipi: Accepted connection from 172.22.0.1
Sipi: Socket connection: timeout or socket closed from main
Sipi: Accepted connection from 172.22.0.1
Sipi: upload.lua: wrote image file to /sipi/images/tmp/FuTrwQskxBT-BbyOs2IJWPG.jp2
Sipi: upload.lua: wrote image file to /sipi/images/tmp/7hzkNdjECZp-DG19b4T8PTQ.jp2
Sipi: Accepted connection from 172.22.0.1
Sipi: Accepted connection from 172.22.0.1
Sipi: upload.lua: wrote image file to /sipi/images/tmp/Fag0y3dXDt1-BmBwvUP1JwM.jp2
...
Sipi: upload.lua: wrote image file to /sipi/images/tmp/LM5vksDuelt-CGexSfVH4Oi.jp2
Sipi: -->POLLWRNORM
Sipi: upload.lua: wrote image file to /sipi/images/tmp/CBB1iu1EwUx-CtSMs8bVf1S.jp2
...
Sipi: upload.lua: wrote image file to /sipi/images/tmp/HDGOTQRnFTp-EKMZkG70UCr.jp2
==1== Thread 2:
==1== Syscall param socketcall.sendto(msg) points to uninitialised byte(s)
==1==    at 0x489377C: __libc_send (send.c:28)
==1==    by 0x489377C: send (send.c:23)
==1==    by 0x5D9A84: shttps::SocketControl::send_control_message(int, shttps::SocketControl::SocketInfo const&) (shttps/SocketControl.cpp:124)
==1==    by 0x58D15D: shttps::Server::stop() (shttps/Server.h:506)
==1==    by 0x5E61D3: shttps::sig_thread(void*) (shttps/Server.cpp:107)
==1==    by 0x4888608: start_thread (pthread_create.c:477)
==1==    by 0x50BD292: clone (clone.S:95)
==1==  Address 0x5de9de4 is on thread 2's stack
==1==  in frame #2, created by shttps::Server::stop() (shttps/Server.h:502)
==1== 
DBG> 508 Sent stop message to stoppipe[1]=38
```

It seems that this is not connected to upload. Calling `knora.json` or `info.json` on a previously uploaded image results in the following valgrind output:

```
==1== Memcheck, a memory error detector
==1== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==1== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==1== Command: /sipi/sipi --config=/sipi/config/sipi.knora-docker-config.lua
==1== 
Ivan was here
BUILD_TIMESTAMP: 2021-12-10 17:36
BUILD_TIMESTAMP: 2021-12-10 17:36
BUILD_SCM_TAG: v3.3.1-4-g3df4eb9
BUILD_SCM_REVISION: 3df4eb9f80162ee3968ba03eaae33cda028b4fcd
Sipi: BUILD_TIMESTAMP: 2021-12-10 17:36
Sipi: BUILD_SCM_TAG: v3.3.1-4-g3df4eb9
Sipi: BUILD_SCM_REVISION: 3df4eb9f80162ee3968ba03eaae33cda028b4fcd
Sipi: Cache at "/sipi/cache" cachesize=104857600 nfiles=0 hysteresis=0.100000
Sipi: Starting SipiHttpServer::run()
Sipi: Sipi server starting
Sipi: Serving images from /sipi/images
Sipi: In Server::run
Sipi: Starting shttps server with 16 threads
Sipi: Creating thread pool....
Sipi: Added route /upload with script /sipi/scripts/upload.lua
Sipi: Added route /store with script /sipi/scripts/store.lua
Sipi: Added route /delete_temp_file with script /sipi/scripts/delete_temp_file.lua
Sipi: Added route /test_functions with script /sipi/scripts/test_functions.lua
Sipi: Added route /test_file_info with script /sipi/scripts/test_file_info.lua
Sipi: Added route /test_knora_session_cookie with script /sipi/scripts/test_knora_session_cookie.lua
Sipi: Server listening on HTTP port 1024
Sipi: Accepted connection from 172.22.0.1
==1== Conditional jump or move depends on uninitialised value(s)
==1==    at 0x5E53A6: shttps::Server::run() (shttps/Server.cpp:1023)
==1==    by 0x541556: Sipi::SipiHttpServer::run() (src/SipiHttpServer.cpp:1800)
==1==    by 0x4759A5: main (src/sipi.cpp:1267)
==1== 
Sipi: Accepted connection from 172.22.0.1
==1== Syscall param socketcall.sendto(msg) points to uninitialised byte(s)
==1==    at 0x489377C: __libc_send (send.c:28)
==1==    by 0x489377C: send (send.c:23)
==1==    by 0x5D9A84: shttps::SocketControl::send_control_message(int, shttps::SocketControl::SocketInfo const&) (shttps/SocketControl.cpp:124)
==1==    by 0x5E5AA2: shttps::Server::run() (shttps/Server.cpp:1158)
==1==    by 0x541556: Sipi::SipiHttpServer::run() (src/SipiHttpServer.cpp:1800)
==1==    by 0x4759A5: main (src/sipi.cpp:1267)
==1==  Address 0x1ffeff9a8c is on thread 1's stack
==1==  in frame #2, created by shttps::Server::run() (shttps/Server.cpp:944)
==1== 
Sipi: Socket connection: timeout or socket closed from main
Sipi: upload.lua: wrote image file to /sipi/images/tmp/Eod3yXeDInC-BivTleswEGp.jp2
Sipi: pre_flight called in sipi.init-knora.lua
Sipi: pre_flight called in sipi.init-knora.lua
Sipi: pre_flight called in sipi.init-knora.lua
Sipi: pre_flight called in sipi.init-knora.lua
Sipi: pre_flight called in sipi.init-knora.lua
Sipi: pre_flight called in sipi.init-knora.lua
Sipi: pre_flight called in sipi.init-knora.lua
Sipi: pre_flight called in sipi.init-knora.lua
Sipi: pre_flight called in sipi.init-knora.lua
Sipi: pre_flight called in sipi.init-knora.lua
Sipi: pre_flight called in sipi.init-knora.lua
Sipi: pre_flight called in sipi.init-knora.lua
Sipi: pre_flight called in sipi.init-knora.lua
Sipi: pre_flight called in sipi.init-knora.lua
Sipi: pre_flight called in sipi.init-knora.lua
Sipi: pre_flight called in sipi.init-knora.lua
Sipi: pre_flight called in sipi.init-knora.lua
==1== Thread 5:
==1== Conditional jump or move depends on uninitialised value(s)
==1==    at 0x5A6EDD: Sipi::SipiSize::get_size(unsigned long, unsigned long, unsigned long&, unsigned long&, int&, bool&) (src/iiifparser/SipiSize.cpp:187)
==1==    by 0x5500B7: Sipi::iiif_send_info(shttps::Connection&, Sipi::SipiHttpServer*, shttps::LuaServer&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&, bool) (src/SipiHttpServer.cpp:551)
==1==    by 0x544D05: Sipi::process_get_request(shttps::Connection&, shttps::LuaServer&, void*, void*) (src/SipiHttpServer.cpp:1216)
==1==    by 0x5E6E2D: shttps::Server::processRequest(std::istream*, std::ostream*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int, bool, int&, bool) (shttps/Server.cpp:1310)
==1==    by 0x5E650E: shttps::process_request(void*) (shttps/Server.cpp:799)
==1==    by 0x4888608: start_thread (pthread_create.c:477)
==1==    by 0x50BD292: clone (clone.S:95)
==1== 
==1== Conditional jump or move depends on uninitialised value(s)
==1==    at 0x5A81C4: Sipi::SipiSize::get_size(unsigned long, unsigned long, unsigned long&, unsigned long&, int&, bool&) (src/iiifparser/SipiSize.cpp:374)
==1==    by 0x5500B7: Sipi::iiif_send_info(shttps::Connection&, Sipi::SipiHttpServer*, shttps::LuaServer&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&, bool) (src/SipiHttpServer.cpp:551)
==1==    by 0x544D05: Sipi::process_get_request(shttps::Connection&, shttps::LuaServer&, void*, void*) (src/SipiHttpServer.cpp:1216)
==1==    by 0x5E6E2D: shttps::Server::processRequest(std::istream*, std::ostream*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int, bool, int&, bool) (shttps/Server.cpp:1310)
==1==    by 0x5E650E: shttps::process_request(void*) (shttps/Server.cpp:799)
==1==    by 0x4888608: start_thread (pthread_create.c:477)
==1==    by 0x50BD292: clone (clone.S:95)
==1== 
==1== Conditional jump or move depends on uninitialised value(s)
==1==    at 0x5A8773: Sipi::SipiSize::get_size(unsigned long, unsigned long, unsigned long&, unsigned long&, int&, bool&) (src/iiifparser/SipiSize.cpp:429)
==1==    by 0x5500B7: Sipi::iiif_send_info(shttps::Connection&, Sipi::SipiHttpServer*, shttps::LuaServer&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&, bool) (src/SipiHttpServer.cpp:551)
==1==    by 0x544D05: Sipi::process_get_request(shttps::Connection&, shttps::LuaServer&, void*, void*) (src/SipiHttpServer.cpp:1216)
==1==    by 0x5E6E2D: shttps::Server::processRequest(std::istream*, std::ostream*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int, bool, int&, bool) (shttps/Server.cpp:1310)
==1==    by 0x5E650E: shttps::process_request(void*) (shttps/Server.cpp:799)
==1==    by 0x4888608: start_thread (pthread_create.c:477)
==1==    by 0x50BD292: clone (clone.S:95)
==1== 
==1== Conditional jump or move depends on uninitialised value(s)
==1==    at 0x4EC1402: std::ostreambuf_iterator<char, std::char_traits<char> > std::num_put<char, std::ostreambuf_iterator<char, std::char_traits<char> > >::_M_insert_int<long>(std::ostreambuf_iterator<char, std::char_traits<char> >, std::ios_base&, char, long) const (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28)
==1==    by 0x4ECFD5E: std::ostream& std::ostream::_M_insert<long>(long) (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28)
==1==    by 0x5A88BA: Sipi::SipiSize::get_size(unsigned long, unsigned long, unsigned long&, unsigned long&, int&, bool&) (src/iiifparser/SipiSize.cpp:433)
==1==    by 0x5500B7: Sipi::iiif_send_info(shttps::Connection&, Sipi::SipiHttpServer*, shttps::LuaServer&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&, bool) (src/SipiHttpServer.cpp:551)
==1==    by 0x544D05: Sipi::process_get_request(shttps::Connection&, shttps::LuaServer&, void*, void*) (src/SipiHttpServer.cpp:1216)
==1==    by 0x5E6E2D: shttps::Server::processRequest(std::istream*, std::ostream*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int, bool, int&, bool) (shttps/Server.cpp:1310)
==1==    by 0x5E650E: shttps::process_request(void*) (shttps/Server.cpp:799)
==1==    by 0x4888608: start_thread (pthread_create.c:477)
==1==    by 0x50BD292: clone (clone.S:95)
==1== 
==1== Use of uninitialised value of size 8
==1==    at 0x4EC110B: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28)
==1==    by 0x4EC142C: std::ostreambuf_iterator<char, std::char_traits<char> > std::num_put<char, std::ostreambuf_iterator<char, std::char_traits<char> > >::_M_insert_int<long>(std::ostreambuf_iterator<char, std::char_traits<char> >, std::ios_base&, char, long) const (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28)
==1==    by 0x4ECFD5E: std::ostream& std::ostream::_M_insert<long>(long) (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28)
==1==    by 0x5A88BA: Sipi::SipiSize::get_size(unsigned long, unsigned long, unsigned long&, unsigned long&, int&, bool&) (src/iiifparser/SipiSize.cpp:433)
==1==    by 0x5500B7: Sipi::iiif_send_info(shttps::Connection&, Sipi::SipiHttpServer*, shttps::LuaServer&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&, bool) (src/SipiHttpServer.cpp:551)
==1==    by 0x544D05: Sipi::process_get_request(shttps::Connection&, shttps::LuaServer&, void*, void*) (src/SipiHttpServer.cpp:1216)
==1==    by 0x5E6E2D: shttps::Server::processRequest(std::istream*, std::ostream*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int, bool, int&, bool) (shttps/Server.cpp:1310)
==1==    by 0x5E650E: shttps::process_request(void*) (shttps/Server.cpp:799)
==1==    by 0x4888608: start_thread (pthread_create.c:477)
==1==    by 0x50BD292: clone (clone.S:95)
==1== 
==1== Conditional jump or move depends on uninitialised value(s)
==1==    at 0x4EC111D: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28)
==1==    by 0x4EC142C: std::ostreambuf_iterator<char, std::char_traits<char> > std::num_put<char, std::ostreambuf_iterator<char, std::char_traits<char> > >::_M_insert_int<long>(std::ostreambuf_iterator<char, std::char_traits<char> >, std::ios_base&, char, long) const (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28)
==1==    by 0x4ECFD5E: std::ostream& std::ostream::_M_insert<long>(long) (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28)
==1==    by 0x5A88BA: Sipi::SipiSize::get_size(unsigned long, unsigned long, unsigned long&, unsigned long&, int&, bool&) (src/iiifparser/SipiSize.cpp:433)
==1==    by 0x5500B7: Sipi::iiif_send_info(shttps::Connection&, Sipi::SipiHttpServer*, shttps::LuaServer&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&, bool) (src/SipiHttpServer.cpp:551)
==1==    by 0x544D05: Sipi::process_get_request(shttps::Connection&, shttps::LuaServer&, void*, void*) (src/SipiHttpServer.cpp:1216)
==1==    by 0x5E6E2D: shttps::Server::processRequest(std::istream*, std::ostream*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int, bool, int&, bool) (shttps/Server.cpp:1310)
==1==    by 0x5E650E: shttps::process_request(void*) (shttps/Server.cpp:799)
==1==    by 0x4888608: start_thread (pthread_create.c:477)
==1==    by 0x50BD292: clone (clone.S:95)
==1== 
==1== Conditional jump or move depends on uninitialised value(s)
==1==    at 0x4EC1462: std::ostreambuf_iterator<char, std::char_traits<char> > std::num_put<char, std::ostreambuf_iterator<char, std::char_traits<char> > >::_M_insert_int<long>(std::ostreambuf_iterator<char, std::char_traits<char> >, std::ios_base&, char, long) const (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28)
==1==    by 0x4ECFD5E: std::ostream& std::ostream::_M_insert<long>(long) (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28)
==1==    by 0x5A88BA: Sipi::SipiSize::get_size(unsigned long, unsigned long, unsigned long&, unsigned long&, int&, bool&) (src/iiifparser/SipiSize.cpp:433)
==1==    by 0x5500B7: Sipi::iiif_send_info(shttps::Connection&, Sipi::SipiHttpServer*, shttps::LuaServer&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&, bool) (src/SipiHttpServer.cpp:551)
==1==    by 0x544D05: Sipi::process_get_request(shttps::Connection&, shttps::LuaServer&, void*, void*) (src/SipiHttpServer.cpp:1216)
==1==    by 0x5E6E2D: shttps::Server::processRequest(std::istream*, std::ostream*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int, bool, int&, bool) (shttps/Server.cpp:1310)
==1==    by 0x5E650E: shttps::process_request(void*) (shttps/Server.cpp:799)
==1==    by 0x4888608: start_thread (pthread_create.c:477)
==1==    by 0x50BD292: clone (clone.S:95)
==1== 
Sipi: pre_flight called in sipi.init-knora.lua
==1== Thread 2:
==1== Syscall param socketcall.sendto(msg) points to uninitialised byte(s)
==1==    at 0x489377C: __libc_send (send.c:28)
==1==    by 0x489377C: send (send.c:23)
==1==    by 0x5D9A84: shttps::SocketControl::send_control_message(int, shttps::SocketControl::SocketInfo const&) (shttps/SocketControl.cpp:124)
==1==    by 0x58D15D: shttps::Server::stop() (shttps/Server.h:506)
==1==    by 0x5E61D3: shttps::sig_thread(void*) (shttps/Server.cpp:107)
==1==    by 0x4888608: start_thread (pthread_create.c:477)
==1==    by 0x50BD292: clone (clone.S:95)
==1==  Address 0x5de9de4 is on thread 2's stack
==1==  in frame #2, created by shttps::Server::stop() (shttps/Server.h:502)
==1== 
DBG> 508 Sent stop message to stoppipe[1]=38
```