### PR TITLE
DEV-4658 Add symbols to Sipi stacktraces / improve logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -439,6 +439,7 @@ add_executable(sipi
         ${PROJECT_SOURCE_DIR}/src/iiifparser/SipiRegion.cpp ${PROJECT_SOURCE_DIR}/include/iiifparser/SipiRegion.h
         ${PROJECT_SOURCE_DIR}/src/iiifparser/SipiSize.cpp include/iiifparser/SipiSize.h
         ${PROJECT_SOURCE_DIR}/src/SipiCommon.cpp ${PROJECT_SOURCE_DIR}/include/SipiCommon.h
+        ${PROJECT_SOURCE_DIR}/src/Logger.cpp ${PROJECT_SOURCE_DIR}/include/Logger.h
         ${PROJECT_SOURCE_DIR}/shttps/Global.h
         ${PROJECT_SOURCE_DIR}/shttps/Error.cpp ${PROJECT_SOURCE_DIR}/shttps/Error.h
         ${PROJECT_SOURCE_DIR}/shttps/Hash.cpp ${PROJECT_SOURCE_DIR}/shttps/Hash.h

--- a/include/Logger.h
+++ b/include/Logger.h
@@ -1,0 +1,12 @@
+#ifndef LOGGER_H
+#define LOGGER_H
+
+enum LogLevel { LL_DEBUG, LL_INFO, LL_WARN, LL_ERROR };
+
+void log_format(LogLevel logl, const char *message, ...);
+void log_debug(const char *message, ...);
+void log_info(const char *message, ...);
+void log_warn(const char *message, ...);
+void log_err(const char *message, ...);
+
+#endif

--- a/shttps/Server.cpp
+++ b/shttps/Server.cpp
@@ -30,6 +30,7 @@
 // #include "openssl/applink.c"
 
 
+#include "Logger.h"
 #include "LuaServer.h"
 #include "Parsing.h"
 #include "Server.h"
@@ -64,7 +65,7 @@ static void *sig_thread(void *arg)
     // Ignore any other signals. We must in particular ignore
     // SIGPIPE.
     if (sig == SIGINT || sig == SIGTERM) {
-      syslog(LOG_INFO, "Got SIGINT or SIGTERM, stopping server");
+      log_info("Got SIGINT or SIGTERM, stopping server");
       serverptr->stop();
       return nullptr;
     }
@@ -94,7 +95,7 @@ static void default_handler(Connection &conn, LuaServer &lua, void *user_data, v
     return;
   }
 
-  syslog(LOG_WARNING, "No handler available! Host: %s Uri: %s", conn.host().c_str(), conn.uri().c_str());
+  log_warn("No handler available! Host: %s Uri: %s", conn.host().c_str(), conn.uri().c_str());
 }
 //=========================================================================
 
@@ -121,7 +122,7 @@ void script_handler(shttps::Connection &conn, LuaServer &lua, void *user_data, v
     conn.header("Content-Type", "text/text; charset=utf-8");
     conn << "File not found\n";
     conn.flush();
-    syslog(LOG_ERR, "script_handler: %s not readable!", script.c_str());
+    log_err("script_handler: %s not readable!", script.c_str());
     return;
   }
 
@@ -154,7 +155,7 @@ void script_handler(shttps::Connection &conn, LuaServer &lua, void *user_data, v
           return;
         }
 
-        syslog(LOG_ERR, "script_handler: error executing lua script: %s", err.to_string().c_str());
+        log_err("script_handler: error executing lua script: %s", err.to_string().c_str());
         return;
       }
       conn.flush();
@@ -200,7 +201,7 @@ void script_handler(shttps::Connection &conn, LuaServer &lua, void *user_data, v
             return;
           }
 
-          syslog(LOG_ERR, "script_handler: error executing lua chunk: %s", err.to_string().c_str());
+          log_err("script_handler: error executing lua chunk: %s", err.to_string().c_str());
           return;
         }
       }
@@ -213,7 +214,7 @@ void script_handler(shttps::Connection &conn, LuaServer &lua, void *user_data, v
       conn.header("Content-Type", "text/text; charset=utf-8");
       conn << "Script has no valid extension: '" << extension << "' !";
       conn.flush();
-      syslog(LOG_ERR, "script_handler: error executing script, unknown extension: %s", extension.c_str());
+      log_err("script_handler: error executing script, unknown extension: %s", extension.c_str());
     }
   } catch (InputFailure iofail) {
     return;// we have an io error => just return, the thread will exit
@@ -227,7 +228,7 @@ void script_handler(shttps::Connection &conn, LuaServer &lua, void *user_data, v
       return;
     }
 
-    syslog(LOG_ERR, "file_handler: internal error: %s", err.to_string().c_str());
+    log_err("file_handler: internal error: %s", err.to_string().c_str());
     return;
   }
 }
@@ -275,7 +276,7 @@ void file_handler(shttps::Connection &conn, LuaServer &lua, void *user_data, voi
     conn.header("Content-Type", "text/text; charset=utf-8");
     conn << "File not found\n";
     conn.flush();
-    syslog(LOG_ERR, "file_handler: %s not readable", infile.c_str());
+    log_err("file_handler: %s not readable", infile.c_str());
     return;
   }
 
@@ -289,7 +290,7 @@ void file_handler(shttps::Connection &conn, LuaServer &lua, void *user_data, voi
       conn.header("Content-Type", "text/text; charset=utf-8");
       conn << infile << " not aregular file\n";
       conn.flush();
-      syslog(LOG_ERR, "file_handler: %s is not regular file", infile.c_str());
+      log_err("file_handler: %s is not regular file", infile.c_str());
       return;
     }
   } else {
@@ -297,7 +298,7 @@ void file_handler(shttps::Connection &conn, LuaServer &lua, void *user_data, voi
     conn.header("Content-Type", "text/text; charset=utf-8");
     conn << "Could not stat file" << infile << "\n";
     conn.flush();
-    syslog(LOG_ERR, "file_handler: Could not stat %s", infile.c_str());
+    log_err("file_handler: Could not stat %s", infile.c_str());
     return;
   }
 
@@ -339,11 +340,11 @@ void file_handler(shttps::Connection &conn, LuaServer &lua, void *user_data, voi
           conn << "Lua Error:\r\n==========\r\n" << err << "\r\n";
           conn.flush();
         } catch (int i) {
-          syslog(LOG_ERR, "file_handler: error executing lua chunk!");
+          log_err("file_handler: error executing lua chunk!");
           return;
         }
 
-        syslog(LOG_ERR, "file_handler: error executing lua chunk: %s", err.to_string().c_str());
+        log_err("file_handler: error executing lua chunk: %s", err.to_string().c_str());
         return;
       }
 
@@ -388,7 +389,7 @@ void file_handler(shttps::Connection &conn, LuaServer &lua, void *user_data, voi
             conn.flush();
           } catch (InputFailure iofail) {}
 
-          syslog(LOG_ERR, "file_handler: error executing lua chunk: %s", err.to_string().c_str());
+          log_err("file_handler: error executing lua chunk: %s", err.to_string().c_str());
           return;
         }
       }
@@ -468,7 +469,7 @@ void file_handler(shttps::Connection &conn, LuaServer &lua, void *user_data, voi
       conn.flush();
     } catch (InputFailure iofail) {}
 
-    syslog(LOG_ERR, "file_handler: internal error: %s", err.to_string().c_str());
+    log_err("file_handler: internal error: %s", err.to_string().c_str());
     return;
   }
 }
