### PR TITLE
chore: add .claude/worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ icc.zip
 /coverage
 /coverage.info
 *.gcov
+
+# Claude Code
+.claude/worktrees/


### PR DESCRIPTION
## Summary
- Add `.claude/worktrees/` to `.gitignore` to prevent Claude Code managed worktrees from being tracked

Claude Code's built-in worktree support creates managed worktrees under `.claude/worktrees/`. These should not be committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)