### PR TITLE
fix: update ijg jpeg lib to v9f, partially fixes DEV-3474

### DIFF
--- a/ext/jpeg/CMakeLists.txt
+++ b/ext/jpeg/CMakeLists.txt
@@ -9,13 +9,13 @@ set(timestamp_policy DOWNLOAD_EXTRACT_TIMESTAMP OLD)
 
 ExternalProject_Add(project_jpeg
         INSTALL_DIR ${CMAKE_BINARY_DIR}/local
-        URL https://github.com/dasch-swiss/sipi-third-party/raw/main/third-party/jpegsrc.v9c.tar.gz
+        URL https://ijg.org/files/jpegsrc.v9f.tar.gz
         ${timestamp_policy}
         DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/local/extsrcs/downloads
         #URL_HASH SHA256=650250979303a649e21f87b5ccd02672af1ea6954b911342ea491f351ceb7122
         #DOWNLOAD_EXTRACT_TIMESTAMP OLD
-        SOURCE_DIR ${CMAKE_BINARY_DIR}/local/extsrcs/libjpeg-v9c
-        CONFIGURE_COMMAND ${CMAKE_BINARY_DIR}/local/extsrcs/libjpeg-v9c/configure --prefix=${CMAKE_BINARY_DIR}/local --enable-shared --enable-static --libdir=${CMAKE_BINARY_DIR}/local/lib
+        SOURCE_DIR ${CMAKE_BINARY_DIR}/local/extsrcs/libjpeg-v9f
+        CONFIGURE_COMMAND ${CMAKE_BINARY_DIR}/local/extsrcs/libjpeg-v9f/configure --prefix=${CMAKE_BINARY_DIR}/local --enable-shared --enable-static --libdir=${CMAKE_BINARY_DIR}/local/lib
         BUILD_COMMAND make
         BUILD_IN_SOURCE 1
 )


### PR DESCRIPTION
As far as I understand, the core of the issue is that the ijg library used not to correctly recognize when the 4 channel colorspace is actually YCCA, which is likely (but I can't say with 100% certainty) fixed in v9e: https://github.com/libjpeg-turbo/ijg/commit/ff9491d4e0a06542ae82367183e4548664705d80#diff-71516311e7ecc262ab53731fc7ec0ea1c6d50ff9367bdea67804f9af5c9015e5L165-R180

I discovered where the bug lies after checking that the values of a image of just cyan (100%, 0%, 0%, 0%) are 0, 255, 255, 255, so it could not have been the fault of the image profile convertor (LittleCMS, in this case. In addition, I tried setting all the parameters for LCMS manually and tested it with a byte array, which was all correct.)

Knowing the root cause, additional reports of such problems can be found, because this feature space is probably not extensively tested.

With the ijg lib updated to v9f, the original file attached in the issue is getting converted correctly, although files converted with imagemagick still remain black.