@@ -542,24 +543,24 @@ Server::Server(int port_p,
       if (res != nullptr) {
         if (setuid(pwd.pw_uid) == 0) {
           int old_ll = setlogmask(LOG_MASK(LOG_INFO));
-          syslog(LOG_INFO, "Server will run as user %s (%d)", userid_str.c_str(), getuid());
+          log_info("Server will run as user %s (%d)", userid_str.c_str(), getuid());
           setlogmask(old_ll);
 
           if (setgid(pwd.pw_gid) == 0) {
             int old_ll = setlogmask(LOG_MASK(LOG_INFO));
-            syslog(LOG_INFO, "Server will run with group-id %d", getgid());
+            log_info("Server will run with group-id %d", getgid());
             setlogmask(old_ll);
           } else {
-            syslog(LOG_ERR, "setgid() failed! Reason: %m");
+            log_err("setgid() failed! Reason: %m");
           }
         } else {
-          syslog(LOG_ERR, "setgid() failed! Reason: %m");
+          log_err("setgid() failed! Reason: %m");
         }
       } else {
-        syslog(LOG_ERR, "Could not get uid of user %s: you must start Sipi as root", userid_str.c_str());
+        log_err("Could not get uid of user %s: you must start Sipi as root", userid_str.c_str());
       }
     } else {
-      syslog(LOG_ERR, "Could not get uid of user %s: you must start Sipi as root", userid_str.c_str());
+      log_err("Could not get uid of user %s: you must start Sipi as root", userid_str.c_str());
     }
   }
   SSL_load_error_strings();
@@ -635,14 +636,14 @@ static int prepare_socket(int port)
   sockfd = socket(AF_INET, SOCK_STREAM, 0);
 
   if (sockfd < 0) {
-    syslog(LOG_ERR, "Could not create socket: %m");
+    log_err("Could not create socket: %m");
     exit(1);
   }
 
   int optval = 1;
 
   if (::setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof optval) < 0) {
-    syslog(LOG_ERR, "Could not set socket option: %m");
+    log_err("Could not set socket option: %m");
     exit(1);
   }
 
