### PR TITLE
fix: Fix planar BigTIFF ingestion (DEV-3384)

### DIFF
--- a/src/formats/SipiIOTiff.cpp
+++ b/src/formats/SipiIOTiff.cpp
@@ -734,7 +734,7 @@ bool SipiIOTiff::read(SipiImage *img,
 
     if ((region == nullptr) || (region->getType() == SipiRegion::FULL)) {
       if (planar == PLANARCONFIG_CONTIG) {
-        uint32 i;
+        uint64 i;
         auto *dataptr = new uint8[img->ny * sll];
 
         for (i = 0; i < img->ny; i++) {


### PR DESCRIPTION
Since the files that are to be tested range in the multiple gigabytes (when uncompressed) and will take a lot of space and time when testing, they have not been added to the test suite. Accordingly, the fix will be tested on the dev env.

As before, when ingesting a tiled BigTiff, an error noting the incompatibility will be issued.