### PR TITLE
ci: remove LFS pre-push hook in docs deploy job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -367,6 +367,8 @@ jobs:
     needs: [release-gate]
     steps:
       - uses: actions/checkout@v4
+      - name: Remove LFS hooks (not needed for docs deploy)
+        run: rm -f .git/hooks/pre-push
       - uses: mhausenblas/mkdocs-deploy-gh-pages@master
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Motivation
The docs job in the publish workflow failed during the v3.18.0 release.
The `mkdocs-deploy-gh-pages` action runs inside a Docker container that
does not have `git-lfs` installed, so the LFS `pre-push` hook causes
`mkdocs gh-deploy` to fail when pushing to `gh-pages`.

## Summary
- Remove the LFS `pre-push` hook after checkout in the docs deploy job

## Key Changes
### Publish workflow
- Added a step to `rm -f .git/hooks/pre-push` before the mkdocs deploy action runs

## Challenges and Decisions
### LFS hook inside third-party Docker container
**Problem:** `mhausenblas/mkdocs-deploy-gh-pages` mounts the workspace
(including `.git/hooks/`) into its own Docker container. That container
has no `git-lfs` binary, so the pre-push hook fails with
`git-lfs was not found on your path`.

**Tried:** `git lfs uninstall --skip-repo` on the runner — but the hook
is already written to `.git/hooks/` by checkout, and it gets mounted
into the container regardless of the runner's git config.

**Solution:** Delete `.git/hooks/pre-push` directly. The docs job only
builds markdown and pushes HTML to `gh-pages` — no LFS objects are needed.

## Gotchas
- Any workflow step that uses a third-party Docker action after checkout
  will inherit the repo's git hooks. If the container lacks `git-lfs`,
  LFS hooks will fail silently or loudly depending on the hook type.

## Test Plan
- [ ] Merge and re-run the failed v3.18.0 publish workflow, or verify on next release