@@ -655,12 +656,12 @@ static int prepare_socket(int port)
 
   /* Now bind the host address using bind() call.*/
   if (::bind(sockfd, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0) {
-    syslog(LOG_ERR, "Could not bind socket: %m");
+    log_err("Could not bind socket: %m");
     exit(1);
   }
 
   if (::listen(sockfd, SOMAXCONN) < 0) {
-    syslog(LOG_ERR, "Could not listen on socket: %m");
+    log_err("Could not listen on socket: %m");
     exit(1);
   }
 
@@ -681,8 +682,7 @@ static int close_socket(const SocketControl::SocketInfo &socket_info)
       ;
     if (sstat < 0) {
       const auto loc = std::source_location::current();
-      syslog(LOG_WARNING,
-        "SSL socket error: shutdown of socket failed at [%s: %d] with error code %d",
+      log_warn("SSL socket error: shutdown of socket failed at [%s: %d] with error code %d",
         loc.file_name(),
         loc.line(),
         SSL_get_error(socket_info.ssl_sid, sstat));
@@ -692,7 +692,7 @@ static int close_socket(const SocketControl::SocketInfo &socket_info)
   }
   if (shutdown(socket_info.sid, SHUT_RDWR) < 0) {
     const auto loc = std::source_location::current();
-    syslog(LOG_DEBUG,
+    log_debug(
       "Debug: shutting down socket at [%s: %d]: %m failed (client terminated already?)",
       loc.file_name(),
       loc.line());
@@ -700,7 +700,7 @@ static int close_socket(const SocketControl::SocketInfo &socket_info)
 
   if (close(socket_info.sid) == -1) {
     const auto loc = std::source_location::current();
-    syslog(LOG_DEBUG,
+    log_debug(
       "Debug: closing socket at [%s: %d]: %m failed (client terminated already?)",
       loc.file_name(),
       loc.line());
@@ -726,7 +726,7 @@ static void *socket_request_processor(void *arg)
     poll_status = poll(readfds, 1, -1);
     if (poll_status < 0) {
       const auto loc = std::source_location::current();
-      syslog(LOG_ERR, "Blocking poll on control pipe failed at [%s: %d]", loc.file_name(), loc.line());
+      log_err("Blocking poll on control pipe failed at [%s: %d]", loc.file_name(), loc.line());
       tdata->result = -1;
       return nullptr;
     }
@@ -792,10 +792,10 @@ static void *socket_request_processor(void *arg)
     } else if (readfds[0].revents == POLLHUP) {
       return nullptr;
     } else if (readfds[0].revents == POLLERR) {
-      syslog(LOG_ERR, "Thread pool got POLLERR message");
+      log_err("Thread pool got POLLERR message");
       return nullptr;
     } else {
-      syslog(LOG_ERR, "Thread pool got UNKNONW(!) message");
+      log_err("Thread pool got UNKNONW(!) message");
       return nullptr;
     }
   } while (true);
@@ -816,7 +816,7 @@ SocketControl::SocketInfo Server::accept_connection(int sock, bool ssl)
 
   if (socket_id.sid <= 0) {
     auto loc = std::source_location::current();
-    syslog(LOG_ERR, "Socket error  at [%s: %d]: %m", loc.file_name(), loc.line());
+    log_err("Socket error  at [%s: %d]: %m", loc.file_name(), loc.line());
     // ToDo: Perform appropriate action!
   }
   socket_id.type = SocketControl::NOOP;
@@ -842,52 +842,50 @@ SocketControl::SocketInfo Server::accept_connection(int sock, bool ssl)
   if (ssl) {
     try {
       if ((sslctx = SSL_CTX_new(SSLv23_server_method())) == nullptr) {
-        syslog(LOG_ERR, "OpenSSL error: SSL_CTX_new() failed");
+        log_err("OpenSSL error: SSL_CTX_new() failed");
         throw SSLError("OpenSSL error: SSL_CTX_new() failed");
       }
       SSL_CTX_set_options(sslctx, SSL_OP_SINGLE_DH_USE);
       if (SSL_CTX_use_certificate_file(sslctx, _ssl_certificate.c_str(), SSL_FILETYPE_PEM) != 1) {
         std::string msg = "OpenSSL error: SSL_CTX_use_certificate_file(" + _ssl_certificate + ") failed";
-        syslog(LOG_ERR, "%s", msg.c_str());
+        log_err("%s", msg.c_str());
         throw SSLError(msg);
       }
       if (SSL_CTX_use_PrivateKey_file(sslctx, _ssl_key.c_str(), SSL_FILETYPE_PEM) != 1) {
         std::string msg = "OpenSSL error: SSL_CTX_use_PrivateKey_file(" + _ssl_certificate + ") failed";
-        syslog(LOG_ERR, "%s", msg.c_str());
+        log_err("%s", msg.c_str());
         throw SSLError(msg);
       }
       if (!SSL_CTX_check_private_key(sslctx)) {
         std::string msg = "OpenSSL error: SSL_CTX_check_private_key() failed";
-        syslog(LOG_ERR, "%s", msg.c_str());
+        log_err("%s", msg.c_str());
         throw SSLError(msg);
       }
       if ((cSSL = SSL_new(sslctx)) == nullptr) {
         std::string msg = "OpenSSL error: SSL_new() failed";
-        syslog(LOG_ERR, "%s", msg.c_str());
+        log_err("%s", msg.c_str());
         throw SSLError(msg);
       }
       if (SSL_set_fd(cSSL, socket_id.sid) != 1) {
         std::string msg = "OpenSSL error: SSL_set_fd() failed";
-        syslog(LOG_ERR, "%s", msg.c_str());
+        log_err("%s", msg.c_str());
         throw SSLError(msg);
       }
 
       // Here is the SSL Accept portion.  Now all reads and writes must use SS
       if ((SSL_accept(cSSL)) <= 0) {
         std::string msg = "OpenSSL error: SSL_accept() failed";
-        syslog(LOG_ERR, "%s", msg.c_str());
+        log_err("%s", msg.c_str());
         throw SSLError(msg);
       }
     } catch (SSLError &err) {
-      syslog(LOG_ERR, "%s", err.to_string().c_str());
+      log_err("%s", err.to_string().c_str());
       int sstat;
 
       while ((sstat = SSL_shutdown(cSSL)) == 0)
         ;
 
-      if (sstat < 0) {
-        syslog(LOG_WARNING, "SSL socket error: shutdown (2) of socket failed: %d", SSL_get_error(cSSL, sstat));
-      }
+      if (sstat < 0) { log_warn("SSL socket error: shutdown (2) of socket failed: %d", SSL_get_error(cSSL, sstat)); }
 
       SSL_free(cSSL);
       SSL_CTX_free(sslctx);
@@ -904,7 +902,7 @@ SocketControl::SocketInfo Server::accept_connection(int sock, bool ssl)
  */
 void Server::run()
 {
-  syslog(LOG_DEBUG, "In Server::run");
+  log_debug("In Server::run");
   // Start a thread just to catch signals sent to the server process.
   pthread_t sighandler_thread;
   sigset_t set;
@@ -914,21 +912,21 @@ void Server::run()
   sigaddset(&set, SIGPIPE);
 
   int pthread_sigmask_result = pthread_sigmask(SIG_BLOCK, &set, nullptr);
-  if (pthread_sigmask_result != 0) { syslog(LOG_ERR, "pthread_sigmask failed! (err=%d)", pthread_sigmask_result); }
+  if (pthread_sigmask_result != 0) { log_err("pthread_sigmask failed! (err=%d)", pthread_sigmask_result); }
 
   //
   // start the thread that handles incoming signals (SIGTERM, SIGPIPE etc.)
   //
   if (pthread_create(&sighandler_thread, nullptr, &sig_thread, (void *)this) != 0) {
-    syslog(LOG_ERR, "Couldn't create thread: %s", strerror(errno));
+    log_err("Couldn't create thread: %s", strerror(errno));
     return;
   }
 
   int old_ll = setlogmask(LOG_MASK(LOG_INFO));
-  syslog(LOG_INFO, "Starting shttps server with %d threads", _nthreads);
+  log_info("Starting shttps server with %d threads", _nthreads);
   setlogmask(old_ll);
 
-  syslog(LOG_INFO, "Creating thread pool....");
+  log_info("Creating thread pool....");
   ThreadControl thread_control(_nthreads, socket_request_processor, this);
   SocketControl socket_control(thread_control);
 
@@ -940,25 +938,25 @@ void Server::run()
     add_route(route.method, route.route, script_handler, &(route.script));
 
     old_ll = setlogmask(LOG_MASK(LOG_INFO));
-    syslog(LOG_INFO, "Added route %s with script %s", route.route.c_str(), route.script.c_str());
+    log_info("Added route %s with script %s", route.route.c_str(), route.script.c_str());
     setlogmask(old_ll);
   }
 
   _sockfd = prepare_socket(_port);
   old_ll = setlogmask(LOG_MASK(LOG_INFO));
-  syslog(LOG_INFO, "Server listening on HTTP port %d", _port);
+  log_info("Server listening on HTTP port %d", _port);
   setlogmask(old_ll);
 
   if (_ssl_port > 0) {
     _ssl_sockfd = prepare_socket(_ssl_port);
     old_ll = setlogmask(LOG_MASK(LOG_INFO));
-    syslog(LOG_INFO, "Server listening on SSL port %d", _ssl_port);
+    log_info("Server listening on SSL port %d", _ssl_port);
     setlogmask(old_ll);
   }
 
   if (socketpair(PF_LOCAL, SOCK_STREAM, 0, stoppipe) != 0) {
     auto loc = std::source_location::current();
-    syslog(LOG_ERR, "Creating pipe failed at [%s: %d]: %m", loc.file_name(), loc.line());
+    log_err("Creating pipe failed at [%s: %d]: %m", loc.file_name(), loc.line());
     return;
   }
 
@@ -975,7 +973,7 @@ void Server::run()
     int nsocks;
     if ((nsocks = poll(sockets, socket_control.get_sockets_size(), -1)) < 0) {
       auto loc = std::source_location::current();
-      syslog(LOG_ERR, "Blocking poll failed at [%s: %d]: %m", loc.file_name(), loc.line());
+      log_err("Blocking poll failed at [%s: %d]: %m", loc.file_name(), loc.line());
       running = false;
       break;
     }
@@ -1058,16 +1056,16 @@ void Server::run()
               //
               // a thread sent an EXIT message –– should not happen!!
               //
-              syslog(LOG_ERR, "A worker thread sent an EXIT message! This should never happen!");
+              log_err("A worker thread sent an EXIT message! This should never happen!");
               break;
             }
             case SocketControl::ERROR: {
-              syslog(LOG_ERR, "A worker thread sent an ERROR message! This should never happen!");
+              log_err("A worker thread sent an ERROR message! This should never happen!");
               // ToDo: React to this message
               break;
             }
             default: {
-              syslog(LOG_ERR, "A worker thread sent an non-dentifiable message! This should never happen!");
+              log_err("A worker thread sent an non-dentifiable message! This should never happen!");
               // error handling
             }
             }
@@ -1080,7 +1078,7 @@ void Server::run()
 
             SocketControl::SocketInfo msg =
               SocketControl::receive_control_message(sockets[i].fd);// read the message from the pipe
-            if (msg.type != SocketControl::EXIT) { syslog(LOG_ERR, "Got unexpected message from interrupt"); }
+            if (msg.type != SocketControl::EXIT) { log_err("Got unexpected message from interrupt"); }
 
             SocketControl::SocketInfo sockid;
             socket_control.remove(socket_control.get_http_socket_id(), sockid);// remove the HTTP socket
@@ -1095,14 +1093,14 @@ void Server::run()
             // we got input ready from normal listener socket
             SocketControl::SocketInfo sockid = accept_connection(sockets[i].fd, false);
             socket_control.add_dyn_socket(sockid);
-            syslog(LOG_INFO, "Accepted connection from %s", sockid.peer_ip);//  ==> CHANGES open_sockets!!
+            log_info("Accepted connection from %s", sockid.peer_ip);//  ==> CHANGES open_sockets!!
           } else if (i == socket_control.get_ssl_socket_id()) {
             //
             // external SSL request coming in
             //
             SocketControl::SocketInfo sockid = accept_connection(sockets[i].fd, true);
             socket_control.add_dyn_socket(sockid);
-            syslog(LOG_INFO, "Accepted SSL connection from %s", sockid.peer_ip);//  ==> CHANGES open_sockets!!
+            log_info("Accepted SSL connection from %s", sockid.peer_ip);//  ==> CHANGES open_sockets!!
           } else {
             //
             // DYN_SOCKET: a client socket (already accepted) has data -> dispatch the processing to a free thread
@@ -1114,7 +1112,7 @@ void Server::run()
               socket_control.remove(i, sockid);//  ==> CHANGES open_sockets!!
               sockid.type = SocketControl::PROCESS_REQUEST;
               int n = SocketControl::send_control_message(tinfo.control_pipe, sockid);
-              if (n < 0) { syslog(LOG_WARNING, "Got something unexpected..."); }
+              if (n < 0) { log_warn("Got something unexpected..."); }
             } else {// no thread available, push socket into waiting queue
               socket_control.move_to_waiting(i);//  ==> CHANGES open_sockets!!
             }
@@ -1153,20 +1151,20 @@ void Server::run()
             SocketControl::SocketInfo sockid;
             socket_control.remove(i, sockid);//  ==> CHANGES open_sockets!!
           } else {
-            syslog(LOG_ERR, "We got a HANGUP from an unknown socket (socket_id = %d)", i);
+            log_err("We got a HANGUP from an unknown socket (socket_id = %d)", i);
           }
         } else {
           // we've got something else...
-          if (sockets[i].revents & POLLERR) { syslog(LOG_DEBUG, "-->POLLERR"); }
-          if (sockets[i].revents & POLLHUP) { syslog(LOG_DEBUG, "-->POLLHUP"); }
-          if (sockets[i].revents & POLLIN) { syslog(LOG_DEBUG, "-->POLLIN"); }
-          if (sockets[i].revents & POLLNVAL) { syslog(LOG_DEBUG, "-->POLLNVAL"); }
-          if (sockets[i].revents & POLLOUT) { syslog(LOG_DEBUG, "-->POLLOUT"); }
-          if (sockets[i].revents & POLLPRI) { syslog(LOG_DEBUG, "-->POLLPRI"); }
-          if (sockets[i].revents & POLLRDBAND) { syslog(LOG_DEBUG, "-->POLLRDBAND"); }
-          if (sockets[i].revents & POLLRDNORM) { syslog(LOG_DEBUG, "-->POLLRDNORM"); }
-          if (sockets[i].revents & POLLWRBAND) { syslog(LOG_DEBUG, "-->POLLWRBAND"); }
-          if (sockets[i].revents & POLLWRNORM) { syslog(LOG_DEBUG, "-->POLLWRNORM"); }
+          if (sockets[i].revents & POLLERR) { log_debug("-->POLLERR"); }
+          if (sockets[i].revents & POLLHUP) { log_debug("-->POLLHUP"); }
+          if (sockets[i].revents & POLLIN) { log_debug("-->POLLIN"); }
+          if (sockets[i].revents & POLLNVAL) { log_debug("-->POLLNVAL"); }
+          if (sockets[i].revents & POLLOUT) { log_debug("-->POLLOUT"); }
+          if (sockets[i].revents & POLLPRI) { log_debug("-->POLLPRI"); }
+          if (sockets[i].revents & POLLRDBAND) { log_debug("-->POLLRDBAND"); }
+          if (sockets[i].revents & POLLRDNORM) { log_debug("-->POLLRDNORM"); }
+          if (sockets[i].revents & POLLWRBAND) { log_debug("-->POLLWRBAND"); }
+          if (sockets[i].revents & POLLWRNORM) { log_debug("-->POLLWRNORM"); }
           // running = false;
           // break; // accept returned something strange – probably we want to shutdown the server
         }
@@ -1175,7 +1173,7 @@ void Server::run()
   }
 
   old_ll = setlogmask(LOG_MASK(LOG_INFO));
