### PR TITLE
docs: add missing pages to mkdocs nav configuration

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -7,6 +7,7 @@ edit_uri: blob/main/docs/
 copyright: "&copy; 2017 - 2026 <a href='https://dasch.swiss' target='_blank'>Data and Service Center for the Humanities (DaSCH)</a>"
 
 nav:
+  - Home: index.md
   - Overview: guide/index.md
   - Introduction: guide/introduction.md
   - Reference: guide/sipi.md
@@ -19,6 +20,7 @@ nav:
   - Developing: development/developing.md
   - Downstream Dependencies: development/downstream-dependencies.md
   - Commit and PR Conventions: development/commit-conventions.md
+  - Reviewer Guidelines: development/reviewer-guidelines.md
   - Release Notes: release-notes/index.md
 
 theme:
@@ -76,5 +78,6 @@ plugins:
           - development/developing.md: "Development guide"
           - development/downstream-dependencies.md: "Runtime packages and downstream consumers"
           - development/commit-conventions.md: "Commit organization and PR description conventions"
+          - development/reviewer-guidelines.md: "Code review checklist for human and AI reviewers"
         "Release Notes":
           - release-notes/index.md

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -28,3 +28,8 @@ Welcome to the documentation for **SIPI** (Simple Image Presentation Interface).
 ## Release Notes
 
 - **[Release Notes](release-notes/index.md)** — Version history
+
+## For LLMs
+
+- **[llms.txt](llms.txt)** — Summary for LLMs
+- **[llms-full.txt](llms-full.txt)** — Full documentation for LLMs


### PR DESCRIPTION
## Motivation
mkdocs warns about pages that exist in `docs/src/` but are not listed
in the `nav` configuration. This means those pages are built but not
reachable from the site navigation.

## Summary
- Add `index.md` (landing page) and `development/reviewer-guidelines.md` to the nav
- Add `reviewer-guidelines.md` to the llmstxt plugin sections

## Key Changes
### mkdocs.yml
- Added `Home: index.md` as the first nav entry
- Added `Reviewer Guidelines: development/reviewer-guidelines.md` to the development section
- Added reviewer-guidelines to the llmstxt Development section

## Test Plan
- [ ] `mkdocs build` produces no nav warnings
- [ ] Both pages are reachable from the site navigation