### PR TITLE
feat: Support IIIF Image's API HEAD requests (DEV-4072)

### DIFF
--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -298,7 +298,7 @@ class SipiTestManager:
             raise SipiTestError(
                 "Sipi compare: pixels not identical {} {}:\n {}".format(downloaded_file_path, expected_file_path, compare_process.stdout))
 
-    def expect_status_code(self, url_path, status_code, headers=None):
+    def expect_status_code(self, url_path, status_code, headers=None, method='get'):
         """
         Requests a file and expects to get a particular HTTP status code.
 
@@ -308,15 +308,13 @@ class SipiTestManager:
         """
 
         sipi_url = self.make_sipi_url(url_path)
-        response = requests.get(sipi_url, headers=headers)
+        response = getattr(requests, method)(sipi_url, headers=headers)
 
         if response.status_code != status_code:
-            raise SipiTestError(
-                "Received status code {} for URL {}, expected {} (wrote {}). Response:\n{}".format(response.status_code,
-                                                                                                   sipi_url,
-                                                                                                   status_code,
-                                                                                                   self.sipi_log_file,
-                                                                                                   response.text))
+            format = "Received status code {} for URL {}, expected {} (wrote {}). Response:\n{}"
+            raise SipiTestError(format.format(response.status_code, sipi_url, status_code, self.sipi_log_file, response.text))
+
+        return response
 
     def get_image_info(self, url_path, headers=None):
         """


### PR DESCRIPTION
HEAD requests should return the status code without the body content. E2E Tests included.