-  syslog(LOG_INFO, "Server shutting down");
+  log_info("Server shutting down");
   setlogmask(old_ll);
 
   // close(stoppipe[0]);
@@ -1207,7 +1205,7 @@ shttps::ThreadStatus Server::process_request(std::istream *ins,
   bool socket_reuse)
 {
   if (_tmpdir.empty()) {
-    syslog(LOG_WARNING, "_tmpdir is empty");
+    log_warn("_tmpdir is empty");
     throw Error("_tmpdir is empty");
   }
   if (ins->eof() || os->eof()) return CLOSE;
@@ -1247,11 +1245,11 @@ shttps::ThreadStatus Server::process_request(std::istream *ins,
       RequestHandler handler = get_handler(conn, &hd);
       handler(conn, luaserver, _user_data, hd);
     } catch (InputFailure iofail) {
-      syslog(LOG_ERR, "Possibly socket closed by peer");
+      log_err("Possibly socket closed by peer");
       return CLOSE;// or CLOSE ??
     }
 
-    if (!conn.cleanupUploads()) { syslog(LOG_ERR, "Cleanup of uploaded files failed"); }
+    if (!conn.cleanupUploads()) { log_err("Cleanup of uploaded files failed"); }
 
     if (conn.keepAlive()) {
       return CONTINUE;
@@ -1259,10 +1257,10 @@ shttps::ThreadStatus Server::process_request(std::istream *ins,
       return CLOSE;
     }
   } catch (InputFailure iofail) {// "error" is thrown, if the socket was closed from the main thread...
-    syslog(LOG_DEBUG, "Socket connection: timeout or socket closed from main");
+    log_debug("Socket connection: timeout or socket closed from main");
     return CLOSE;
   } catch (Error &err) {
-    syslog(LOG_WARNING, "Internal server error: %s", err.to_string().c_str());
+    log_warn("Internal server error: %s", err.to_string().c_str());
     try {
       *os << "HTTP/1.1 500 INTERNAL_SERVER_ERROR\r\n";
       *os << "Content-Type: text/plain\r\n";
@@ -1271,7 +1269,7 @@ shttps::ThreadStatus Server::process_request(std::istream *ins,
       *os << "Content-Length: " << ss.str().length() << "\r\n\r\n";
       *os << ss.str();
     } catch (InputFailure iofail) {
-      syslog(LOG_DEBUG, "Possibly socket closed by peer");
+      log_debug("Possibly socket closed by peer");
     }
     return CLOSE;
   }
@@ -1286,4 +1284,4 @@ void Server::debugmsg(const int line, const std::string &msg)
 }
 //=========================================================================
 
-}
+}// namespace shttps

--- a/shttps/Shttp.cpp
+++ b/shttps/Shttp.cpp
@@ -13,6 +13,7 @@
 #include "Error.h"
 #include "Server.h"
 #include "LuaServer.h"
+#include "Logger.h"
 
 shttps::Server *serverptr = nullptr;
 
