### PR TITLE
ci: add Docker buildx layer caching and optimize build parallelism

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -33,7 +33,11 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-      - run: make docker-test-build-amd64 # two stage build, where test is run in the first stage
+      - name: Build and test Docker image
+        run: make docker-test-build-amd64
+        env:
+          DOCKER_CACHE_FROM: "--cache-from type=gha,scope=amd64,url=${{ env.ACTIONS_CACHE_URL }},token=${{ env.ACTIONS_RUNTIME_TOKEN }}"
+          DOCKER_CACHE_TO: "--cache-to type=gha,mode=max,scope=amd64,url=${{ env.ACTIONS_CACHE_URL }},token=${{ env.ACTIONS_RUNTIME_TOKEN }}"
       - run: make test-smoke-ci
       - name: Docker Scout — compare to production
         if: github.event_name == 'pull_request'
@@ -81,7 +85,11 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-      - run: make docker-test-build-arm64 # two stage build, where test is run in the first stage
+      - name: Build and test Docker image
+        run: make docker-test-build-arm64
+        env:
+          DOCKER_CACHE_FROM: "--cache-from type=gha,scope=arm64,url=${{ env.ACTIONS_CACHE_URL }},token=${{ env.ACTIONS_RUNTIME_TOKEN }}"
+          DOCKER_CACHE_TO: "--cache-to type=gha,mode=max,scope=arm64,url=${{ env.ACTIONS_CACHE_URL }},token=${{ env.ACTIONS_RUNTIME_TOKEN }}"
       - run: make test-smoke-ci
       - name: Docker Scout — compare to production
         if: github.event_name == 'pull_request'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,11 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-      - run: make docker-test-build-amd64 # builds image + extracts sipi-amd64.debug
+      - name: Build and test Docker image
+        run: make docker-test-build-amd64
+        env:
+          DOCKER_CACHE_FROM: "--cache-from type=gha,scope=publish-amd64,url=${{ env.ACTIONS_CACHE_URL }},token=${{ env.ACTIONS_RUNTIME_TOKEN }}"
+          DOCKER_CACHE_TO: "--cache-to type=gha,mode=max,scope=publish-amd64,url=${{ env.ACTIONS_CACHE_URL }},token=${{ env.ACTIONS_RUNTIME_TOKEN }}"
       - run: make test-smoke-ci
       - name: Push image to Docker hub
         run: make docker-push-amd64
@@ -82,7 +86,11 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-      - run: make docker-test-build-arm64 # builds image + extracts sipi-arm64.debug
+      - name: Build and test Docker image
+        run: make docker-test-build-arm64
+        env:
+          DOCKER_CACHE_FROM: "--cache-from type=gha,scope=publish-arm64,url=${{ env.ACTIONS_CACHE_URL }},token=${{ env.ACTIONS_RUNTIME_TOKEN }}"
+          DOCKER_CACHE_TO: "--cache-to type=gha,mode=max,scope=publish-arm64,url=${{ env.ACTIONS_CACHE_URL }},token=${{ env.ACTIONS_RUNTIME_TOKEN }}"
       - run: make test-smoke-ci
       - name: Push image to Docker hub
         run: make docker-push-arm64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
           nix \
             --extra-experimental-features "nix-command flakes" \
             --option filter-syscalls false \
-            develop --command bash -c "cmake -S . -B ./build -DCODE_COVERAGE=ON -DCMAKE_BUILD_TYPE=Debug --log-context && cmake --build ./build --parallel 4 && cd build && ctest --output-on-failure"
+            develop --command bash -c "cmake -S . -B ./build -DCODE_COVERAGE=ON -DCMAKE_BUILD_TYPE=Debug --log-context && cmake --build ./build --parallel \$(nproc) && cd build && ctest --output-on-failure"
       - name: Gather code coverage
         if: ${{ matrix.runs-on == 'ubuntu-24.04' }}
         run: |


### PR DESCRIPTION
## Summary

- **Add GitHub Actions cache** (`type=gha`) for Docker buildx builds — currently zero caching is configured, so every CI build starts from scratch (~12 min)
- **Split `COPY . .`** in Dockerfile into targeted directory copies so changes to docs, CI configs, Makefile, etc. don't invalidate build layers
- **Replace `--parallel 4`** with `$(nproc)` everywhere (Dockerfile, Makefile, test.yml) to use all available cores

## Details

### Caching mechanism
Configurable Makefile variables (`DOCKER_CACHE_FROM`, `DOCKER_CACHE_TO`) that default to empty for local builds. CI workflows pass `--cache-from type=gha,scope=<arch>` and `--cache-to type=gha,mode=max,scope=<arch>` via environment variables. The `mode=max` option caches all intermediate layers, not just the final image.

### Expected impact
- **Cache HIT** (no source changes): ~1-2 min vs ~12 min today
- **Partial HIT** (only source changes): faster due to cached base layers
- **Cache MISS** (first run): ~12 min (same as today, but populates cache)

### Files changed
- `Dockerfile` — syntax `1.3` → `1`, split COPY, `$(nproc)`
- `Makefile` — cache vars + all buildx commands, native build parallelism
- `.github/workflows/docker-build.yml` — GHA cache env vars for amd64/arm64
- `.github/workflows/publish.yml` — GHA cache env vars for amd64/arm64
- `.github/workflows/test.yml` — `--parallel $(nproc)`

## Test plan
- [ ] CI passes on first run (cache miss — same duration as before)
- [ ] Verify GHA cache entries created (Settings → Actions → Caches)
- [ ] Re-run CI to verify cache hit reduces build time
- [ ] `make docker-build` works locally unchanged (no cache flags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)