### PR TITLE
feat: return 404 for missing files (INFRA-735)

### DIFF
--- a/src/SipiHttpServer.cpp
+++ b/src/SipiHttpServer.cpp
@@ -637,7 +637,7 @@ static void serve_info_json_file(Connection &conn_obj,
   try {
     access = check_file_access(conn_obj, serv, luaserver, params, prefix_as_path);
   } catch (SipiError &err) {
-    send_error(conn_obj, Connection::INTERNAL_SERVER_ERROR, err);
+    send_error(conn_obj, Connection::NOT_FOUND, err);
     return;
   }
 

--- a/test/e2e/test_02_server.py
+++ b/test/e2e/test_02_server.py
@@ -99,7 +99,7 @@ class TestServer:
             "/knora/DenyLeaves.jpg/full/max/0/default.jpg", 401)
 
     def test_not_found(self, manager):
-        """return 401 Unauthorized if the user does not have permission to see the image"""
+        """return 404 Not Found if the file is missing. Sipi will try and fail to find this file in the image directory."""
         manager.expect_status_code(
             "/file-should-be-missing-123", 404)
 

--- a/test/e2e/test_02_server.py
+++ b/test/e2e/test_02_server.py
@@ -98,6 +98,11 @@ class TestServer:
         manager.expect_status_code(
             "/knora/DenyLeaves.jpg/full/max/0/default.jpg", 401)
 
+    def test_not_found(self, manager):
+        """return 401 Unauthorized if the user does not have permission to see the image"""
+        manager.expect_status_code(
+            "/file-should-be-missing-123", 404)
+
     def test_iiif_url_parsing(self, manager):
         """Return 400 for invalid IIIF URL's"""
         manager.expect_status_code("/unit//lena512.jp2", 400)


### PR DESCRIPTION
Technically, the underlying function checks for file accessibility, but an internal server error would be inappropriate even then.