@@ -22,7 +23,7 @@ static sig_t old_broken_pipe_handler;
 static void sighandler(int sig) {
     if (serverptr != nullptr) {
         int old_ll = setlogmask(LOG_MASK(LOG_INFO));
-        syslog(LOG_INFO, "Got SIGINT, stopping server");
+        log_info("Got SIGINT, stopping server");
         setlogmask(old_ll);
         serverptr->stop();
     } else {

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -3,15 +3,96 @@
 #include <cstring>
 #include <ctime>
 #include <iomanip>
+#include <iostream>
 #include <sstream>
+#include <string>
 
 #include "Logger.h"
 #include "jansson.h"
 
+// https://stackoverflow.com/questions/17316506/strip-invalid-utf8-from-string-in-c-c
+std::string correct_non_utf_8(const std::string *str)
+{
+  int i, f_size = str->size();
+  unsigned char c, c2, c3, c4;
+  std::string to;
+  to.reserve(f_size);
+
+  for (i = 0; i < f_size; i++) {
+    c = (unsigned char)(*str)[i];
+    if (c < 32) {// control char
+      if (c == 9 || c == 10 || c == 13) {// allow only \t \n \r
+        to.append(1, c);
+      }
+      continue;
+    } else if (c < 127) {// normal ASCII
+      to.append(1, c);
+      continue;
+    } else if (c < 160) {// control char (nothing should be defined here either ASCI, ISO_8859-1 or UTF8, so skipping)
+      if (c2 == 128) {// fix microsoft mess, add euro
+        to.append(1, 226);
+        to.append(1, 130);
+        to.append(1, 172);
+      }
+      if (c2 == 133) {// fix IBM mess, add NEL = \n\r
+        to.append(1, 10);
+        to.append(1, 13);
+      }
+      continue;
+    } else if (c < 192) {// invalid for UTF8, converting ASCII
+      to.append(1, (unsigned char)194);
+      to.append(1, c);
+      continue;
+    } else if (c < 194) {// invalid for UTF8, converting ASCII
+      to.append(1, (unsigned char)195);
+      to.append(1, c - 64);
+      continue;
+    } else if (c < 224 && i + 1 < f_size) {// possibly 2byte UTF8
+      c2 = (unsigned char)(*str)[i + 1];
+      if (c2 > 127 && c2 < 192) {// valid 2byte UTF8
+        if (c == 194 && c2 < 160) {// control char, skipping
+          ;
+        } else {
+          to.append(1, c);
+          to.append(1, c2);
+        }
+        i++;
+        continue;
+      }
+    } else if (c < 240 && i + 2 < f_size) {// possibly 3byte UTF8
+      c2 = (unsigned char)(*str)[i + 1];
+      c3 = (unsigned char)(*str)[i + 2];
+      if (c2 > 127 && c2 < 192 && c3 > 127 && c3 < 192) {// valid 3byte UTF8
+        to.append(1, c);
+        to.append(1, c2);
+        to.append(1, c3);
+        i += 2;
+        continue;
+      }
+    } else if (c < 245 && i + 3 < f_size) {// possibly 4byte UTF8
+      c2 = (unsigned char)(*str)[i + 1];
+      c3 = (unsigned char)(*str)[i + 2];
+      c4 = (unsigned char)(*str)[i + 3];
+      if (c2 > 127 && c2 < 192 && c3 > 127 && c3 < 192 && c4 > 127 && c4 < 192) {// valid 4byte UTF8
+        to.append(1, c);
+        to.append(1, c2);
+        to.append(1, c3);
+        to.append(1, c4);
+        i += 3;
+        continue;
+      }
+    }
+    // invalid UTF8, converting ASCII (c>245 || string too short for multi-byte))
+    to.append(1, (unsigned char)195);
+    to.append(1, c - 64);
+  }
+  return to;
+}
+
 // includes quotes
 std::string to_escaped_json_string(const std::string &input)
 {
-  json_t *json_str = json_string(input.c_str());
+  json_t *json_str = json_string_nocheck(correct_non_utf_8(&input).c_str());
   char *escaped_cstr = json_dumps(json_str, JSON_ENCODE_ANY);
   std::string escaped_string(escaped_cstr);
 
@@ -43,7 +124,8 @@ void log_format(LogLevel ll, const char *message, va_list args)
 {
   char format[vsnprintf_buf_size];
   vsnprintf(format, vsnprintf_buf_size, message, args);
-  printf("{\"level\": \"%s\", \"message\": %s}\n", LogLevelToString(ll), to_escaped_json_string(format).c_str());
+  char *outfmt = "{\"level\": \"%s\", \"message\": %s}\n";
+  fprintf(stderr, outfmt, LogLevelToString(ll), to_escaped_json_string(format).c_str());
 }
 
 void log_debug(const char *message, ...)

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -8,98 +8,42 @@
 #include <string>
 
 #include "Logger.h"
-#include "jansson.h"
 
-// https://stackoverflow.com/questions/17316506/strip-invalid-utf8-from-string-in-c-c
-std::string correct_non_utf_8(const std::string *str)
+std::string escape_json_str(const std::string &s)
 {
-  int i, f_size = str->size();
-  unsigned char c, c2, c3, c4;
-  std::string to;
-  to.reserve(f_size);
-
-  for (i = 0; i < f_size; i++) {
-    c = (unsigned char)(*str)[i];
-    if (c < 32) {// control char
-      if (c == 9 || c == 10 || c == 13) {// allow only \t \n \r
-        to.append(1, c);
-      }
-      continue;
-    } else if (c < 127) {// normal ASCII
-      to.append(1, c);
-      continue;
-    } else if (c < 160) {// control char (nothing should be defined here either ASCI, ISO_8859-1 or UTF8, so skipping)
-      if (c2 == 128) {// fix microsoft mess, add euro
-        to.append(1, 226);
-        to.append(1, 130);
-        to.append(1, 172);
-      }
-      if (c2 == 133) {// fix IBM mess, add NEL = \n\r
-        to.append(1, 10);
-        to.append(1, 13);
-      }
-      continue;
-    } else if (c < 192) {// invalid for UTF8, converting ASCII
-      to.append(1, (unsigned char)194);
-      to.append(1, c);
-      continue;
-    } else if (c < 194) {// invalid for UTF8, converting ASCII
-      to.append(1, (unsigned char)195);
-      to.append(1, c - 64);
-      continue;
-    } else if (c < 224 && i + 1 < f_size) {// possibly 2byte UTF8
-      c2 = (unsigned char)(*str)[i + 1];
-      if (c2 > 127 && c2 < 192) {// valid 2byte UTF8
-        if (c == 194 && c2 < 160) {// control char, skipping
-          ;
-        } else {
-          to.append(1, c);
-          to.append(1, c2);
-        }
-        i++;
-        continue;
-      }
-    } else if (c < 240 && i + 2 < f_size) {// possibly 3byte UTF8
-      c2 = (unsigned char)(*str)[i + 1];
-      c3 = (unsigned char)(*str)[i + 2];
-      if (c2 > 127 && c2 < 192 && c3 > 127 && c3 < 192) {// valid 3byte UTF8
-        to.append(1, c);
-        to.append(1, c2);
-        to.append(1, c3);
-        i += 2;
-        continue;
-      }
-    } else if (c < 245 && i + 3 < f_size) {// possibly 4byte UTF8
-      c2 = (unsigned char)(*str)[i + 1];
-      c3 = (unsigned char)(*str)[i + 2];
-      c4 = (unsigned char)(*str)[i + 3];
-      if (c2 > 127 && c2 < 192 && c3 > 127 && c3 < 192 && c4 > 127 && c4 < 192) {// valid 4byte UTF8
-        to.append(1, c);
-        to.append(1, c2);
-        to.append(1, c3);
-        to.append(1, c4);
-        i += 3;
-        continue;
+  std::ostringstream o;
+  for (auto c = s.cbegin(); c != s.cend(); c++) {
+    switch (*c) {
+    case '"':
+      o << "\\\"";
+      break;
+    case '\\':
+      o << "\\\\";
+      break;
+    case '\b':
+      o << "\\b";
+      break;
+    case '\f':
+      o << "\\f";
+      break;
+    case '\n':
+      o << "\\n";
+      break;
+    case '\r':
+      o << "\\r";
+      break;
+    case '\t':
+      o << "\\t";
+      break;
+    default:
+      if ('\x00' <= *c && *c <= '\x1f') {
+        o << "\\u" << std::hex << std::setw(4) << std::setfill('0') << static_cast<int>(*c);
+      } else {
+        o << *c;
       }
     }
-    // invalid UTF8, converting ASCII (c>245 || string too short for multi-byte))
-    to.append(1, (unsigned char)195);
-    to.append(1, c - 64);
   }
-  return to;
-}
-
-// includes quotes
-std::string to_escaped_json_string(const std::string &input)
-{
-  json_t *json_str = json_string_nocheck(correct_non_utf_8(&input).c_str());
-  char *escaped_cstr = json_dumps(json_str, JSON_ENCODE_ANY);
-  std::string escaped_string(escaped_cstr);
-
-  free(escaped_cstr);
-  json_decref(json_str);
-
-  return escaped_string;
+  return o.str();
 }
 
 inline const char *LogLevelToString(LogLevel ll)
@@ -125,7 +69,7 @@ void log_format(LogLevel ll, const char *message, va_list args)
   char format[vsnprintf_buf_size];
   vsnprintf(format, vsnprintf_buf_size, message, args);
   char *outfmt = "{\"level\": \"%s\", \"message\": %s}\n";
-  fprintf(stderr, outfmt, LogLevelToString(ll), to_escaped_json_string(format).c_str());
+  fprintf(stderr, outfmt, LogLevelToString(ll), escape_json_str(format).c_str());
 }
 
 void log_debug(const char *message, ...)

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -1,0 +1,102 @@
+#include <cstdarg>
+#include <cstdio>
+#include <cstring>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
+
+#include "Logger.h"
+
+std::string escape_json_str(const std::string &s)
+{
+  std::ostringstream o;
+  for (auto c = s.cbegin(); c != s.cend(); c++) {
+    switch (*c) {
+    case '"':
+      o << "\\\"";
+      break;
+    case '\\':
+      o << "\\\\";
+      break;
+    case '\b':
+      o << "\\b";
+      break;
+    case '\f':
+      o << "\\f";
+      break;
+    case '\n':
+      o << "\\n";
+      break;
+    case '\r':
+      o << "\\r";
+      break;
+    case '\t':
+      o << "\\t";
+      break;
+    default:
+      if ('\x00' <= *c && *c <= '\x1f') {
+        o << "\\u" << std::hex << std::setw(4) << std::setfill('0') << static_cast<int>(*c);
+      } else {
+        o << *c;
+      }
+    }
+  }
+  return o.str();
+}
+
+inline const char *LogLevelToString(LogLevel ll)
+{
+  switch (ll) {
+  case LL_DEBUG:
+    return "DEBUG";
+  case LL_INFO:
+    return "INFO";
+  case LL_WARN:
+    return "WARN";
+  case LL_ERROR:
+    return "ERROR";
+  default:
+    return "Missing";
+  }
+}
+
+const int vsnprintf_buf_size = 1000;
+
+void log_format(LogLevel ll, const char *message, va_list args)
+{
+  char format[vsnprintf_buf_size];
+  vsnprintf(format, vsnprintf_buf_size, message, args);
+  printf("{\"level\": \"%s\", \"message\": \"%s\"}\n", LogLevelToString(ll), escape_json_str(format).c_str());
+}
+
+void log_debug(const char *message, ...)
+{
+  va_list args;
+  va_start(args, message);
+  log_format(LL_DEBUG, message, args);
+  va_end(args);
+}
+
+void log_info(const char *message, ...)
+{
+  va_list args;
+  va_start(args, message);
+  log_format(LL_INFO, message, args);
+  va_end(args);
+}
+
+void log_warn(const char *message, ...)
+{
+  va_list args;
+  va_start(args, message);
+  log_format(LL_WARN, message, args);
+  va_end(args);
+}
+
+void log_err(const char *message, ...)
+{
+  va_list args;
+  va_start(args, message);
+  log_format(LL_ERROR, message, args);
+  va_end(args);
+}

--- a/src/formats/SipiIOJ2k.cpp
+++ b/src/formats/SipiIOJ2k.cpp
@@ -38,6 +38,7 @@
 #include "SipiError.hpp"
 #include "SipiImageError.hpp"
 #include "formats/SipiIOJ2k.h"
+#include "Logger.h"
 
 using namespace kdu_core;
 using namespace kdu_supp;
@@ -141,7 +142,7 @@ public:
 
   void flush(bool end_of_message = false)
   {
-    if (end_of_message) { syslog(LOG_WARNING, "%s", msg.c_str()); }
+    if (end_of_message) { log_warn("%s", msg.c_str()); }
   }
 };
 //=============================================================================
@@ -165,7 +166,7 @@ public:
   void flush(bool end_of_message = false)
   {
     if (end_of_message) {
-      syslog(LOG_ERR, "%s", msg.c_str());
+      log_err("%s", msg.c_str());
       throw KDU_ERROR_EXCEPTION;
     }
   }
@@ -251,7 +252,7 @@ bool SipiIOJ2k::read(SipiImage *img,
               img->xmp = std::make_shared<SipiXmp>(xmp_buf.get(),
                 xmp_len);// ToDo: Problem with thread safety!!!!!!!!!!!!!!
             } catch (SipiError &err) {
-              syslog(LOG_ERR, "%s", err.to_string().c_str());
+              log_err("%s", err.to_string().c_str());
             }
           } else if (memcmp(buf, iptc_uuid, 16) == 0) {
             auto iptc_len = box.get_remaining_bytes();
@@ -260,7 +261,7 @@ bool SipiIOJ2k::read(SipiImage *img,
             try {
               img->iptc = std::make_shared<SipiIptc>(iptc_buf.get(), iptc_len);
             } catch (SipiError &err) {
-              syslog(LOG_ERR, "%s", err.to_string().c_str());
+              log_err("%s", err.to_string().c_str());
             }
           } else if (memcmp(buf, exif_uuid, 16) == 0) {
             auto exif_len = box.get_remaining_bytes();
@@ -269,7 +270,7 @@ bool SipiIOJ2k::read(SipiImage *img,
             try {
               img->exif = std::make_shared<SipiExif>(exif_buf.get(), exif_len);
             } catch (SipiError &err) {
-              syslog(LOG_ERR, "%s", err.to_string().c_str());
+              log_err("%s", err.to_string().c_str());
             }
           }
         }
@@ -455,7 +456,7 @@ bool SipiIOJ2k::read(SipiImage *img,
         } else if (numcol == 4) {
           img->photo = PhotometricInterpretation::SEPARATED;
         } else {
-          syslog(LOG_ERR, "Unsupported number of colors: %d", numcol);
+          log_err("Unsupported number of colors: %d", numcol);
           throw SipiImageError("Unsupported number of colors: " + std::to_string(numcol));
         }
         int icc_len;
@@ -485,7 +486,7 @@ bool SipiIOJ2k::read(SipiImage *img,
       }
 
       default: {
-        syslog(LOG_ERR, "Unsupported ICC profile: %s", std::to_string(space).c_str());
+        log_err("Unsupported ICC profile: %s", std::to_string(space).c_str());
         throw SipiImageError("Unsupported ICC profile: " + std::to_string(space));
       }
       }
@@ -535,7 +536,7 @@ bool SipiIOJ2k::read(SipiImage *img,
       codestream.destroy();
       input->close();
       jpx_in.close();// Not really necessary here.
-      syslog(LOG_ERR, "Error while decompressing image: %s.", filepath.c_str());
+      log_err("Error while decompressing image: %s.", filepath.c_str());
       return false;
     }
     img->pixels = buffer8;
@@ -551,7 +552,7 @@ bool SipiIOJ2k::read(SipiImage *img,
       codestream.destroy();
       input->close();
       jpx_in.close();// Not really necessary here.
-      syslog(LOG_ERR, "Error while decompressing image: %s.", filepath.c_str());
+      log_err("Error while decompressing image: %s.", filepath.c_str());
       return false;
     }
     img->pixels = reinterpret_cast<byte *>(buffer16);
@@ -568,7 +569,7 @@ bool SipiIOJ2k::read(SipiImage *img,
       codestream.destroy();
       input->close();
       jpx_in.close();// Not really necessary here.
-      syslog(LOG_ERR, "Error while decompressing image: %s.", filepath.c_str());
+      log_err("Error while decompressing image: %s.", filepath.c_str());
       return false;
     }
     img->pixels = reinterpret_cast<byte *>(buffer16);
@@ -579,7 +580,7 @@ bool SipiIOJ2k::read(SipiImage *img,
     codestream.destroy();
     input->close();
     jpx_in.close();// Not really necessary here.
-    syslog(LOG_ERR, "Unsupported number of bits/sample: %ld !", img->bps);
+    log_err("Unsupported number of bits/sample: %ld !", img->bps);
     throw SipiImageError("Unsupported number of bits/sample!");
   }
   }

--- a/src/formats/SipiIOTiff.cpp
+++ b/src/formats/SipiIOTiff.cpp
@@ -24,6 +24,7 @@
 #include "SipiImage.hpp"
 #include "SipiImageError.hpp"
 #include "formats/SipiIOTiff.h"
+#include "Logger.h"
 
 
 #include "shttps/Global.h"
@@ -381,16 +382,16 @@ unsigned char *read_watermark(const std::string &wmfile, int &nx, int &ny, int &
 
 static void tiffError(const char *module, const char *fmt, va_list argptr)
 {
-  syslog(LOG_ERR, "ERROR IN TIFF! Module: %s", module);
-  vsyslog(LOG_ERR, fmt, argptr);
+  log_err("ERROR IN TIFF! Module: %s", module);
+  log_err(fmt, argptr);
 }
 //============================================================================
 
 
 static void tiffWarning(const char *module, const char *fmt, va_list argptr)
 {
-  syslog(LOG_ERR, "ERROR IN TIFF! Module: %s", module);
-  vsyslog(LOG_ERR, fmt, argptr);
+  log_err("ERROR IN TIFF! Module: %s", module);
+  log_err(fmt, argptr);
 }
 //============================================================================
 
@@ -623,7 +624,7 @@ bool SipiIOTiff::read(SipiImage *img,
       try {
         img->iptc = std::make_shared<SipiIptc>(iptc_content, iptc_length);
       } catch (SipiError &err) {
-        syslog(LOG_ERR, "%s", err.to_string().c_str());
+        log_err("%s", err.to_string().c_str());
       }
     }
 
@@ -646,7 +647,7 @@ bool SipiIOTiff::read(SipiImage *img,
       try {
         img->xmp = std::make_shared<SipiXmp>(xmp_content, xmp_length);
       } catch (SipiError &err) {
-        syslog(LOG_ERR, "%s", err.to_string().c_str());
+        log_err("%s", err.to_string().c_str());
       }
     }
 
@@ -662,7 +663,7 @@ bool SipiIOTiff::read(SipiImage *img,
       try {
         img->icc = std::make_shared<SipiIcc>(icc_buf, icc_len);
       } catch (SipiError &err) {
-        syslog(LOG_ERR, "%s", err.to_string().c_str());
+        log_err("%s", err.to_string().c_str());
       }
     } else if (1 == TIFFGetField(tif, TIFFTAG_WHITEPOINT, &whitepoint_ti)) {
       whitepoint[0] = whitepoint_ti[0];
@@ -1197,7 +1198,7 @@ void SipiIOTiff::write(SipiImage *img, const std::string &filepath, const SipiCo
 
       if (buf.size() > 0) { TIFFSetField(tif, TIFFTAG_ICCPROFILE, buf.size(), buf.data()); }
     } catch (SipiError &err) {
-      syslog(LOG_ERR, "%s", err.to_string().c_str());
+      log_err("%s", err.to_string().c_str());
     }
   }
   //
@@ -1208,7 +1209,7 @@ void SipiIOTiff::write(SipiImage *img, const std::string &filepath, const SipiCo
       std::vector<unsigned char> buf = img->iptc->iptcBytes();
       if (buf.size() > 0) { TIFFSetField(tif, TIFFTAG_RICHTIFFIPTC, buf.size(), buf.data()); }
     } catch (SipiError &err) {
-      syslog(LOG_ERR, "%s", err.to_string().c_str());
+      log_err("%s", err.to_string().c_str());
     }
   }
 
@@ -1220,7 +1221,7 @@ void SipiIOTiff::write(SipiImage *img, const std::string &filepath, const SipiCo
       std::string buf = img->xmp->xmpBytes();
       if (!buf.empty() > 0) { TIFFSetField(tif, TIFFTAG_XMLPACKET, buf.size(), buf.c_str()); }
     } catch (SipiError &err) {
-      syslog(LOG_ERR, "%s", err.to_string().c_str());
+      log_err("%s", err.to_string().c_str());
     }
   }
   //
@@ -1292,7 +1293,7 @@ void SipiIOTiff::readExif(SipiImage *img, TIFF *tif, toff_t exif_offset)
           try {
             img->exif->addKeyVal(exiftag_list[i].tag_id, "Photo", r);
           } catch (const SipiError &err) {
-            syslog(LOG_ERR, "Error writing EXIF data: %s", err.to_string().c_str());
+            log_err("Error writing EXIF data: %s", err.to_string().c_str());
           }
         }
         break;
