### PR TITLE
Remove release flag from Sentry debug files upload

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,7 +56,6 @@ jobs:
           sentry-cli debug-files upload \
             --org "$SENTRY_ORG" \
             --project "$SENTRY_PROJECT" \
-            --release "$GITHUB_REF_NAME" \
             sipi-amd64.debug
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -114,7 +113,6 @@ jobs:
           sentry-cli debug-files upload \
             --org "$SENTRY_ORG" \
             --project "$SENTRY_PROJECT" \
-            --release "$GITHUB_REF_NAME" \
             sipi-arm64.debug
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}


### PR DESCRIPTION
'## Summary
- Remove the invalid `--release` flag from `sentry-cli debug-files upload` in both amd64 and arm64 publish jobs
- `sentry-cli debug-files upload` does not support `--release`; debug files are matched to crash events via build IDs embedded in the binary, not release versions ([sentry-cli#444](https://github.com/getsentry/sentry-cli/issues/444))
- This was causing the upload steps to fail immediately with an unknown argument error, resulting in no debug symbols being uploaded to Sentry

## Test plan
- [ ] Merge and create a new tag to trigger the publish workflow
- [ ] Verify the "Upload debug symbols to Sentry" steps succeed (no longer exit instantly)
- [ ] Confirm debug symbols appear in Sentry under the project's debug files'