### PR TITLE
fix: crashing on jp2 decompression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,7 +375,7 @@ add_executable(sipi
         src/metadata/SipiIptc.cpp include/metadata/SipiIptc.h
         src/metadata/SipiExif.cpp include/metadata/SipiExif.h
         src/metadata/SipiEssentials.cpp include/metadata/SipiEssentials.h
-        src/SipiImage.cpp include/SipiImage.h
+        src/SipiImage.cpp include/SipiImage.h include/SipiImageError.h
         src/formats/SipiIOTiff.cpp include/formats/SipiIOTiff.h
         src/formats/SipiIOJ2k.cpp include/formats/SipiIOJ2k.h
         src/formats/SipiIOJpeg.cpp include/formats/SipiIOJpeg.h
@@ -403,7 +403,8 @@ add_executable(sipi
         shttps/jwt.c shttps/jwt.h
         shttps/makeunique.h
         src/SipiFilenameHash.cpp include/SipiFilenameHash.h
-        include/iiifparser/SipiIdentifier.h src/iiifparser/SipiIdentifier.cpp )
+        include/iiifparser/SipiIdentifier.h src/iiifparser/SipiIdentifier.cpp
+        include/SipiImageError.h)
 
 add_dependencies(sipi
         icc_profiles)

--- a/ext/tiff/CMakeLists.txt
+++ b/ext/tiff/CMakeLists.txt
@@ -28,11 +28,11 @@ ExternalProject_Add(project_tiff
         DEPENDS zstd
         INSTALL_DIR ${COMMON_LOCAL}
         TEST_BEFORE_INSTALL 1
-        URL http://download.osgeo.org/libtiff/tiff-4.1.0.tar.gz
+        URL https://download.osgeo.org/libtiff/tiff-4.1.0.tar.gz
         DOWNLOAD_DIR ${COMMON_SRCS}/downloads
         ${timestamp_policy}
-        SOURCE_DIR ${COMMON_SRCS}/libtiff-4.1.0
-        PATCH_COMMAND patch ${COMMON_SRCS}/libtiff-4.1.0/libtiff/tif_dirinfo.c < ${COMMON_PATCHES}/tiff-4.0.4.patch
+        SOURCE_DIR ${COMMON_SRCS}/libtiff
+        PATCH_COMMAND patch ${COMMON_SRCS}/libtiff/libtiff/tif_dirinfo.c < ${COMMON_PATCHES}/tiff-4.0.4.patch
         CMAKE_ARGS  ${CMAKE_CREATE_SHARED}
                     -DCMAKE_C_STANDARD_LIBRARIES="-lpthread"
                     -DCMAKE_PREFIX_PATH=${COMMON_LOCAL}

--- a/ext/tiff/CMakeLists.txt
+++ b/ext/tiff/CMakeLists.txt
@@ -20,6 +20,7 @@ else()
     unset(timestamp_policy)
 endif()
 
+set(LibTiffVersion "4.1.0")
 
 ExternalProject_Add(project_tiff
         DEPENDS jpeg
@@ -28,11 +29,11 @@ ExternalProject_Add(project_tiff
         DEPENDS zstd
         INSTALL_DIR ${COMMON_LOCAL}
         TEST_BEFORE_INSTALL 1
-        URL https://download.osgeo.org/libtiff/tiff-4.1.0.tar.gz
+        URL https://download.osgeo.org/libtiff/tiff-${LibTiffVersion}.tar.gz
         DOWNLOAD_DIR ${COMMON_SRCS}/downloads
         ${timestamp_policy}
-        SOURCE_DIR ${COMMON_SRCS}/libtiff
-        PATCH_COMMAND patch ${COMMON_SRCS}/libtiff/libtiff/tif_dirinfo.c < ${COMMON_PATCHES}/tiff-4.0.4.patch
+        SOURCE_DIR ${COMMON_SRCS}/libtiff-${LibTiffVersion}
+        PATCH_COMMAND patch ${COMMON_SRCS}/libtiff-${LibTiffVersion}/libtiff/tif_dirinfo.c < ${COMMON_PATCHES}/tiff-4.0.4.patch
         CMAKE_ARGS  ${CMAKE_CREATE_SHARED}
                     -DCMAKE_C_STANDARD_LIBRARIES="-lpthread"
                     -DCMAKE_PREFIX_PATH=${COMMON_LOCAL}
@@ -42,7 +43,7 @@ ExternalProject_Add(project_tiff
                     -DWEBP_INCLUDE_DIR=${CONFIGURE_INCDIR}
         INSTALL_COMMAND make test
         COMMAND make install
-        COMMAND ${CMAKE_COMMAND} -E copy ${COMMON_SRCS}/libtiff-4.1.0/libtiff/tif_dir.h ${COMMON_LOCAL}/include/
+        COMMAND ${CMAKE_COMMAND} -E copy ${COMMON_SRCS}/libtiff-${LibTiffVersion}/libtiff/tif_dir.h ${COMMON_LOCAL}/include/
         BUILD_IN_SOURCE 1
 )
 ExternalProject_Get_Property(project_tiff install_dir)

--- a/include/SipiImageError.h
+++ b/include/SipiImageError.h
@@ -1,0 +1,8 @@
+//
+// Created by Ivan Subotic on 26.01.2024.
+//
+
+#ifndef SIPIIMAGEERROR_H
+#define SIPIIMAGEERROR_H
+
+#endif //SIPIIMAGEERROR_H

--- a/src/SipiImage.cpp
+++ b/src/SipiImage.cpp
@@ -54,16 +54,6 @@ namespace Sipi {
                                                                                {"jpg", std::make_shared<SipiIOJpeg>()},
                                                                                {"png", std::make_shared<SipiIOPng>()}};
 
-    /* ToDo: remove if everything is OK
-    std::unordered_map<std::string, std::string> SipiImage::mimetypes = {{"jpx",  "image/jp2"},
-                                                                         {"jp2",  "image/jp2"},
-                                                                         {"jpg",  "image/jpeg"},
-                                                                         {"jpeg", "image/jpeg"},
-                                                                         {"tiff", "image/tiff"},
-                                                                         {"tif",  "image/tiff"},
-                                                                         {"png",  "image/png"}};
-                                                                         */
-
     SipiImage::SipiImage() {
         nx = 0;
         ny = 0;
@@ -225,50 +215,14 @@ namespace Sipi {
     void SipiImage::ensure_exif() {
         if (exif == nullptr) exif = std::make_shared<SipiExif>();
     }
-
     //============================================================================
 
+
     /*!
-     * This function compares the actual mime type of a file (based on its magic number) to
-     * the given mime type (sent by the client) and the extension of the given filename (sent by the client)
+     * Reads the image from a file by calling the appropriate reader.
+     * The readers return either boolean or throw an exception,
+     * so in any case wrap the call to this method in a try/catch block.
      */
-     /* ToDo: Delete
-    bool SipiImage::checkMimeTypeConsistency(const std::string &path, const std::string &given_mimetype,
-                                             const std::string &filename) {
-        try {
-            std::string actual_mimetype = shttps::Parsing::getFileMimetype(path).first;
-
-            if (actual_mimetype != given_mimetype) {
-                //std::cerr << actual_mimetype << " does not equal " << given_mimetype << std::endl;
-                return false;
-            }
-
-            size_t dot_pos = filename.find_last_of(".");
-
-            if (dot_pos == std::string::npos) {
-                //std::cerr << "invalid filename " << filename << std::endl;
-                return false;
-            }
-
-            std::string extension = filename.substr(dot_pos + 1);
-            std::transform(extension.begin(), extension.end(), extension.begin(), ::tolower); // convert file extension to lower case (uppercase letters in file extension have to be converted for mime type comparison)
-            std::string mime_from_extension = Sipi::SipiImage::mimetypes.at(extension);
-
-            if (mime_from_extension != actual_mimetype) {
-                //std::cerr << "filename " << filename << "has not mime type " << actual_mimetype << std::endl;
-                return false;
-            }
-        } catch (std::out_of_range &e) {
-            std::stringstream ss;
-            ss << "Unsupported file type: \"" << filename;
-            throw SipiImageError(thisSourceFile, __LINE__, ss.str());
-        } catch (shttps::Error &err) {
-            throw SipiImageError(thisSourceFile, __LINE__, err.to_string());
-        }
-
-        return true;
-    }
-    */
     void SipiImage::read(const std::string& filepath, int pagenum, const std::shared_ptr<SipiRegion>& region,
                          const std::shared_ptr<SipiSize>& size, bool force_bps_8, ScalingQuality scaling_quality) {
         size_t pos = filepath.find_last_of('.');
@@ -296,7 +250,7 @@ namespace Sipi {
         }
 
         if (!got_file) {
-            throw SipiImageError(__file__, __LINE__, "Could not read file " + filepath);
+            throw SipiImageError(__file__, __LINE__, "Error reading file " + filepath);
         }
     }
     //============================================================================

--- a/src/formats/SipiIOJ2k.cpp
+++ b/src/formats/SipiIOJ2k.cpp
@@ -529,12 +529,12 @@ namespace Sipi {
 
         //
         // the following code directly converts a 16-Bit jpx into an 8-bit image.
-        // In order to retrieve a 16-Bit image, use kdu_uin16 *buffer an the apropriate signature of the pull_stripe method
+        // In order to retrieve a 16-Bit image, use kdu_uin16 *buffer and the apropriate signature of the pull_stripe method
         //
         kdu_supp::kdu_stripe_decompressor decompressor;
         decompressor.start(codestream);
-        int stripe_heights[4] = {dims.size.y, dims.size.y, dims.size.y,
-                                 dims.size.y}; // enough for alpha channel (4 components)
+        //TODO: check image for number of components and make this dynamic
+        int stripe_heights[5] = {dims.size.y, dims.size.y, dims.size.y, dims.size.y, dims.size.y}; // enough for alpha channel (5 components)
 
         if (force_bps_8) img->bps = 8; // forces kakadu to convert to 8 bit!
         switch (img->bps) {
@@ -546,36 +546,53 @@ namespace Sipi {
                     codestream.destroy();
                     input->close();
                     jpx_in.close(); // Not really necessary here.
-                    throw SipiImageError(__file__, __LINE__, "Error while decompressing image!");
+                    syslog(LOG_ERR, "Error while decompressing image: %s.", filepath.c_str());
+                    return false;
                 }
-                img->pixels = static_cast<byte *>(buffer8);
+                img->pixels = buffer8;
                 break;
             }
             case 12: {
                 std::vector<char> get_signed(img->nc, 0); // vector<bool> does not work -> special treatment in C++
                 auto *buffer16 = new kdu_core::kdu_int16[(int) dims.area() * img->nc];
-                decompressor.pull_stripe(buffer16,
-                                         stripe_heights,
-                                         nullptr,
-                                         nullptr,
-                                         nullptr,
-                                         nullptr,
-                                         (bool *) get_signed.data());
-                img->pixels = (byte *) buffer16;
+                try {
+                    decompressor.pull_stripe(buffer16,
+                                             stripe_heights,
+                                             nullptr,
+                                             nullptr,
+                                             nullptr,
+                                             nullptr,
+                                             reinterpret_cast<bool *>(get_signed.data()));
+                } catch (kdu_exception &exc) {
+                    codestream.destroy();
+                    input->close();
+                    jpx_in.close(); // Not really necessary here.
+                    syslog(LOG_ERR, "Error while decompressing image: %s.", filepath.c_str());
+                    return false;
+                }
+                img->pixels = reinterpret_cast<byte *>(buffer16);
                 img->bps = 16;
                 break;
             }
             case 16: {
                 std::vector<char> get_signed(img->nc, 0); // vector<bool> does not work -> special treatment in C++
                 auto *buffer16 = new kdu_core::kdu_int16[(int) dims.area() * img->nc];
-                decompressor.pull_stripe(buffer16,
-                                         stripe_heights,
-                                         nullptr,
-                                         nullptr,
-                                         nullptr,
-                                         nullptr,
-                                         (bool *) get_signed.data());
-                img->pixels = (byte *) buffer16;
+                try {
+                    decompressor.pull_stripe(buffer16,
+                                             stripe_heights,
+                                             nullptr,
+                                             nullptr,
+                                             nullptr,
+                                             nullptr,
+                                             reinterpret_cast<bool *>(get_signed.data()));
+                } catch (kdu_exception &exc) {
+                    codestream.destroy();
+                    input->close();
+                    jpx_in.close(); // Not really necessary here.
+                    syslog(LOG_ERR, "Error while decompressing image: %s.", filepath.c_str());
+                    return false;
+                }
+                img->pixels = reinterpret_cast<byte *>(buffer16);
                 break;
             }
             default: {

--- a/test/_test_data/images/unit/.gitignore
+++ b/test/_test_data/images/unit/.gitignore
@@ -13,6 +13,7 @@
 !cielab_2.tif
 !cmyk.tif
 !cmyk_lossy.jp2
+!dev_3229.tif
 !gray_with_icc.jp2
 !has-missing-sidecar-file.mp4
 !has-missing-sidecar-file.mp4.orig

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -2,16 +2,8 @@
 # This file needs to be updated whenever a new test is added.
 #
 # all tests can be run from the build directory with `make test`
-include(CheckCXXCompilerFlag)
-#set(CMAKE_CXX_STANDARD 17)
-check_cxx_compiler_flag("-fvisibility-inlines-hidden" SUPPORTS_FVISIBILITY_INLINES_HIDDEN_FLAG)
-if(SUPPORTS_FVISIBILITY_INLINES_HIDDEN_FLAG)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility-inlines-hidden")
-endif()
-check_cxx_compiler_flag("-fvisibility=hidden" SUPPORTS_FVISIBILITY_FLAG)
-if(SUPPORTS_FVISIBILITY_FLAG)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden")
-endif()
+
+set(CMAKE_CXX_FLAGS "-O0 -g -std=c++14 -Wall -Wno-uninitialized -Wno-deprecated -Woverloaded-virtual")
 
 find_package(Threads REQUIRED)
 

--- a/test/unit/sipiimage/CMakeLists.txt
+++ b/test/unit/sipiimage/CMakeLists.txt
@@ -1,14 +1,3 @@
-include(CheckCXXCompilerFlag)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCMAKE_CXX_STANDARD=17")
-
-check_cxx_compiler_flag("-fvisibility-inlines-hidden" SUPPORTS_FVISIBILITY_INLINES_HIDDEN_FLAG)
-if(SUPPORTS_FVISIBILITY_INLINES_HIDDEN_FLAG)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility-inlines-hidden")
-endif()
-check_cxx_compiler_flag("-fvisibility=hidden" SUPPORTS_FVISIBILITY_FLAG)
-if(SUPPORTS_FVISIBILITY_FLAG)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden")
-endif()
 
 link_directories(
         ${CONFIGURE_LIBDIR}
@@ -41,7 +30,8 @@ add_executable(
         ${PROJECT_SOURCE_DIR}/src/metadata/SipiIptc.cpp ${PROJECT_SOURCE_DIR}/include/metadata/SipiIptc.h
         ${PROJECT_SOURCE_DIR}/src/metadata/SipiExif.cpp ${PROJECT_SOURCE_DIR}/include/metadata/SipiExif.h
         ${PROJECT_SOURCE_DIR}/src/metadata/SipiEssentials.cpp ${PROJECT_SOURCE_DIR}/include/metadata/SipiEssentials.h
-        ${PROJECT_SOURCE_DIR}/src/SipiImage.cpp ${PROJECT_SOURCE_DIR}/include/SipiImage.h ${PROJECT_SOURCE_DIR}/include/SipiIO.h
+        ${PROJECT_SOURCE_DIR}/src/SipiImage.cpp ${PROJECT_SOURCE_DIR}/include/SipiImage.h ${PROJECT_SOURCE_DIR}/include/SipiImageError.h
+        ${PROJECT_SOURCE_DIR}/include/SipiIO.h
         ${PROJECT_SOURCE_DIR}/src/formats/SipiIOTiff.cpp ${PROJECT_SOURCE_DIR}/include/formats/SipiIOTiff.h
         ${PROJECT_SOURCE_DIR}/src/formats/SipiIOJ2k.cpp ${PROJECT_SOURCE_DIR}/include/formats/SipiIOJ2k.h
         ${PROJECT_SOURCE_DIR}/src/formats/SipiIOJpeg.cpp ${PROJECT_SOURCE_DIR}/include/formats/SipiIOJpeg.h
@@ -69,6 +59,7 @@ add_executable(
         ${PROJECT_SOURCE_DIR}/shttps/Server.cpp ${PROJECT_SOURCE_DIR}/shttps/Server.h
         ${PROJECT_SOURCE_DIR}/shttps/jwt.c ${PROJECT_SOURCE_DIR}/shttps/jwt.h
         ${PROJECT_SOURCE_DIR}/shttps/makeunique.h ${PROJECT_SOURCE_DIR}/src/SipiFilenameHash.cpp ${PROJECT_SOURCE_DIR}/include/SipiFilenameHash.h
+        ../../../include/SipiImageError.h
 )
 add_dependencies(sipiimage icc_profiles)
 

--- a/test/unit/sipiimage/sipiimage.cpp
+++ b/test/unit/sipiimage/sipiimage.cpp
@@ -291,10 +291,10 @@ TEST(SipiImage, Dev3229)
     Sipi::SipiImage img1;
     Sipi::SipiImage img2;
 
-    const std::string problem = "../../../../test/_test_data/images/unit/dev_3229.tif";
+    const std::string problematic_tif = "../../../../test/_test_data/images/unit/dev_3229.tif";
+    const std::string problematic_tif_converted_to_jpx = "../../../../test/_test_data/images/unit/dev_3229.jpx";
 
-    ASSERT_NO_THROW(img1.read(problem));
-    ASSERT_NO_THROW(img1.write("jpx", "../../../../test/_test_data/images/unit/dev_3229.jpx"));
-
-    img2.read("../../../../test/_test_data/images/unit/dev_3229.jpx");
+    ASSERT_NO_THROW(img1.read(problematic_tif));
+    ASSERT_NO_THROW(img1.write("jpx", problematic_tif_converted_to_jpx));
+    ASSERT_NO_THROW(img2.read(problematic_tif_converted_to_jpx));
 }

--- a/test/unit/sipiimage/sipiimage.cpp
+++ b/test/unit/sipiimage/sipiimage.cpp
@@ -284,3 +284,17 @@ TEST(SipiImage, Watermark)
     ASSERT_THROW(img4.add_watermark(watermark_incorrect), std::exception);
 
 }
+
+TEST(SipiImage, Dev3229)
+{
+    Sipi::SipiIOTiff::initLibrary();
+    Sipi::SipiImage img1;
+    Sipi::SipiImage img2;
+
+    const std::string problem = "../../../../test/_test_data/images/unit/dev_3229.tif";
+
+    ASSERT_NO_THROW(img1.read(problem));
+    ASSERT_NO_THROW(img1.write("jpx", "../../../../test/_test_data/images/unit/dev_3229.jpx"));
+
+    img2.read("../../../../test/_test_data/images/unit/dev_3229.jpx");
+}

--- a/test/unit/sipiimage/sipiimage.cpp
+++ b/test/unit/sipiimage/sipiimage.cpp
@@ -293,8 +293,13 @@ TEST(SipiImage, Dev3229)
 
     const std::string problematic_tif = "../../../../test/_test_data/images/unit/dev_3229.tif";
     const std::string problematic_tif_converted_to_jpx = "../../../../test/_test_data/images/unit/dev_3229.jpx";
+    const std::string problematic_tif_converted_from_jpx_to_tif = "../../../../test/_test_data/images/unit/dev_3229_2.tif";
 
     ASSERT_NO_THROW(img1.read(problematic_tif));
     ASSERT_NO_THROW(img1.write("jpx", problematic_tif_converted_to_jpx));
     ASSERT_NO_THROW(img2.read(problematic_tif_converted_to_jpx));
+
+    // now test if conversion back to TIFF gives an identical image
+    ASSERT_NO_THROW(img2.write("tif", problematic_tif_converted_from_jpx_to_tif));
+    EXPECT_TRUE(image_identical(problematic_tif, problematic_tif_converted_from_jpx_to_tif));
 }


### PR DESCRIPTION
The original TIFF has 5 components. Image was converted to JP2 but reading it back would crash as the buffer was fixed in size for 4 components and would explode ;-)

related to DEV-3229