@@ -1304,7 +1305,7 @@ void SipiIOTiff::readExif(SipiImage *img, TIFF *tif, toff_t exif_offset)
           try {
             img->exif->addKeyVal(exiftag_list[i].tag_id, "Photo", uc);
           } catch (const SipiError &err) {
-            syslog(LOG_ERR, "Error writing EXIF data: %s", err.to_string().c_str());
+            log_err("Error writing EXIF data: %s", err.to_string().c_str());
           }
         }
         break;
@@ -1316,7 +1317,7 @@ void SipiIOTiff::readExif(SipiImage *img, TIFF *tif, toff_t exif_offset)
           try {
             img->exif->addKeyVal(exiftag_list[i].tag_id, "Photo", us);
           } catch (const SipiError &err) {
-            syslog(LOG_ERR, "Error writing EXIF data: %s", err.to_string().c_str());
+            log_err("Error writing EXIF data: %s", err.to_string().c_str());
           }
         }
         break;
@@ -1328,7 +1329,7 @@ void SipiIOTiff::readExif(SipiImage *img, TIFF *tif, toff_t exif_offset)
           try {
             img->exif->addKeyVal(exiftag_list[i].tag_id, "Photo", ui);
           } catch (const SipiError &err) {
-            syslog(LOG_ERR, "Error writing EXIF data: %s", err.to_string().c_str());
+            log_err("Error writing EXIF data: %s", err.to_string().c_str());
           }
         }
         break;
@@ -1340,7 +1341,7 @@ void SipiIOTiff::readExif(SipiImage *img, TIFF *tif, toff_t exif_offset)
           try {
             img->exif->addKeyVal(exiftag_list[i].tag_id, "Photo", std::string(tmpstr));
           } catch (const SipiError &err) {
-            syslog(LOG_ERR, "Error writing EXIF data: %s", err.to_string().c_str());
+            log_err("Error writing EXIF data: %s", err.to_string().c_str());
           }
         }
         break;
@@ -1355,7 +1356,7 @@ void SipiIOTiff::readExif(SipiImage *img, TIFF *tif, toff_t exif_offset)
           try {
             img->exif->addKeyVal(exiftag_list[i].tag_id, "Photo", r, len);
           } catch (const SipiError &err) {
-            syslog(LOG_ERR, "Error writing EXIF data: %s", err.to_string().c_str());
+            log_err("Error writing EXIF data: %s", err.to_string().c_str());
           }
           delete[] r;
         }
@@ -1370,7 +1371,7 @@ void SipiIOTiff::readExif(SipiImage *img, TIFF *tif, toff_t exif_offset)
           try {
             img->exif->addKeyVal(exiftag_list[i].tag_id, "Photo", tmpbuf, len);
           } catch (const SipiError &err) {
-            syslog(LOG_ERR, "Error writing EXIF data: %s", err.to_string().c_str());
+            log_err("Error writing EXIF data: %s", err.to_string().c_str());
           }
         }
         break;
@@ -1383,7 +1384,7 @@ void SipiIOTiff::readExif(SipiImage *img, TIFF *tif, toff_t exif_offset)
           try {
             img->exif->addKeyVal(exiftag_list[i].tag_id, "Photo", tmpbuf, len);
           } catch (const SipiError &err) {
-            syslog(LOG_ERR, "Error writing EXIF data: %s", err.to_string().c_str());
+            log_err("Error writing EXIF data: %s", err.to_string().c_str());
           }
         }
         break;
@@ -1396,7 +1397,7 @@ void SipiIOTiff::readExif(SipiImage *img, TIFF *tif, toff_t exif_offset)
           try {
             img->exif->addKeyVal(exiftag_list[i].tag_id, "Photo", tmpbuf, len);
           } catch (const SipiError &err) {
-            syslog(LOG_ERR, "Error writing EXIF data: %s", err.to_string().c_str());
+            log_err("Error writing EXIF data: %s", err.to_string().c_str());
           }
         }
         break;
@@ -1411,7 +1412,7 @@ void SipiIOTiff::readExif(SipiImage *img, TIFF *tif, toff_t exif_offset)
             try {
               img->exif->addKeyVal(exiftag_list[i].tag_id, "Photo", tmpbuf, len);
             } catch (const SipiError &err) {
-              syslog(LOG_ERR, "Error writing EXIF data: %s", err.to_string().c_str());
+              log_err("Error writing EXIF data: %s", err.to_string().c_str());
             }
           }
         } else {
@@ -1420,7 +1421,7 @@ void SipiIOTiff::readExif(SipiImage *img, TIFF *tif, toff_t exif_offset)
             try {
               img->exif->addKeyVal(exiftag_list[i].tag_id, "Photo", tmpbuf, len);
             } catch (const SipiError &err) {
-              syslog(LOG_ERR, "Error writing EXIF data: %s", err.to_string().c_str());
+              log_err("Error writing EXIF data: %s", err.to_string().c_str());
             }
           }
         }

--- a/src/formats/SipiIOTiff.cpp
+++ b/src/formats/SipiIOTiff.cpp
@@ -382,7 +382,9 @@ unsigned char *read_watermark(const std::string &wmfile, int &nx, int &ny, int &
 
 static void tiffError(const char *module, const char *fmt, va_list argptr)
 {
+  // due to erroneous UTF8 sequences in fmt values
   if (std::string(module) == "TIFFSetField") return;
+  if (std::string(module) == "_TIFFSetField") return;
 
   log_err("ERROR IN TIFF! Module: %s", module);
   log_err(fmt, argptr);
@@ -392,6 +394,10 @@ static void tiffError(const char *module, const char *fmt, va_list argptr)
 
 static void tiffWarning(const char *module, const char *fmt, va_list argptr)
 {
+  // due to erroneous UTF8 sequences in fmt values
+  if (std::string(module) == "TIFFSetField") return;
+  if (std::string(module) == "_TIFFSetField") return;
+
   log_err("ERROR IN TIFF! Module: %s", module);
   log_err(fmt, argptr);
 }

--- a/src/formats/SipiIOTiff.cpp
+++ b/src/formats/SipiIOTiff.cpp
@@ -382,6 +382,8 @@ unsigned char *read_watermark(const std::string &wmfile, int &nx, int &ny, int &
 
 static void tiffError(const char *module, const char *fmt, va_list argptr)
 {
+  if (std::string(module) == "TIFFSetField") return;
+
   log_err("ERROR IN TIFF! Module: %s", module);
   log_err(fmt, argptr);
 }

--- a/src/formats/SipiIOTiff.cpp
+++ b/src/formats/SipiIOTiff.cpp
@@ -20,11 +20,11 @@
 
 #include "shttps/Connection.h"
 
+#include "Logger.h"
 #include "SipiError.hpp"
 #include "SipiImage.hpp"
 #include "SipiImageError.hpp"
 #include "formats/SipiIOTiff.h"
-#include "Logger.h"
 
 
 #include "shttps/Global.h"
@@ -380,26 +380,22 @@ unsigned char *read_watermark(const std::string &wmfile, int &nx, int &ny, int &
 //============================================================================
 
 
-static void tiffError(const char *module, const char *fmt, va_list argptr)
+static void tiffError(const char *module, const char *fmt, va_list args)
 {
-  // due to erroneous UTF8 sequences in fmt values
-  if (std::string(module) == "TIFFSetField") return;
-  if (std::string(module) == "_TIFFSetField") return;
+  // silenced due to erroneous UTF8 sequences in fmt values, leading to segfaults, perhaps fixable.
 
-  log_err("ERROR IN TIFF! Module: %s", module);
-  log_err(fmt, argptr);
+  /* log_err("ERROR IN TIFF! Module: %s", module); */
+  /* log_err(fmt, argptr); */
 }
 //============================================================================
 
 
-static void tiffWarning(const char *module, const char *fmt, va_list argptr)
+static void tiffWarning(const char *module, const char *fmt, va_list args)
 {
-  // due to erroneous UTF8 sequences in fmt values
-  if (std::string(module) == "TIFFSetField") return;
-  if (std::string(module) == "_TIFFSetField") return;
+  // silenced due to erroneous UTF8 sequences in fmt values, leading to segfaults, perhaps fixable.
 
-  log_err("ERROR IN TIFF! Module: %s", module);
-  log_err(fmt, argptr);
+  /* log_err("ERROR IN TIFF! Module: %s", module); */
+  /* log_err(fmt, argptr); */
 }
 //============================================================================
 
@@ -1726,4 +1722,4 @@ unsigned char *SipiIOTiff::cvrt8BitTo1bit(const SipiImage &img, unsigned int &sl
 }
 //============================================================================
 
-}
+}// namespace Sipi

--- a/src/sipi.cpp
+++ b/src/sipi.cpp
@@ -32,6 +32,7 @@
 
 
 #include "CLI11.hpp"
+#include "Logger.h"
 #include "SipiConf.h"
 #include "SipiFilenameHash.h"
 #include "SipiHttpServer.hpp"

--- a/src/sipi.cpp
+++ b/src/sipi.cpp
@@ -308,7 +308,7 @@ void sig_handler(const int sig)
 
   msg += "\n" + get_stack_trace();
   sentry_capture_event(sentry_value_new_message_event(SENTRY_LEVEL_FATAL, "sig_handler", msg.c_str()));
-  syslog(LOG_ERR, "%s", msg.c_str());
+  log_err("%s", msg.c_str());
   sentry_flush(2000);
 
   exit(1);
@@ -334,7 +334,7 @@ void my_terminate_handler()
 
   msg += "\n" + get_stack_trace();
   sentry_capture_event(sentry_value_new_message_event(SENTRY_LEVEL_FATAL, "my_terminate_handler", msg.c_str()));
-  syslog(LOG_ERR, "%s", msg.c_str());
+  log_err("%s", msg.c_str());
   sentry_flush(2000);
 
   std::abort();// Abort the program or perform other cleanup
@@ -841,14 +841,14 @@ int main(int argc, char *argv[])
       try {
         size = std::make_shared<Sipi::SipiSize>(optSize);
       } catch (std::exception &e) {
-        syslog(LOG_ERR, "Error in size parameter: %s", e.what());
+        log_err("Error in size parameter: %s", e.what());
         return EXIT_FAILURE;
       }
     } else if (!sipiopt.get_option("--scale")->empty()) {
       try {
         size = std::make_shared<Sipi::SipiSize>(optScale);
       } catch (std::exception &e) {
-        syslog(LOG_ERR, "Error in scale parameter: %s", e.what());
+        log_err("Error in scale parameter: %s", e.what());
         return EXIT_FAILURE;
       }
     }
@@ -1296,12 +1296,11 @@ int main(int argc, char *argv[])
 
 
       // TODO: At this point the config is loaded and we can initialize metrics
-      if (!optSipiSentryDsn.empty()) syslog(LOG_INFO, "SIPI_SENTRY_DSN: %s", optSipiSentryDsn.c_str());
+      if (!optSipiSentryDsn.empty()) log_info("SIPI_SENTRY_DSN: %s", optSipiSentryDsn.c_str());
 
-      if (!optSipiSentryEnvironment.empty())
-        syslog(LOG_INFO, "SIPI_SENTRY_ENVRONMENT: %s", optSipiSentryEnvironment.c_str());
+      if (!optSipiSentryEnvironment.empty()) log_info("SIPI_SENTRY_ENVRONMENT: %s", optSipiSentryEnvironment.c_str());
 
-      if (!optSipiSentryRelease.empty()) syslog(LOG_INFO, "SIPI_SENTRY_Release: %s", optSipiSentryRelease.c_str());
+      if (!optSipiSentryRelease.empty()) log_info("SIPI_SENTRY_Release: %s", optSipiSentryRelease.c_str());
 
       // Create object SipiHttpServer
       auto nthreads = sipiConf.getNThreads();
@@ -1310,9 +1309,9 @@ int main(int argc, char *argv[])
         sipiConf.getPort(), nthreads, sipiConf.getUseridStr(), sipiConf.getLogfile(), sipiConf.getLoglevel());
 
       int old_ll = setlogmask(LOG_MASK(LOG_INFO));
-      syslog(LOG_INFO, "BUILD_TIMESTAMP: %s", BUILD_TIMESTAMP);
-      syslog(LOG_INFO, "BUILD_SCM_TAG: %s", BUILD_SCM_TAG);
-      syslog(LOG_INFO, "BUILD_SCM_REVISION: %s", BUILD_SCM_REVISION);
+      log_info("BUILD_TIMESTAMP: %s", BUILD_TIMESTAMP);
+      log_info("BUILD_SCM_TAG: %s", BUILD_SCM_TAG);
+      log_info("BUILD_SCM_REVISION: %s", BUILD_SCM_REVISION);
       setlogmask(old_ll);
 
       server.ssl_port(sipiConf.getSSLPort());// set the secure connection port (-1 means no ssl socket)
@@ -1372,7 +1371,7 @@ int main(int argc, char *argv[])
       // start the server
       server.run();
     } catch (shttps::Error &err) {
-      syslog(LOG_ERR, "Error starting server: %s", err.what());
+      log_err("Error starting server: %s", err.what());
       std::cerr << err << '\n';
     }
   }

--- a/test/unit/configuration/CMakeLists.txt
+++ b/test/unit/configuration/CMakeLists.txt
@@ -23,6 +23,7 @@ file(GLOB SRCS *.cpp)
 add_executable(${TEST_NAME}
         ${SRCS}
         ${PROJECT_SOURCE_DIR}/src/SipiConf.cpp ${PROJECT_SOURCE_DIR}/include/SipiConf.h
+        ${PROJECT_SOURCE_DIR}/src/Logger.cpp ${PROJECT_SOURCE_DIR}/include/Logger.h
         ${PROJECT_SOURCE_DIR}/src/SipiError.cpp
         ${PROJECT_SOURCE_DIR}/src/SipiError.hpp
         ${PROJECT_SOURCE_DIR}/shttps/Global.h

--- a/test/unit/sipiimage/CMakeLists.txt
+++ b/test/unit/sipiimage/CMakeLists.txt
@@ -67,6 +67,8 @@ add_executable(${TEST_NAME}
         ${PROJECT_SOURCE_DIR}/include/iiifparser/SipiSize.h
         ${PROJECT_SOURCE_DIR}/src/SipiCommon.cpp
         ${PROJECT_SOURCE_DIR}/include/SipiCommon.h
+        ${PROJECT_SOURCE_DIR}/src/Logger.cpp
+        ${PROJECT_SOURCE_DIR}/include/Logger.h
         ${PROJECT_SOURCE_DIR}/shttps/Global.h
         ${PROJECT_SOURCE_DIR}/shttps/Error.cpp
         ${PROJECT_SOURCE_DIR}/shttps/Error.h


### PR DESCRIPTION
Locally, sending stacktraces after segfaults (intentionally produced) won't work no matter white, despite Sentry being able to send messages. I'm willing to give this a try on the DEV environment as a last resort effort.

Replacing mostly automated with `sed -i '/);/ s:syslog(LOG_\([A-Z_]*\), *":log_\L\1(":' $(rg 'syslog\(.*LOG_' -l)`.