### PR TITLE
fix: support 1-bit TIFF, broaden JPEG handling, add --json CLI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -479,6 +479,7 @@ add_executable(sipi
         ${PROJECT_SOURCE_DIR}/src/SipiImage.cpp
         ${PROJECT_SOURCE_DIR}/src/SipiImage.hpp
         ${PROJECT_SOURCE_DIR}/src/SipiImageError.hpp
+        ${PROJECT_SOURCE_DIR}/src/SipiReport.cpp ${PROJECT_SOURCE_DIR}/include/SipiReport.h
         ${PROJECT_SOURCE_DIR}/src/formats/SipiIOTiff.cpp ${PROJECT_SOURCE_DIR}/include/formats/SipiIOTiff.h
         ${PROJECT_SOURCE_DIR}/src/formats/SipiIOJ2k.cpp ${PROJECT_SOURCE_DIR}/include/formats/SipiIOJ2k.h
         ${PROJECT_SOURCE_DIR}/src/formats/SipiIOJpeg.cpp ${PROJECT_SOURCE_DIR}/include/formats/SipiIOJpeg.h

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
   - Overview: guide/index.md
   - Introduction: guide/introduction.md
   - Reference: guide/sipi.md
+  - JSON Output: guide/json-output.md
   - Running: guide/running.md
   - Lua Integration: lua/index.md
   - Lua Image Functions: lua/lua-image.md
@@ -73,6 +74,7 @@ plugins:
           - guide/introduction.md: "IIIF concepts and SIPI use cases"
           - guide/running.md: "CLI usage, server mode, logging, error codes"
           - guide/sipi.md: "IIIF URL syntax, configuration reference"
+          - guide/json-output.md: "Structured JSON CLI output schema (--json)"
         "Lua Scripting":
           - lua/index.md: "Lua integration and server API"
           - lua/lua-image.md: "Lua image manipulation functions"

--- a/docs/src/development/testing-strategy.md
+++ b/docs/src/development/testing-strategy.md
@@ -632,7 +632,12 @@ The following matrix maps every testable IIIF spec requirement to its test statu
 | 16-bit depth through IIIF pipeline | :x: GAP | — | Unit-tested, not HTTP-level |
 | Progressive JPEG handling | :x: GAP | — | Common in web content, untested |
 | TIFF with JPEG compression | :x: GAP | — | Known bug (YCrCb autoconvert) |
-| 1-bit TIFF (bi-level) | :x: GAP | — | May fail on color conversion |
+| 1-bit TIFF (bi-level) | :white_check_mark: | unit + rust-e2e | MINISWHITE and MINISBLACK, LZW and uncompressed (DEV-6249) |
+| JPEG YCCK colorspace | :white_check_mark: | unit | Was throw; now decoded via CMYK path (DEV-6250) |
+| JPEG CMYK with APP14 (Photoshop) — inverted before ICC | :white_check_mark: | unit | DEV-6257 |
+| JPEG CMYK without APP14 (raw) — not inverted | :white_check_mark: | unit | DEV-6257 negative case |
+| JPEG with APP13 before APP1 + non-ASCII IPTC | :white_check_mark: | unit | Heritage collection regression (DEV-6250) |
+| CLI `--json` output contract | :white_check_mark: | unit + rust-e2e | success + error payloads, single-document stdout |
 | Watermark application via HTTP | :x: GAP | — | Unit-tested, not e2e |
 | Restrict + watermark combined | :x: GAP | — | Untested combination |
 | Watermark cache key separation | :x: GAP | — | Separate entries untested |
@@ -675,7 +680,7 @@ The following matrix maps every testable IIIF spec requirement to its test statu
 - **Configuration** (6 gaps): parseSizeString, deprecated keys, CLI overrides, jwt_secret, invalid Lua, nonexistent paths
 - **Lua API** (5 gaps): SImage methods, JWT round-trip, UUID round-trip, HTTP client, error propagation
 - **Connection handling** (5 gaps): keep-alive, chunked, Connection: close, thread pool, graceful shutdown
-- **Format edge cases** (6 gaps): CMYK/CIELab/16-bit through IIIF, progressive JPEG, TIFF-JPEG, 1-bit TIFF
+- **Format edge cases** (5 gaps): CMYK/CIELab/16-bit through IIIF, progressive JPEG, TIFF-JPEG. *Previously listed 1-bit TIFF and YCCK-JPEG; both resolved by DEV-6249 / DEV-6250 / DEV-6257.*
 - **Concurrency** (4 gaps): cache writes, eviction during read, parallel uploads, Lua state isolation
 - **Resource limits** (4 gaps): cache disabled, LRU purge, nfiles limit, keep-alive timeout
 - **Memory/OOM** (5 gaps): sustained load, concurrent decode, accounting, buffers, cache relief — **active production issue**

--- a/docs/src/guide/json-output.md
+++ b/docs/src/guide/json-output.md
@@ -1,0 +1,177 @@
+# Structured JSON Output (`--json`)
+
+When the `--json` flag is set on a CLI invocation (`sipi --json --file
+<input> --outf <output>`) sipi emits a single JSON document to `stdout`
+instead of human-readable text. The document mirrors the internal
+`ImageContext` that sipi otherwise sends to Sentry, so every CLI run —
+success or failure — yields the same structured payload a Sentry event
+would.
+
+This page is the reference for the schema, the emission rules, and the
+exit-code / stream contract.
+
+## Contract
+
+- `stdout` contains **exactly one** JSON document terminated by a
+  trailing newline. Nothing precedes the opening `{` and nothing
+  follows the matching `}`.
+- `stderr` carries every log line (info, warning, and error). This is a
+  change from the default CLI log routing, where info/warn go to
+  `stdout`.
+- Exit codes are unchanged: `0` on success, non-zero on failure.
+- The flag is CLI-only: passing `--json` together with `--config`
+  (server mode) is silently ignored. Server-mode errors continue to go
+  through Sentry and HTTP responses.
+- `--json` is mutually exclusive with `--salsah` and `--query` at CLI
+  parse time (both also write to `stdout` in incompatible ways).
+- The schema is **not versioned** today — there is a single consumer
+  (local debugging / ad-hoc integrations) and the cost of adding a
+  `schema_version` field exceeds its value while there is only one
+  version. Future changes are additive and documented on this page.
+
+## Success payload
+
+Emitted when the conversion completes successfully.
+
+```json
+{
+  "status": "ok",
+  "mode": "cli",
+  "input_file": "/path/to/input.jpg",
+  "output_file": "/tmp/out.jp2",
+  "output_format": "jpx",
+  "file_size_bytes": 26688,
+  "image": {
+    "width": 404,
+    "height": 201,
+    "channels": 3,
+    "bps": 8,
+    "colorspace": "RGB",
+    "icc_profile_type": "sRGB",
+    "orientation": "TOPLEFT"
+  }
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `status` | string | Always `"ok"` on the success payload. |
+| `mode` | string | Always `"cli"`. |
+| `input_file` | string | Absolute path to the source image. |
+| `output_file` | string | Absolute path to the produced output file. |
+| `output_format` | string | Output format (`"jpx"`, `"tif"`, `"jpg"`, `"png"`). |
+| `file_size_bytes` | integer | Size of the source image in bytes. |
+| `image` | object | Decoded image properties (see below). |
+| `image.width` | integer | Width in pixels. |
+| `image.height` | integer | Height in pixels. |
+| `image.channels` | integer | Samples per pixel (e.g. 3 for RGB, 4 for CMYK/RGBA). |
+| `image.bps` | integer | Bits per sample (8 or 16). |
+| `image.colorspace` | string | Photometric interpretation: `MINISBLACK`, `MINISWHITE`, `RGB`, `YCBCR`, `SEPARATED`, etc. |
+| `image.icc_profile_type` | string | Well-known profile name (`sRGB`, `AdobeRGB`, `CMYK (USWebCoatedSWOP)`, `Gray D50`, …) or `"unknown/embedded"` for arbitrary ICC buffers. |
+| `image.orientation` | string | TIFF orientation tag value (e.g. `TOPLEFT`). |
+
+## Error payload
+
+Emitted when any phase of the conversion fails.
+
+```json
+{
+  "status": "error",
+  "mode": "cli",
+  "phase": "read",
+  "error_message": "Images with 1 bit/sample not supported in file ...",
+  "input_file": "/path/to/bilevel.tif",
+  "output_file": "/tmp/out.jp2",
+  "output_format": "jpx",
+  "file_size_bytes": 4768164,
+  "image": {
+    "width": 8040,
+    "height": 9624,
+    "channels": 1,
+    "bps": 1,
+    "colorspace": "MINISWHITE",
+    "icc_profile_type": "",
+    "orientation": "TOPLEFT"
+  }
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `status` | string | Always `"error"` on the error payload. |
+| `phase` | string | `"cli_args"`, `"read"`, `"convert"`, or `"write"` (in order of when they can fire). |
+| `error_message` | string | The message from the thrown exception (or the parameter validation failure). |
+| `image` | object, optional | Populated with whatever `ImageContext` captured before the failure point; **omitted entirely** when `phase == "cli_args"` because no image was loaded. |
+
+### Phase semantics
+
+| Phase | Meaning |
+|---|---|
+| `cli_args` | Failure during CLI argument validation — invalid `--size` / `--scale` syntax, unknown output extension. Fires before any image is loaded; the `image` object is omitted. |
+| `read` | Failure while decoding the input file (corrupt JPEG, unsupported TIFF variant, I/O error). The `image` object reflects any properties parsed from the header before the failure. |
+| `convert` | Failure during the intermediate processing pipeline — orientation, ICC conversion, rotation, watermarking. The `image` object reflects the fully-decoded input image. |
+| `write` | Failure while encoding or writing the output file (format-specific encoder errors, disk full). |
+
+### Reserved fields
+
+`request_uri` is part of the internal `ImageContext` struct (it is populated
+during HTTP request handling) but is **intentionally omitted** from the CLI
+`--json` output. It is reserved for potential future server-side use of this
+emitter.
+
+## Worked examples
+
+### Success — convert a JPEG to JPEG 2000
+
+```console
+$ sipi --json --file input.jpg out.jp2 2>/dev/null | jq
+{
+  "status": "ok",
+  "mode": "cli",
+  "input_file": "input.jpg",
+  "output_file": "out.jp2",
+  "output_format": "jpx",
+  "file_size_bytes": 26688,
+  "image": {
+    "width": 404,
+    "height": 201,
+    "channels": 3,
+    "bps": 8,
+    "colorspace": "RGB",
+    "icc_profile_type": "sRGB",
+    "orientation": "TOPLEFT"
+  }
+}
+```
+
+### `cli_args` error — invalid `--scale`
+
+```console
+$ sipi --json --file input.jpg out.jp2 --scale bogus 2>/dev/null | jq
+{
+  "status": "error",
+  "mode": "cli",
+  "phase": "cli_args",
+  "error_message": "Error in scale parameter: ...",
+  "input_file": "",
+  "output_file": "",
+  "output_format": "",
+  "file_size_bytes": 0
+}
+```
+
+Note the absence of `image`.
+
+### Shell pipeline
+
+The structured output is shell-pipeable because log chatter is kept out
+of `stdout`:
+
+```bash
+if sipi --json --file input.jpg out.jp2 2>sipi.log | jq -e '.status == "ok"' >/dev/null; then
+  echo "conversion succeeded"
+else
+  echo "conversion failed — see sipi.log"
+  cat sipi.log
+fi
+```

--- a/docs/src/guide/running.md
+++ b/docs/src/guide/running.md
@@ -40,7 +40,10 @@ SIPI uses two logging modes depending on how it is running:
 
 - **CLI mode** (`--file`, `--compare`, `--query`): Plain text output.
   Errors go to **stderr**, informational messages go to **stdout**.
-  This is the standard Unix convention for command-line tools.
+  This is the standard Unix convention for command-line tools. When
+  `--json` is also set (see [Structured JSON output](#structured-json-output-cli)),
+  every level is routed to **stderr** so `stdout` stays reserved for the
+  single JSON document.
 
 - **Server mode** (`--config`): JSON-formatted log lines go to **stdout**.
   This follows container best practices — Docker, Kubernetes, and log
@@ -102,6 +105,24 @@ If none is specified, the default level is `INFO`.
 |------|-------|-------------|
 | `--query` | `-x` | Dump all information about the given file |
 | `--compare <f1> <f2>` | `-C` | Compare two files pixel-wise |
+
+### Structured JSON output (CLI)
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Emit a single JSON document to `stdout` instead of human-readable output. Useful for programmatic consumers and for local debugging when no Sentry DSN is configured. Mutually exclusive with `--salsah` and `--query`; silently ignored with `--config` (server mode). |
+
+Use cases:
+
+- **Local debugging with no Sentry DSN** — the primary RDU case. Every
+  `ImageContext` field normally sent to Sentry appears in the JSON
+  document instead.
+- **CI pipelines** that need to assert on image properties
+  (`jq '.image.bps'`) or on a specific failure mode (`jq '.phase'`).
+- **Scripts** that consume sipi output pipeline-style.
+
+See [`json-output.md`](json-output.md) for the full schema, worked
+examples, and the `stdout` / `stderr` contract.
 
 ### JPEG2000 Options
 
@@ -234,7 +255,7 @@ Error <phase> image: <details>
 Where `<phase>` is one of `reading`, `converting`, or `writing`. Example:
 
 ```
-Error reading image: Unsupported JPEG colorspace YCCK (file=input.jpg, dimensions=2048x1536, components=4)
+Error reading image: Unsupported JPEG colorspace JCS_UNKNOWN (file=input.jpg, dimensions=2048x1536, components=4)
 ```
 
 ### Sentry Integration (CLI Mode)
@@ -266,7 +287,7 @@ Each Sentry event includes:
 
 | Error | Meaning |
 | ----- | ------- |
-| Unsupported colorspace (YCCK, unknown) | The JPEG uses a colorspace SIPI cannot convert. Re-encode the source image in sRGB. |
+| Unsupported colorspace (JCS_UNKNOWN) | The JPEG uses a colorspace SIPI cannot convert. Re-encode the source image in sRGB. |
 | Unsupported bits/sample | Only 8 and 16 bits/sample are supported. Images with other bit depths must be converted first. |
 | Channel/colorspace mismatch | The number of channels does not match the declared colorspace (e.g., 4 channels but RGB). The file metadata may be corrupt. |
 | ICC profile incompatible | The ICC profile does not match the channel count (e.g., CMYK profile on a 3-channel image). |

--- a/docs/src/guide/sipi.md
+++ b/docs/src/guide/sipi.md
@@ -105,6 +105,16 @@ In command line mode, SIPI supports the following options:
 - `-w <filepath>`, `--watermark <filepath>`: Overlays a watermark to the output image. <filepath> must be a single
   channel, gray valued TIFF. That is, the TIFF file must have the following tag values: SAMPLESPERPIXEL = 1,
   BITSPERSAMPLE = 8, PHOTOMETRIC = PHOTOMETRIC_MINISBLACK.
+- `--json`: Emit a single structured JSON document to stdout instead of human-readable output. The document mirrors
+  the internal `ImageContext` that is otherwise sent to Sentry and includes the input/output paths, the decoded image
+  properties, and — on failure — a `phase` (`cli_args` | `read` | `convert` | `write`) with the `error_message`.
+  Useful for programmatic consumers and for debugging when no Sentry DSN is configured. Stderr carries any log output
+  so stdout stays reserved for the single JSON document. CLI-only: has no effect with `--config` (server mode).
+  Mutually exclusive with `--salsah` and `--query`. See [`json-output.md`](json-output.md) for the full schema and
+  worked examples. Example:
+  ```bash
+  sipi --json --file input.jpg out.jp2 | jq '.image.bps'
+  ```
   
 #### JPEG2000 Specific Options
 Usually, the SIPI command line tool is used to create JPEG2000 images suitable for a IIIF repository. SIPI supports

--- a/include/Logger.h
+++ b/include/Logger.h
@@ -18,4 +18,15 @@ bool is_cli_mode();
 void set_log_level(LogLevel level);
 LogLevel get_log_level();
 
+/*!
+ * Enable JSON-output mode. When true, every log level (info, warn, err) is
+ * routed to stderr so that stdout stays reserved for the single JSON document
+ * produced by `--json`. Backed by `std::atomic<bool>`: writers use
+ * `memory_order_relaxed` since the flag is set once at CLI startup
+ * (immediately after CLI11 parses `--json`) and never re-set, and readers
+ * only need to observe the value published by that single store.
+ */
+void set_json_mode(bool enabled);
+bool is_json_mode();
+
 #endif

--- a/include/SipiReport.h
+++ b/include/SipiReport.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2016 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+ * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#ifndef SIPIREPORT_H
+#define SIPIREPORT_H
+
+#include <optional>
+#include <ostream>
+#include <string>
+
+#include "SipiSentry.h"
+
+namespace Sipi {
+
+/*!
+ * Emit a structured JSON report mirroring the Sentry ImageContext to the given
+ * output stream. Used by the `--json` CLI flag so that environments without a
+ * Sentry DSN still get the full diagnostic payload.
+ *
+ * The produced document is a single JSON object terminated by a trailing
+ * newline. The schema matches the ImageContext struct in SipiSentry.h, minus
+ * `request_uri` (reserved for future server-side use).
+ *
+ * On success (no error_message / no phase): `status == "ok"` and the `image`
+ * object is populated from the ImageContext.
+ *
+ * On error (`error_message` set): `status == "error"`, `phase` (if supplied)
+ * and `error_message` are emitted. If `phase == "cli_args"` the `image`
+ * object is omitted entirely (no image was loaded); otherwise the `image`
+ * object is still emitted and contains whatever the ImageContext captured
+ * before the failure point.
+ *
+ * \param[out] out             Output stream (typically std::cout)
+ * \param[in]  ctx             Image context with metadata about the image
+ * \param[in]  error_message   If present, renders the document as an error
+ * \param[in]  phase           "cli_args" | "read" | "convert" | "write"
+ */
+void emit_json_report(std::ostream &out,
+  const ImageContext &ctx,
+  std::optional<std::string> error_message = std::nullopt,
+  std::optional<std::string> phase = std::nullopt);
+
+/*!
+ * Emit a minimal `phase: "cli_args"` error JSON for CLI argument validation
+ * failures that fire before any image is loaded. The `image` object is
+ * omitted entirely because no image processing was attempted.
+ *
+ * \param[out] out  Output stream (typically std::cout)
+ * \param[in]  err  Error message describing the argument failure
+ */
+void emit_json_cli_arg_error(std::ostream &out, const std::string &err);
+
+}// namespace Sipi
+
+#endif// SIPIREPORT_H

--- a/include/formats/SipiIOTiff.h
+++ b/include/formats/SipiIOTiff.h
@@ -62,16 +62,6 @@ private:
   void separateToContig(SipiImage *img, unsigned int sll);
 
   /*!
-   * Converts a bitonal 1 bit image to a bitonal 8 bit image
-   *
-   * \param img Pointer to SipiImage instance
-   * \param[in] Length of scanline in bytes
-   * \param[in] Value to be used for black pixels
-   * \param[in] Value to be used for white pixels
-   */
-  void cvrt1BitTo8Bit(SipiImage *img, unsigned int sll, unsigned int black, unsigned int white);
-
-  /*!
    * Converts a 8 bps bitonal image to 1 bps bitonal image
    *
    * \param[in] img Reference to SipiImage instance

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -1,3 +1,4 @@
+#include <atomic>
 #include <cstdarg>
 #include <cstdio>
 #include <cstring>
@@ -10,12 +11,20 @@
 #include "Logger.h"
 
 static bool g_cli_mode = false;
+// `g_json_mode` is read from every request worker thread in server mode and
+// from the main thread in CLI mode. It is set once at startup (before any
+// threads exist) and never re-set, so `memory_order_relaxed` is sufficient
+// — but using `std::atomic` rather than a plain bool makes the code
+// formally data-race-free per the C++ memory model.
+static std::atomic<bool> g_json_mode{ false };
 static LogLevel g_log_level = LL_INFO;
 
 void set_cli_mode(bool cli) { g_cli_mode = cli; }
 bool is_cli_mode() { return g_cli_mode; }
 void set_log_level(LogLevel level) { g_log_level = level; }
 LogLevel get_log_level() { return g_log_level; }
+void set_json_mode(bool enabled) { g_json_mode.store(enabled, std::memory_order_relaxed); }
+bool is_json_mode() { return g_json_mode.load(std::memory_order_relaxed); }
 
 std::string escape_json_str(const std::string &s)
 {
@@ -128,9 +137,11 @@ void log_vformat(LogLevel ll, const char *message, va_list args)
   if (ll < g_log_level) return;
 
   if (g_cli_mode) {
-    // CLI mode: plain text, errors→stderr, others→stdout
+    // CLI mode: plain text. Under --json every level goes to stderr so stdout
+    // stays reserved for the single JSON document. Outside --json,
+    // errors→stderr, others→stdout (legacy behaviour).
     std::string msg = vformat(message, args);
-    if (ll >= LL_ERR) {
+    if (g_json_mode.load(std::memory_order_relaxed) || ll >= LL_ERR) {
       fprintf(stderr, "%s\n", msg.c_str());
     } else {
       fprintf(stdout, "%s\n", msg.c_str());

--- a/src/SipiImage.cpp
+++ b/src/SipiImage.cpp
@@ -96,6 +96,7 @@ SipiImage::SipiImage(const SipiImage &img_p)
   emdata = img_p.emdata;
   skip_metadata = img_p.skip_metadata;
   conobj = img_p.conobj;
+  app14_transform = img_p.app14_transform;
 }
 
 //============================================================================
@@ -106,12 +107,13 @@ SipiImage::SipiImage(SipiImage &&other) noexcept
     pixels(other.pixels), xmp(std::move(other.xmp)), icc(std::move(other.icc)),
     iptc(std::move(other.iptc)), exif(std::move(other.exif)),
     emdata(std::move(other.emdata)), conobj(other.conobj),
-    skip_metadata(other.skip_metadata)
+    skip_metadata(other.skip_metadata), app14_transform(other.app14_transform)
 {
   other.pixels = nullptr;
   other.nx = 0;
   other.ny = 0;
   other.conobj = nullptr;
+  other.app14_transform = 255;
 }
 
 //============================================================================
@@ -186,6 +188,7 @@ SipiImage &SipiImage::operator=(const SipiImage &img_p)
     emdata = img_p.emdata;    // BUG FIX: missing in original operator=
     skip_metadata = img_p.skip_metadata;
     conobj = img_p.conobj;
+    app14_transform = img_p.app14_transform;
 
     size_t bufsiz;
 
@@ -242,11 +245,13 @@ SipiImage &SipiImage::operator=(SipiImage &&other) noexcept
     emdata = std::move(other.emdata);
     skip_metadata = other.skip_metadata;
     conobj = other.conobj;
+    app14_transform = other.app14_transform;
 
     other.pixels = nullptr;
     other.nx = 0;
     other.ny = 0;
     other.conobj = nullptr;
+    other.app14_transform = 255;
   }
   return *this;
 }

--- a/src/SipiImage.hpp
+++ b/src/SipiImage.hpp
@@ -148,6 +148,19 @@ protected:
   shttps::Connection *conobj;//!< Pointer to HTTP connection
   SkipMetadata skip_metadata;//!< If true, all metadata is stripped off
 
+  /*!
+   * Adobe APP14 JPEG marker transform flag. Encodes the Photoshop "Unknown"
+   * convention for CMYK/YCCK polarity:
+   *   255 = no APP14 marker present (default; raw CMYK or non-JPEG formats)
+   *     0 = Adobe "Unknown / CMYK" — when nc==4, libjpeg-turbo produces
+   *         inverted CMYK that SipiIOJpeg re-inverts before ICC conversion
+   *     1 = YCbCr (converted to RGB by libjpeg-turbo — no inversion)
+   *     2 = YCCK (libjpeg-turbo produces inverted CMYK that must be re-inverted)
+   * Only read/written by the JPEG handler; default-initialized to 255 so all
+   * non-JPEG paths treat images as "no APP14" and skip the inversion branch.
+   */
+  uint8_t app14_transform = 255;
+
 public:
   //
   /*!
@@ -220,6 +233,12 @@ public:
    * \return ICC profile, or nullptr if not set
    */
   [[nodiscard]] std::shared_ptr<SipiIcc> getIcc() const { return icc; }
+
+  /**
+   * Get the XMP metadata of the image.
+   * \return XMP metadata, or nullptr if not set
+   */
+  [[nodiscard]] std::shared_ptr<SipiXmp> getXmp() const { return xmp; }
 
   /*!
    * Get orientation

--- a/src/SipiReport.cpp
+++ b/src/SipiReport.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2016 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+ * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "SipiReport.h"
+
+#include <jansson.h>
+
+#include <cstdlib>
+#include <memory>
+#include <string>
+
+namespace Sipi {
+
+namespace {
+
+/*! RAII wrapper for the reference-counted jansson value root. */
+using JsonPtr = std::unique_ptr<json_t, decltype(&json_decref)>;
+
+/*! RAII wrapper for malloc'd strings returned by `json_dumps`. */
+using JsonStr = std::unique_ptr<char, decltype(&std::free)>;
+
+/*! Build the nested `image` object from an ImageContext. Ownership is
+ * transferred to the caller via a new reference; the caller is expected
+ * to pass the returned pointer to `json_pack` with the `o` format
+ * (which steals the reference) or wrap it in a JsonPtr. */
+json_t *build_image_object(const ImageContext &ctx)
+{
+  return json_pack("{s:I, s:I, s:I, s:I, s:s, s:s, s:s}",
+    "width",
+    static_cast<json_int_t>(ctx.width),
+    "height",
+    static_cast<json_int_t>(ctx.height),
+    "channels",
+    static_cast<json_int_t>(ctx.channels),
+    "bps",
+    static_cast<json_int_t>(ctx.bps),
+    "colorspace",
+    ctx.colorspace.c_str(),
+    "icc_profile_type",
+    ctx.icc_profile_type.c_str(),
+    "orientation",
+    ctx.orientation.c_str());
+}
+
+}// namespace
+
+void emit_json_report(std::ostream &out,
+  const ImageContext &ctx,
+  std::optional<std::string> error_message,
+  std::optional<std::string> phase)
+{
+  const bool is_error = error_message.has_value();
+  const bool omit_image = phase.has_value() && *phase == "cli_args";
+
+  JsonPtr root{ nullptr, &json_decref };
+  if (!is_error) {
+    // Success payload. Always has an `image` object. json_pack with `o`
+    // steals the reference to `image`, but only on success — guard against
+    // jansson allocation failure by wrapping `image` in a JsonPtr until
+    // ownership transfer is confirmed.
+    JsonPtr image{ build_image_object(ctx), &json_decref };
+    if (image == nullptr) {
+      out << "{\"status\": \"error\", \"mode\": \"cli\", \"phase\": \"internal\", "
+          << "\"error_message\": \"SipiReport: failed to build image object\"}\n";
+      return;
+    }
+    root.reset(json_pack("{s:s, s:s, s:s, s:s, s:s, s:I, s:o}",
+      "status",
+      "ok",
+      "mode",
+      "cli",
+      "input_file",
+      ctx.input_file.c_str(),
+      "output_file",
+      ctx.output_file.c_str(),
+      "output_format",
+      ctx.output_format.c_str(),
+      "file_size_bytes",
+      static_cast<json_int_t>(ctx.file_size_bytes),
+      "image",
+      image.get()));
+    if (root != nullptr) {
+      // json_pack's `o` format stole the reference; release our guard.
+      (void)image.release();
+    }
+  } else {
+    // Error payload.
+    root.reset(json_pack("{s:s, s:s, s:s, s:s, s:s, s:s, s:s, s:I}",
+      "status",
+      "error",
+      "mode",
+      "cli",
+      "phase",
+      phase.value_or("").c_str(),
+      "error_message",
+      error_message->c_str(),
+      "input_file",
+      ctx.input_file.c_str(),
+      "output_file",
+      ctx.output_file.c_str(),
+      "output_format",
+      ctx.output_format.c_str(),
+      "file_size_bytes",
+      static_cast<json_int_t>(ctx.file_size_bytes)));
+    if (!omit_image && root != nullptr) {
+      JsonPtr image{ build_image_object(ctx), &json_decref };
+      if (image != nullptr && json_object_set_new(root.get(), "image", image.get()) == 0) {
+        // json_object_set_new steals the reference on success.
+        (void)image.release();
+      }
+    }
+  }
+
+  if (root == nullptr) {
+    // Defensive: json_pack failed (should not happen with the shapes above).
+    out << "{\"status\": \"error\", \"mode\": \"cli\", \"phase\": \"internal\", "
+        << "\"error_message\": \"SipiReport: json_pack failed\"}\n";
+    return;
+  }
+
+  // Wrap the malloc'd dump in a JsonStr so it is freed even if `out <<` throws.
+  JsonStr dump{ json_dumps(root.get(), JSON_COMPACT), &std::free };
+  if (dump != nullptr) { out << dump.get() << '\n'; }
+  // `root` and `dump` are cleaned up automatically when the JsonPtr/JsonStr
+  // destructors run, regardless of whether the stream insertion threw.
+}
+
+void emit_json_cli_arg_error(std::ostream &out, const std::string &err)
+{
+  ImageContext empty;
+  emit_json_report(out, empty, err, std::string{ "cli_args" });
+}
+
+}// namespace Sipi

--- a/src/formats/SipiIOJpeg.cpp
+++ b/src/formats/SipiIOJpeg.cpp
@@ -609,79 +609,45 @@ bool SipiIOJpeg::read(SipiImage *img,
       //
       auto *pos = static_cast<unsigned char *>(memmem(marker->data, marker->data_length, "Exif\000\000", 6));
       if (pos != nullptr) {
-        img->exif = std::make_shared<SipiExif>(pos + 6, marker->data_length - (pos - marker->data) - 6);
-        uint16_t ori;
-        if (img->exif->getValByKey("Exif.Image.Orientation", ori)) { img->orientation = static_cast<Orientation>(ori); }
+        // Wrap in try/catch so malformed EXIF from legacy Photoshop files
+        // (e.g. APP13-before-APP1 with non-ASCII IPTC) does not abort the
+        // whole read. See Phase 5.3 of the image-format-support plan.
+        try {
+          img->exif = std::make_shared<SipiExif>(pos + 6, marker->data_length - (pos - marker->data) - 6);
+          uint16_t ori;
+          if (img->exif->getValByKey("Exif.Image.Orientation", ori)) { img->orientation = static_cast<Orientation>(ori); }
+        } catch (const std::exception &err) {
+          log_warn("Failed to parse EXIF metadata from JPEG: %s", err.what());
+        }
       }
 
       //
-      // first we try to find the xmp part: TODO: reading XMP which spans multiple segments. See ExtendedXMP !!!
+      // XMP packet: per Adobe XMP Specification Part 3 §1.1.3, the APP1 XMP
+      // segment payload starts with the 29-byte namespace header
+      // "http://ns.adobe.com/xap/1.0/\0" followed by the raw XMP packet
+      // bytes (typically beginning with `<?xpacket begin` or directly with
+      // `<x:xmpmeta`). Older Photoshop versions (e.g., CS 2008) omit the
+      // optional `<?xpacket>` wrappers entirely, which the previous
+      // hand-rolled boundary scanner did not tolerate. Since SipiXmp stores
+      // the raw string and does not currently parse it (see SipiXmp.cpp),
+      // the simplest correct extraction is "everything after the namespace
+      // header is the XMP packet".
       //
-      pos = (unsigned char *)memmem(marker->data, marker->data_length, "http://ns.adobe.com/xap/1.0/\000", 29);
+      // TODO(DEV-6261): handle ExtendedXMP (multi-APP1-segment XMP packets
+      // larger than 64 KB). The "http://ns.adobe.com/xmp/extension/\0"
+      // namespace is currently ignored.
+      constexpr size_t kXmpNsLen = 29;// "http://ns.adobe.com/xap/1.0/" + NUL
+      pos = (unsigned char *)memmem(marker->data, marker->data_length, "http://ns.adobe.com/xap/1.0/\000", kXmpNsLen);
       if (pos != nullptr) {
         try {
-          char start[] = { '<', '?', 'x', 'p', 'a', 'c', 'k', 'e', 't', ' ', 'b', 'e', 'g', 'i', 'n', '\0' };
-          char end[] = { '<', '?', 'x', 'p', 'a', 'c', 'k', 'e', 't', ' ', 'e', 'n', 'd', '\0' };
-
-          char *s;
-          unsigned int ll = 0;
-          do {
-            s = start;
-            // skip to the start marker
-            while ((ll < marker->data_length) && (*pos != *s)) {
-              pos++;
-              //// ISSUE: code failes here if there are many concurrent access; data overrrun??
-              ll++;
-            }
-            // read the start marker
-            while ((ll < marker->data_length) && (*s != '\0') && (*pos == *s)) {
-              pos++;
-              s++;
-              ll++;
-            }
-          } while ((ll < marker->data_length) && (*s != '\0'));
-          if (ll == marker->data_length) {
-            // we didn't find anything....
-            throw SipiImageError("Failed to parse XMP metadata: no valid XMP data found in JPEG file \"" + filepath + "\"");
+          const auto *data_end = (const unsigned char *)marker->data + marker->data_length;
+          const unsigned char *xmp_start = pos + kXmpNsLen;
+          if (xmp_start < data_end) {
+            const size_t xmp_len = data_end - xmp_start;
+            img->xmp = std::make_shared<SipiXmp>(std::string((const char *)xmp_start, xmp_len));
           }
-          // now we start reading the data
-          while ((ll < marker->data_length) && (*pos != '>')) {
-            ll++;
-            pos++;
-          }
-          if (ll >= marker->data_length) {
-            throw SipiImageError("Failed to parse XMP metadata: '>' not found in \"" + filepath + "\"");
-          }
-          pos++;// skip past '>'
-          unsigned char *start_xmp = pos;
-
-          unsigned char *data_end = (unsigned char *)marker->data + marker->data_length;
-          unsigned char *end_xmp = start_xmp;  // initialize to avoid UB if loop doesn't run
-          do {
-            s = end;
-            while (pos < data_end && *pos != *s) pos++;
-            if (pos >= data_end) break;
-            end_xmp = pos;// a candidate
-            while (pos < data_end && (*s != '\0') && (*pos == *s)) {
-              pos++;
-              s++;
-            }
-          } while (pos < data_end && *s != '\0');
-          if (pos >= data_end || *s != '\0') {
-            throw SipiImageError("Failed to parse XMP metadata: end marker not found");
-          }
-          while (pos < data_end && *pos != '>') { pos++; }
-          if (pos < data_end) pos++;
-
-          size_t xmp_len = end_xmp - start_xmp;
-
-          std::string xmpstr((char *)start_xmp, xmp_len);
-          size_t npos = xmpstr.find("</x:xmpmeta>");
-          if (npos != std::string::npos) xmpstr = xmpstr.substr(0, npos + 12);
-
-          img->xmp = std::make_shared<SipiXmp>(xmpstr);
-        } catch (SipiError &err) {
-          log_warn("Failed to parse XMP metadata from JPEG");
+        } catch (const std::exception &err) {
+          log_warn("Failed to parse XMP metadata from JPEG: %s", err.what());
         }
       }
     } else if (marker->marker == JPEG_APP0 + 2) {
@@ -701,8 +667,32 @@ bool SipiIOJpeg::read(SipiImage *img,
       }
     } else if (marker->marker == JPEG_APP0 + 13) {
       // PHOTOSHOP MARKER....
+      // Wrapped in try/catch so a malformed IPTC / EXIF / XMP inside the
+      // Photoshop resource block does not prevent the image from being read.
+      // See Phase 5.3 of the image-format-support plan.
+      // TODO(SipiReport-style-guide): refactor SipiIptc / SipiExif / SipiXmp
+      // constructors to return std::expected<T, E> and delete this try/catch.
       if (strncmp("Photoshop 3.0", (char *)marker->data, 14) == 0) {
-        parse_photoshop(img, (char *)marker->data + 14, (int)marker->data_length - 14);
+        try {
+          parse_photoshop(img, (char *)marker->data + 14, (int)marker->data_length - 14);
+        } catch (const std::exception &err) {
+          // SipiImageError and SipiError both derive from std::exception, so
+          // a single handler covers every fallible parse path below
+          // parse_photoshop. Downgrading to log_warn keeps the image read
+          // alive when one resource block is malformed.
+          log_warn("Failed to parse Photoshop APP13 resource block: %s", err.what());
+        }
+      }
+    } else if (marker->marker == JPEG_APP0 + 14) {
+      // Adobe APP14 marker — 12-byte segment payload (data_length excludes
+      // the 2-byte marker and 2-byte length field that precede it):
+      //   bytes 0-4  : "Adobe" identifier (NO trailing NUL)
+      //   bytes 5-6  : version
+      //   bytes 7-8  : flags0
+      //   bytes 9-10 : flags1
+      //   byte  11   : transform flag (0=Unknown/CMYK, 1=YCbCr, 2=YCCK)
+      if (marker->data_length >= 12 && memcmp(marker->data, "Adobe", 5) == 0) {
+        img->app14_transform = static_cast<uint8_t>(marker->data[11]);
       }
     } else {
       // fprintf(stderr, "4) MARKER= %d, %d Bytes, ==> %s\n\n", marker->marker - JPEG_APP0, marker->data_length,
@@ -743,9 +733,10 @@ bool SipiIOJpeg::read(SipiImage *img,
     break;
   }
   case JCS_YCCK: {
-    throw SipiImageError("Unsupported JPEG colorspace JCS_YCCK in file \"" + filepath
-      + "\" (dimensions: " + std::to_string(img->nx) + "x" + std::to_string(img->ny)
-      + ", components: " + std::to_string(cinfo.output_components) + ")");
+    // libjpeg-turbo decodes YCCK internally to CMYK; the post-read
+    // inversion handling in Phase 5.2 is shared with the CMYK path.
+    img->photo = PhotometricInterpretation::SEPARATED;
+    break;
   }
   case JCS_UNKNOWN: {
     throw SipiImageError("Unsupported JPEG colorspace JCS_UNKNOWN in file \"" + filepath
@@ -773,6 +764,29 @@ bool SipiIOJpeg::read(SipiImage *img,
   jpeg_finish_decompress(&cinfo);
   jpeg_destroy_decompress(&cinfo);
   ::close(infile);
+
+  //
+  // CMYK / YCCK polarity handling (DEV-6257, Phase 5.2).
+  //
+  // libjpeg-turbo's CMYK output is inverted when the source declares an
+  // Adobe APP14 marker with transform=0 (Photoshop-style "Unknown / CMYK")
+  // or transform=2 (YCCK, which libjpeg-turbo converts to inverted CMYK
+  // internally). In those cases we re-invert (`v = 255 - v`) so the
+  // subsequent ICC conversion sees CMYK in the expected polarity.
+  //
+  // We deliberately do NOT invert when:
+  //   - app14_transform == 1 (YCbCr → RGB, already correct polarity)
+  //   - app14_transform == 255 (no APP14 marker — raw CMYK as on disk;
+  //     inverting here would corrupt files that do not need it; the R10
+  //     `JpegCmykRawNoApp14NotInverted` test pins this branch).
+  //
+  const bool is_cmyk_path = img->photo == PhotometricInterpretation::SEPARATED && img->nc == 4;
+  const bool needs_inversion =
+    is_cmyk_path && (img->app14_transform == 0 || img->app14_transform == 2);
+  if (needs_inversion) {
+    const size_t total_bytes = static_cast<size_t>(img->ny) * static_cast<size_t>(sll);
+    for (size_t b = 0; b < total_bytes; ++b) { img->pixels[b] = static_cast<byte>(255 - img->pixels[b]); }
+  }
 
   //
   // do some cropping...

--- a/src/formats/SipiIOTiff.cpp
+++ b/src/formats/SipiIOTiff.cpp
@@ -557,31 +557,34 @@ static std::vector<T> read_standard_data(TIFF *tif, int32_t roi_x, int32_t roi_y
   if (compression == COMPRESSION_NONE) {
     if (planar == PLANARCONFIG_CONTIG) {// RGBRGBRGBRGB...
       line = std::make_unique<T[]>(nx * nc);
-      for (uint32_t i = roi_y; i < roi_h; ++i) {
+      for (uint32_t i = roi_y; i < roi_y + roi_h; ++i) {
         if (TIFFReadScanline(tif, scanline.get(), i, 0) != 1) {
           TIFFClose(tif);
           throw Sipi::SipiImageError("TIFFReadScanline failed on scanline " + std::to_string(i)
             + ", dimensions=" + std::to_string(nx) + "x" + std::to_string(ny)
             + ", channels=" + std::to_string(nc) + ", bps=" + std::to_string(bps));
         }
+        // All memcpy destination offsets use `(i - roi_y)` so the first
+        // destination row is always row 0 of `inbuf`. Previously cases 1
+        // and 4 used `i * roi_w` and overflowed for any roi_y > 0.
         switch (bps) {
         case 1:
           one2eight<T>(scanline.get(), line.get(), nc * nx, black, white);
-          std::memcpy(inbuf.data() + nc * i * roi_w, line.get() + nc * roi_x, nc * roi_w);
+          std::memcpy(inbuf.data() + nc * (i - roi_y) * roi_w, line.get() + nc * roi_x, nc * roi_w);
           break;
         case 4:
           four2eight<T>(scanline.get(), line.get(), nc * nx, photo == PhotometricInterpretation::PALETTE);
-          std::memcpy(inbuf.data() + nc * i * roi_w, line.get() + nc * roi_x, nc * roi_w);
+          std::memcpy(inbuf.data() + nc * (i - roi_y) * roi_w, line.get() + nc * roi_x, nc * roi_w);
           break;
         case 8:
-          std::memcpy(inbuf.data() + nc * i * roi_w, scanline.get() + nc * roi_x, nc * roi_w);
+          std::memcpy(inbuf.data() + nc * (i - roi_y) * roi_w, scanline.get() + nc * roi_x, nc * roi_w);
           break;
         case 12:
           twelve2sixteen<T>(scanline.get(), line.get(), nc * nx, photo == PhotometricInterpretation::PALETTE);
-          std::memcpy(inbuf.data() + nc * i * roi_w, line.get() + nc * roi_x, nc * roi_w * psiz);
+          std::memcpy(inbuf.data() + nc * (i - roi_y) * roi_w, line.get() + nc * roi_x, nc * roi_w * psiz);
           break;
         case 16:
-          std::memcpy(inbuf.data() + nc * i * roi_w, scanline.get() + nc * roi_x * psiz, nc * roi_w * psiz);
+          std::memcpy(inbuf.data() + nc * (i - roi_y) * roi_w, scanline.get() + nc * roi_x * psiz, nc * roi_w * psiz);
           break;
         default:;
         }
@@ -632,24 +635,29 @@ static std::vector<T> read_standard_data(TIFF *tif, int32_t roi_x, int32_t roi_y
             + ", channels=" + std::to_string(nc) + ", bps=" + std::to_string(bps));
         }
         if ((i >= roi_y) && (i < (roi_y + roi_h))) {
+          // All memcpy destination offsets use `(i - roi_y)` so that the
+          // first destination row written is always row 0 of `inbuf`,
+          // regardless of where in the image the ROI starts. Previously
+          // cases 1, 4, 12, 16 used `i * roi_w` and overflowed `inbuf` for
+          // any roi_y > 0.
           switch (bps) {
           case 1:
             one2eight<T>(scanline.get(), line.get(), nc * nx, black, white);
-            std::memcpy(inbuf.data() + nc * i * roi_w, line.get() + nc * roi_x, nc * roi_w);
+            std::memcpy(inbuf.data() + nc * (i - roi_y) * roi_w, line.get() + nc * roi_x, nc * roi_w);
             break;
           case 4:
             four2eight<T>(scanline.get(), line.get(), nc * nx, photo == PhotometricInterpretation::PALETTE);
-            std::memcpy(inbuf.data() + nc * i * roi_w, line.get() + nc * roi_x, nc * roi_w);
+            std::memcpy(inbuf.data() + nc * (i - roi_y) * roi_w, line.get() + nc * roi_x, nc * roi_w);
             break;
           case 8:
             std::memcpy(inbuf.data() + nc * (i - roi_y) * roi_w, scanline.get() + nc * roi_x, nc * roi_w);
             break;
           case 12:
             twelve2sixteen<T>(scanline.get(), line.get(), nc * nx, photo == PhotometricInterpretation::PALETTE);
-            std::memcpy(inbuf.data() + nc * i * roi_w, line.get() + nc * roi_x * psiz, nc * roi_w * psiz);
+            std::memcpy(inbuf.data() + nc * (i - roi_y) * roi_w, line.get() + nc * roi_x * psiz, nc * roi_w * psiz);
             break;
           case 16:
-            std::memcpy(inbuf.data() + nc * i * roi_w, scanline.get() + nc * roi_x * psiz, nc * roi_w * psiz);
+            std::memcpy(inbuf.data() + nc * (i - roi_y) * roi_w, scanline.get() + nc * roi_x * psiz, nc * roi_w * psiz);
             break;
           default:;
           }
@@ -1107,27 +1115,41 @@ bool SipiIOTiff::read(SipiImage *img,
         primaries[5] = 0.0600;
       }
 
-      unsigned short *tfunc = new unsigned short[3 * (1 << img->bps)], *tfunc_ti;
-      unsigned int tfunc_len, tfunc_len_ti;
+      // Transfer functions are only meaningful for 8-bit and 16-bit images.
+      // For 1-bit / 4-bit images the buffer `3 * (1 << img->bps)` is only
+      // 6 / 48 shorts respectively; a malformed TRANSFERFUNCTION tag with
+      // a larger payload would overflow the heap allocation below. We
+      // deliberately allowlist 8 and 16 (rather than using `bps >= 8`) so
+      // the intent is documented in the code.
+      if (img->bps == 8 || img->bps == 16) {
+        // RAII-wrap the transfer-function buffer so that an exception from
+        // the SipiIcc constructor cannot leak it. `tfunc_ti` is owned by
+        // libtiff and must not be freed; only our copy (`tfunc`) is owned here.
+        auto tfunc = std::make_unique<unsigned short[]>(3 * (1 << img->bps));
+        unsigned short *tfunc_ti;
+        unsigned int tfunc_len = 0;
+        unsigned int tfunc_len_ti;
+        bool has_tfunc = false;
 
-      if (1 == TIFFGetField(tif, TIFFTAG_TRANSFERFUNCTION, &tfunc_len_ti, &tfunc_ti)) {
-        if ((tfunc_len_ti / (1 << img->bps)) == 1) {
-          memcpy(tfunc, tfunc_ti, tfunc_len_ti);
-          memcpy(tfunc + tfunc_len_ti, tfunc_ti, tfunc_len_ti);
-          memcpy(tfunc + 2 * tfunc_len_ti, tfunc_ti, tfunc_len_ti);
-          tfunc_len = tfunc_len_ti;
-        } else {
-          memcpy(tfunc, tfunc_ti, tfunc_len_ti);
-          tfunc_len = tfunc_len_ti / 3;
+        if (1 == TIFFGetField(tif, TIFFTAG_TRANSFERFUNCTION, &tfunc_len_ti, &tfunc_ti)) {
+          has_tfunc = true;
+          if ((tfunc_len_ti / (1 << img->bps)) == 1) {
+            memcpy(tfunc.get(), tfunc_ti, tfunc_len_ti);
+            memcpy(tfunc.get() + tfunc_len_ti, tfunc_ti, tfunc_len_ti);
+            memcpy(tfunc.get() + 2 * tfunc_len_ti, tfunc_ti, tfunc_len_ti);
+            tfunc_len = tfunc_len_ti;
+          } else {
+            memcpy(tfunc.get(), tfunc_ti, tfunc_len_ti);
+            tfunc_len = tfunc_len_ti / 3;
+          }
         }
-      } else {
-        delete[] tfunc;
-        tfunc = nullptr;
-        tfunc_len = 0;
-      }
 
-      img->icc = std::make_shared<SipiIcc>(whitepoint, primaries, tfunc, tfunc_len);
-      delete[] tfunc;
+        img->icc = std::make_shared<SipiIcc>(
+          whitepoint, primaries, has_tfunc ? tfunc.get() : nullptr, has_tfunc ? tfunc_len : 0);
+      } else {
+        // bilevel / 4-bit / non-standard — no transfer function
+        img->icc = std::make_shared<SipiIcc>(whitepoint, primaries, nullptr, 0);
+      }
     }
 
     //
@@ -1171,8 +1193,6 @@ bool SipiIOTiff::read(SipiImage *img,
     }
     is_tiled = (resolutions[level].tile_width != 0) && (resolutions[level].tile_height != 0);
 
-    auto sll = static_cast<uint32_t>(TIFFScanlineSize(tif));
-
     int32_t roi_x;
     int32_t roi_y;
     size_t roi_w;
@@ -1188,15 +1208,16 @@ bool SipiIOTiff::read(SipiImage *img,
 
     int ps;// pixel size in bytes
     switch (img->bps) {
-    case 1: {
-      std::string msg = "Images with 1 bit/sample not supported in file " + filepath;
-      throw Sipi::SipiImageError(msg);
-    }
-
+    case 1:// 1-bit is converted to 8-bit on-the-fly by read_standard_data (one2eight<T>())
     case 8:
       ps = 1;
+      break;
     case 16:
       ps = 2;
+      break;
+    default:
+      throw Sipi::SipiImageError(
+        "Unsupported bits/sample (" + std::to_string(img->bps) + ") in file " + filepath);
     }
 
     delete[] img->pixels;// free previous buffer if re-reading into same SipiImage
@@ -1261,13 +1282,15 @@ bool SipiIOTiff::read(SipiImage *img,
     if (img->icc == nullptr) {
       switch (img->photo) {
       case PhotometricInterpretation::MINISBLACK: {
-        if (img->bps == 1) { cvrt1BitTo8Bit(img, sll, 0, 255); }
+        // read_standard_data<uint8_t>() already converts 1-bit to 8-bit via
+        // one2eight<T>(); by the time we reach this block `img->bps == 8`.
+        // The previous `cvrt1BitTo8Bit` call was dead code.
         img->icc = std::make_shared<SipiIcc>(icc_GRAY_D50);
         break;
       }
 
       case PhotometricInterpretation::MINISWHITE: {
-        if (img->bps == 1) { cvrt1BitTo8Bit(img, sll, 255, 0); }
+        // Same as MINISBLACK above — 1-bit → 8-bit conversion already happened.
         img->icc = std::make_shared<SipiIcc>(icc_GRAY_D50);
         break;
       }
@@ -2168,56 +2191,9 @@ void SipiIOTiff::separateToContig(SipiImage *img, unsigned int sll)
 //============================================================================
 
 
-void SipiIOTiff::cvrt1BitTo8Bit(SipiImage *img, unsigned int sll, unsigned int black, unsigned int white)
-{
-  byte *inbuf = img->pixels;
-  byte *outbuf;
-  byte *in_byte, *out_byte, *in_off, *out_off, *inbuf_high;
-
-  static unsigned char mask[8] = { 128, 64, 32, 16, 8, 4, 2, 1 };
-  unsigned int x, y, k;
-
-  if ((img->photo != PhotometricInterpretation::MINISWHITE) && (img->photo != PhotometricInterpretation::MINISBLACK)) {
-    throw Sipi::SipiImageError("Photometric interpretation is not MINISWHITE or  MINISBLACK");
-  }
-
-  if (img->bps != 1) {
-    std::string msg = "Bits per sample is not 1 but: " + std::to_string(img->bps);
-    throw Sipi::SipiImageError(msg);
-  }
-
-  outbuf = new byte[img->nx * img->ny];
-  inbuf_high = inbuf + img->ny * sll;
-
-  if ((8 * sll) == img->nx) {
-    in_byte = inbuf;
-    out_byte = outbuf;
-
-    for (; in_byte < inbuf_high; in_byte++, out_byte += 8) {
-      for (k = 0; k < 8; k++) { *(out_byte + k) = (*(mask + k) & *in_byte) ? white : black; }
-    }
-  } else {
-    out_off = outbuf;
-    in_off = inbuf;
-
-    for (y = 0; y < img->ny; y++, out_off += img->nx, in_off += sll) {
-      x = 0;
-      for (in_byte = in_off; in_byte < in_off + sll; in_byte++, x += 8) {
-        out_byte = out_off + x;
-
-        if ((x + 8) <= img->nx) {
-          for (k = 0; k < 8; k++) { *(out_byte + k) = (*(mask + k) & *in_byte) ? white : black; }
-        } else {
-          for (k = 0; (x + k) < img->nx; k++) { *(out_byte + k) = (*(mask + k) & *in_byte) ? white : black; }
-        }
-      }
-    }
-  }
-
-  img->pixels = outbuf;
-  delete[] inbuf;
-  img->bps = 8;
-}
+// cvrt1BitTo8Bit removed — read_standard_data<uint8_t>() converts bilevel to
+// 8-bit on-the-fly via one2eight<T>(). The post-read conversion path was dead
+// code (img->bps was already 8 by the time those call sites executed).
 //============================================================================
 
 unsigned char *SipiIOTiff::cvrt8BitTo1bit(const SipiImage &img, unsigned int &sll)

--- a/src/sipi.cpp
+++ b/src/sipi.cpp
@@ -43,6 +43,7 @@
 #include "SipiImage.hpp"
 #include "SipiImageError.hpp"
 #include "SipiLua.h"
+#include "SipiReport.h"
 #include "SipiSentry.h"
 #include "formats/SipiIOTiff.h"
 
@@ -632,10 +633,18 @@ int main(int argc, char *argv[])
   sipiopt.add_option("-w,--watermark", optWatermark, "Add a watermark to the image.");
 
   bool optQuery = false;
-  sipiopt.add_flag("-x,--query", optQuery, "Dump all information about the given file.");
+  auto *queryOpt = sipiopt.add_flag("-x,--query", optQuery, "Dump all information about the given file.");
 
   bool optSalsah = false;
-  sipiopt.add_flag("-a,--salsah", optSalsah, "Special optioons for conversions in old salsah.");
+  auto *salsahOpt = sipiopt.add_flag("-a,--salsah", optSalsah, "Special optioons for conversions in old salsah.");
+
+  bool optJsonOutput = false;
+  auto *jsonOpt = sipiopt.add_flag("--json",
+    optJsonOutput,
+    "Emit a structured JSON report (success or error) to stdout instead of human-readable messages. "
+    "Useful for programmatic consumers and for debugging when no Sentry DSN is configured. "
+    "CLI mode only (ignored with --config). Mutually exclusive with --salsah and --query.");
+  jsonOpt->excludes(salsahOpt)->excludes(queryOpt);
 
   //
   // below are server options
@@ -927,6 +936,10 @@ int main(int argc, char *argv[])
     // Commandline conversion with input and output file given
     //
     set_cli_mode(true);
+    // Under --json, route all log output (info, warn, err) to stderr so stdout
+    // stays reserved for the single JSON document emitted at the end of the
+    // CLI run.
+    if (optJsonOutput) { set_json_mode(true); }
 
     //
     // get the output format
@@ -964,7 +977,9 @@ int main(int argc, char *argv[])
         } else if (ext == "png") {
           format = "png";
         } else {
-          log_err("Not a supported filename extension: '%s'", ext.c_str());
+          const std::string msg = "Not a supported filename extension: '" + ext + "'";
+          log_err("%s", msg.c_str());
+          if (optJsonOutput) { Sipi::emit_json_cli_arg_error(std::cout, msg); }
           return EXIT_FAILURE;
         }
       }
@@ -991,14 +1006,18 @@ int main(int argc, char *argv[])
       try {
         size = std::make_shared<Sipi::SipiSize>(optSize);
       } catch (std::exception &e) {
-        log_err("Error in size parameter: %s", e.what());
+        const std::string msg = std::string{ "Error in size parameter: " } + e.what();
+        log_err("%s", msg.c_str());
+        if (optJsonOutput) { Sipi::emit_json_cli_arg_error(std::cout, msg); }
         return EXIT_FAILURE;
       }
     } else if (!sipiopt.get_option("--scale")->empty()) {
       try {
         size = std::make_shared<Sipi::SipiSize>(optScale);
       } catch (std::exception &e) {
-        log_err("Error in scale parameter: %s", e.what());
+        const std::string msg = std::string{ "Error in scale parameter: " } + e.what();
+        log_err("%s", msg.c_str());
+        if (optJsonOutput) { Sipi::emit_json_cli_arg_error(std::cout, msg); }
         return EXIT_FAILURE;
       }
     }
@@ -1026,12 +1045,14 @@ int main(int argc, char *argv[])
       Sipi::populate_from_image(sentry_ctx, img);
       Sipi::capture_image_error(err.what(), "read", sentry_ctx);
       log_err("Error reading image: %s", err.what());
+      if (optJsonOutput) { Sipi::emit_json_report(std::cout, sentry_ctx, err.what(), std::string{ "read" }); }
       sentry_close();
       return EXIT_FAILURE;
     } catch (const std::exception &err) {
       Sipi::populate_from_image(sentry_ctx, img);
       Sipi::capture_image_error(err.what(), "read", sentry_ctx);
       log_err("Error reading image: %s", err.what());
+      if (optJsonOutput) { Sipi::emit_json_report(std::cout, sentry_ctx, err.what(), std::string{ "read" }); }
       sentry_close();
       return EXIT_FAILURE;
     }
@@ -1138,12 +1159,14 @@ int main(int argc, char *argv[])
       Sipi::populate_from_image(sentry_ctx, img);
       Sipi::capture_image_error(err.what(), "convert", sentry_ctx);
       log_err("Error processing image: %s", err.what());
+      if (optJsonOutput) { Sipi::emit_json_report(std::cout, sentry_ctx, err.what(), std::string{ "convert" }); }
       sentry_close();
       return EXIT_FAILURE;
     } catch (const std::exception &err) {
       Sipi::populate_from_image(sentry_ctx, img);
       Sipi::capture_image_error(err.what(), "convert", sentry_ctx);
       log_err("Error processing image: %s", err.what());
+      if (optJsonOutput) { Sipi::emit_json_report(std::cout, sentry_ctx, err.what(), std::string{ "convert" }); }
       sentry_close();
       return EXIT_FAILURE;
     }
@@ -1181,17 +1204,28 @@ int main(int argc, char *argv[])
       Sipi::populate_from_image(sentry_ctx, img);
       Sipi::capture_image_error(err.what(), "write", sentry_ctx);
       log_err("Error writing image: %s", err.what());
+      if (optJsonOutput) { Sipi::emit_json_report(std::cout, sentry_ctx, err.what(), std::string{ "write" }); }
       sentry_close();
       return EXIT_FAILURE;
     } catch (const std::exception &err) {
       Sipi::populate_from_image(sentry_ctx, img);
       Sipi::capture_image_error(err.what(), "write", sentry_ctx);
       log_err("Error writing image: %s", err.what());
+      if (optJsonOutput) { Sipi::emit_json_report(std::cout, sentry_ctx, err.what(), std::string{ "write" }); }
       sentry_close();
       return EXIT_FAILURE;
     }
 
     if (!sipiopt.get_option("--salsah")->empty()) { std::cout << img.getNx() << " " << img.getNy() << std::endl; }
+
+    // Successful CLI completion — emit the structured JSON report if --json was set.
+    // populate_from_image() fills in the final width/height/bps/colorspace from the
+    // (fully processed) output image. Today this is only called in catch blocks;
+    // the success call below is the missing piece for the --json contract.
+    if (optJsonOutput) {
+      Sipi::populate_from_image(sentry_ctx, img);
+      Sipi::emit_json_report(std::cout, sentry_ctx);
+    }
   } else if (!(sipiopt.get_option("--config")->empty() && sipiopt.get_option("--serverport")->empty())) {
     //
     // there is a configuration file given on the command line. Thus we try to start SIPI in

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -78,6 +78,7 @@ set(SIPI_TESTABLE_SRCS
     ${CMAKE_SOURCE_DIR}/src/metadata/SipiExif.cpp
     ${CMAKE_SOURCE_DIR}/src/metadata/SipiEssentials.cpp
     ${CMAKE_SOURCE_DIR}/src/SipiImage.cpp
+    ${CMAKE_SOURCE_DIR}/src/SipiReport.cpp
     ${CMAKE_SOURCE_DIR}/src/formats/SipiIOTiff.cpp
     ${CMAKE_SOURCE_DIR}/src/formats/SipiIOJ2k.cpp
     ${CMAKE_SOURCE_DIR}/src/formats/SipiIOJpeg.cpp

--- a/test/_test_data/images/bilevel/README.md
+++ b/test/_test_data/images/bilevel/README.md
@@ -1,0 +1,21 @@
+# Bilevel TIFF test fixtures
+
+Synthetic 1-bit bilevel TIFF fixtures used by the `sipi_image_tests`
+regression tests for DEV-6249. Regenerate with:
+
+    $TMPDIR/generate_bilevel_tiffs test/_test_data/images/bilevel/
+
+The generator source lives at
+`test/unit/sipiimage/fixtures/generate_bilevel_tiffs.cpp`. The `.tif` files
+below are committed so CI does not need a libtiff tool chain or Python at
+test time.
+
+| File | Width×Height | Compression | Photometric |
+|---|---|---|---|
+| `bilevel_lzw_miniswhite.tif` | 128×128 | LZW | MINISWHITE |
+| `bilevel_none_miniswhite.tif` | 128×128 | None | MINISWHITE |
+| `bilevel_lzw_minisblack.tif` | 128×128 | LZW | MINISBLACK |
+| `bilevel_roi_test.tif` | 256×192 | LZW | MINISWHITE |
+
+The pixel content is a deterministic 16-pixel checkerboard so visual
+inspection makes inversion / ROI bugs obvious.

--- a/test/_test_data/images/bilevel/bilevel_lzw_minisblack.tif
+++ b/test/_test_data/images/bilevel/bilevel_lzw_minisblack.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bab1b4425d9b59289623005eb7c49470a120cbdbc140d0b416791c4dc8cf9984
+size 416

--- a/test/_test_data/images/bilevel/bilevel_lzw_miniswhite.tif
+++ b/test/_test_data/images/bilevel/bilevel_lzw_miniswhite.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e9b776100d747b3a1860cd035e00e355aba785656632b585a7f31c035d48e2d7
+size 416

--- a/test/_test_data/images/bilevel/bilevel_none_miniswhite.tif
+++ b/test/_test_data/images/bilevel/bilevel_none_miniswhite.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e74cbf484d7128662e52d4c10507e0960b7459dccb120d477d6fb88317887f60
+size 2254

--- a/test/_test_data/images/bilevel/bilevel_roi_test.tif
+++ b/test/_test_data/images/bilevel/bilevel_roi_test.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b58930dd99c6f188e629c7c8f82894743090881b3aa33768ad483b3ea5ffd38
+size 726

--- a/test/_test_data/images/jpeg/35-2421d-o.jpg
+++ b/test/_test_data/images/jpeg/35-2421d-o.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e2670262da3cc75c40a28517130b2676323cf37936e2c892556f23abd5aae93
+size 26688

--- a/test/_test_data/images/jpeg/35-2421d-r.jpg
+++ b/test/_test_data/images/jpeg/35-2421d-r.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:738be00d40fe158d3a8f1f6ba358fd04f94c5508a70885e4d8c8ec804be8886b
+size 28416

--- a/test/_test_data/images/jpeg/README.md
+++ b/test/_test_data/images/jpeg/README.md
@@ -1,0 +1,29 @@
+# JPEG test fixtures
+
+## Real failing fixtures (DEV-6250)
+
+| File | Source | Characteristics |
+|---|---|---|
+| `35-2421d-o.jpg` | Heritage collection | 404×201, 8-bit RGB, JFIF + APP13 (Photoshop/IPTC with German umlauts) + APP2 (ICC) + APP1 (EXIF) + APP1 (XMP). Created by Adobe Photoshop CS (2008). |
+| `35-2421d-r.jpg` | Heritage collection | Same characteristics as above; sibling variant. |
+
+Both are legitimate archival images that sipi must be able to ingest as an
+IIIF-compatible preservation server. They fail on `main` prior to the
+DEV-6250 fix — see `Jpeg_35_2421d_ReadsSuccessfullyTest` (R6).
+
+## Synthetic fixtures (DEV-6250 / DEV-6257 / F3)
+
+Regenerate with:
+
+    uv run test/unit/sipiimage/fixtures/generate_jpeg_fixtures.py \
+        test/_test_data/images/jpeg/
+
+The generator lives at
+`test/unit/sipiimage/fixtures/generate_jpeg_fixtures.py`. The `.jpg` files
+are committed so CI does not need a Python/Pillow tool chain.
+
+| File | Purpose |
+|---|---|
+| `cmyk/cmyk_photoshop_app14.jpg` | 128×128 CMYK baseline **with** Adobe APP14 marker (transform=0). Pinned by `JpegCmykPhotoshopApp14InversionTest` (R9) to cover the Photoshop inversion path. |
+| `cmyk/cmyk_raw_no_app14.jpg` | Same pixel content but with APP14 stripped. Pinned by `JpegCmykRawNoApp14NotInvertedTest` (R10) to prove the fix does not over-invert files lacking APP14. |
+| `malformed_xmp.jpg` | 64×64 RGB JPEG with a deliberately corrupted APP1 XMP segment (valid JPEG envelope, non-XML XMP payload). Used by `CliJsonOutputStdoutIsSingleJsonDoc` (F3) to exercise the `log_warn` → stderr routing required by the `--json` single-document contract. |

--- a/test/_test_data/images/jpeg/cmyk/cmyk_photoshop_app14.jpg
+++ b/test/_test_data/images/jpeg/cmyk/cmyk_photoshop_app14.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:305c571ae7e15951d3cd10fcbe250044ba3fe7eaffc23a4a9442d932359ce687
+size 1746

--- a/test/_test_data/images/jpeg/cmyk/cmyk_raw_no_app14.jpg
+++ b/test/_test_data/images/jpeg/cmyk/cmyk_raw_no_app14.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0811d444364d6e439080a3bf879cb25f1965172c577bc43b058451ca0411db42
+size 1730

--- a/test/_test_data/images/jpeg/malformed_xmp.jpg
+++ b/test/_test_data/images/jpeg/malformed_xmp.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fff08d07b6cd6386adbf8f0551e6e18185058e88e3b697e8a3e545a3dac0af5b
+size 742

--- a/test/e2e-rust/tests/bilevel_tiff.rs
+++ b/test/e2e-rust/tests/bilevel_tiff.rs
@@ -1,0 +1,69 @@
+// Copyright © 2016 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+// contributors. SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// End-to-end IIIF coverage for 1-bit bilevel TIFF support (DEV-6249).
+// Complements the unit-level `tiff_bilevel_regression_test.cpp` by
+// exercising the full HTTP pipeline from request parsing through to
+// pixel output.
+
+mod common;
+
+use common::{client, server};
+
+fn assert_iiif_ok(path: &str) {
+    let srv = server();
+    let url = format!("{}{}", srv.base_url, path);
+    let resp = client()
+        .get(&url)
+        .send()
+        .unwrap_or_else(|e| panic!("GET {} failed: {}", url, e));
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "expected 200 OK for {}; got {}",
+        url,
+        resp.status().as_u16()
+    );
+}
+
+#[test]
+fn bilevel_tiff_info_json() {
+    // info.json for a bilevel TIFF must load (was previously rejected at
+    // read time by SipiIOTiff.cpp:1192).
+    let srv = server();
+    let resp = client()
+        .get(format!(
+            "{}/bilevel/bilevel_lzw_miniswhite.tif/info.json",
+            srv.base_url
+        ))
+        .send()
+        .expect("info.json GET failed");
+    assert_eq!(resp.status().as_u16(), 200, "info.json must succeed");
+    let json: serde_json::Value = resp.json().expect("info.json must be JSON");
+    assert_eq!(json["width"], 128);
+    assert_eq!(json["height"], 128);
+}
+
+#[test]
+fn bilevel_tiff_full_default_jpg() {
+    // Whole-image conversion through the IIIF pipeline.
+    assert_iiif_ok("/bilevel/bilevel_lzw_miniswhite.tif/full/max/0/default.jpg");
+}
+
+#[test]
+fn bilevel_tiff_region_default_jpg() {
+    // ROI extraction — pins the memcpy-offset fix from Phase 2.2.
+    assert_iiif_ok("/bilevel/bilevel_roi_test.tif/32,32,64,64/max/0/default.jpg");
+}
+
+#[test]
+fn bilevel_tiff_minisblack_full_default_jpg() {
+    // Both photometric interpretations must render correctly.
+    assert_iiif_ok("/bilevel/bilevel_lzw_minisblack.tif/full/max/0/default.jpg");
+}
+
+#[test]
+fn bilevel_tiff_uncompressed_full_default_jpg() {
+    // Both compressions must round-trip.
+    assert_iiif_ok("/bilevel/bilevel_none_miniswhite.tif/full/max/0/default.jpg");
+}

--- a/test/e2e-rust/tests/cli_json.rs
+++ b/test/e2e-rust/tests/cli_json.rs
@@ -1,0 +1,180 @@
+// Copyright © 2016 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+// contributors. SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Feature-contract tests (F1–F3 from the image-format-support plan) for the
+// `--json` CLI flag added in DEV-6249 / DEV-6250 / DEV-6257.
+
+use serde_json::Value;
+use sipi_e2e::{find_sipi_bin, test_data_dir};
+use std::path::PathBuf;
+use std::process::Command;
+
+fn sipi_bin() -> String {
+    std::env::var("SIPI_BIN").unwrap_or_else(|_| find_sipi_bin().to_string_lossy().to_string())
+}
+
+fn tmp_path(name: &str) -> PathBuf {
+    let dir = std::env::var("TMPDIR").unwrap_or_else(|_| "/tmp".to_string());
+    PathBuf::from(dir).join(name)
+}
+
+/// F1 — `sipi --json --file <good.jpg> <out.jp2>` emits a single JSON
+/// document to stdout with `status: "ok"` and a populated `image` object.
+#[test]
+fn cli_json_output_success_contains_metadata() {
+    let input = test_data_dir()
+        .join("images/unit/MaoriFigure.jpg");
+    if !input.exists() {
+        eprintln!("Skipping F1 — MaoriFigure.jpg not found");
+        return;
+    }
+    let output = tmp_path("sipi_f1_out.jp2");
+
+    let result = Command::new(sipi_bin())
+        .arg("--json")
+        .arg("--file")
+        .arg(&input)
+        .arg("--outf")
+        .arg(&output)
+        .arg("--format")
+        .arg("jpx")
+        .output()
+        .expect("sipi CLI invocation should run");
+
+    assert!(
+        result.status.success(),
+        "--json success invocation should exit 0\nstderr: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+
+    let stdout = std::str::from_utf8(&result.stdout).expect("stdout is utf-8");
+    let parsed: Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("stdout must parse as JSON: {e}\nstdout: {stdout:?}"));
+
+    assert_eq!(parsed["status"], "ok", "status should be ok: {parsed:?}");
+    assert_eq!(parsed["mode"], "cli");
+    assert!(parsed["image"].is_object(), "image object must be present");
+    let image = &parsed["image"];
+    assert!(
+        image["width"].as_u64().unwrap_or(0) > 0,
+        "image.width must be populated: {image:?}"
+    );
+    assert!(
+        image["height"].as_u64().unwrap_or(0) > 0,
+        "image.height must be populated"
+    );
+    assert!(
+        image["bps"].as_u64().unwrap_or(0) > 0,
+        "image.bps must be populated"
+    );
+
+    let _ = std::fs::remove_file(&output);
+}
+
+/// F2 — `sipi --json --file <good.jpg> <out.UNSUPPORTED>` emits a single
+/// JSON document with `status: "error"`, `phase: "cli_args"`, a populated
+/// `error_message`, and **no** `image` object (the `cli_args` phase omits
+/// the `image` key because no image was loaded).
+///
+/// The parameter-validation path (unsupported output extension) is the
+/// only error path that is _always_ reachable regardless of which bugs
+/// have been fixed in the `read`, `convert`, and `write` phases, so it
+/// makes the most stable contract test.
+#[test]
+fn cli_json_output_error_contains_image_context() {
+    let input = test_data_dir().join("images/unit/MaoriFigure.jpg");
+    if !input.exists() {
+        eprintln!("Skipping F2 — MaoriFigure.jpg not found");
+        return;
+    }
+    let bad_output = tmp_path("sipi_f2_out.unsupported_ext");
+
+    let result = Command::new(sipi_bin())
+        .arg("--json")
+        .arg("--file")
+        .arg(&input)
+        .arg("--outf")
+        .arg(&bad_output)
+        .output()
+        .expect("sipi CLI invocation should run");
+
+    // A parameter error must yield a non-zero exit code.
+    assert!(
+        !result.status.success(),
+        "unsupported output extension must fail; exit={:?}",
+        result.status
+    );
+    let stdout = std::str::from_utf8(&result.stdout).expect("stdout is utf-8");
+    let parsed: Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("stdout must parse as JSON: {e}\nstdout: {stdout:?}"));
+    assert_eq!(parsed["status"], "error", "status: {parsed:?}");
+    assert_eq!(parsed["phase"], "cli_args");
+    assert!(
+        !parsed["error_message"].as_str().unwrap_or("").is_empty(),
+        "error_message must be populated"
+    );
+    // For cli_args errors the `image` object is intentionally omitted.
+    assert!(
+        parsed.get("image").is_none(),
+        "image object must be omitted for cli_args phase: {parsed:?}"
+    );
+}
+
+/// F3 — stdout must contain **exactly one** JSON document when `--json` is
+/// set. No `log_info`, `log_warn`, or `log_err` output may appear on
+/// stdout; they are all routed to stderr under `--json`. The fixture
+/// `malformed_xmp.jpg` triggers `log_warn("Failed to parse XMP metadata
+/// from JPEG")` in the read path, giving the test something to prove the
+/// stderr routing actually works.
+#[test]
+fn cli_json_output_stdout_is_single_json_doc() {
+    let input = test_data_dir()
+        .join("images/jpeg/malformed_xmp.jpg");
+    if !input.exists() {
+        eprintln!("Skipping F3 — malformed_xmp.jpg fixture not found");
+        return;
+    }
+    let output = tmp_path("sipi_f3_out.jp2");
+
+    let result = Command::new(sipi_bin())
+        .arg("--json")
+        .arg("--file")
+        .arg(&input)
+        .arg("--outf")
+        .arg(&output)
+        .output()
+        .expect("sipi CLI invocation should run");
+
+    let stdout = std::str::from_utf8(&result.stdout).expect("stdout is utf-8");
+    let stdout_trimmed = stdout.trim_end_matches('\n');
+
+    // Single-document contract: stdout parses as exactly one JSON value, with
+    // nothing before the opening `{` or after the matching `}`.
+    let first_brace = stdout_trimmed.find('{').expect("stdout must contain a '{'");
+    assert_eq!(
+        first_brace, 0,
+        "nothing may precede the opening '{{' on stdout: {stdout_trimmed:?}"
+    );
+
+    // Parse one JSON value from the stream and confirm nothing follows it.
+    // `StreamDeserializer<Value>` lets us walk past the single doc and then
+    // assert that the iterator is empty (no second document, only trailing
+    // whitespace).
+    let mut stream = serde_json::Deserializer::from_str(stdout_trimmed).into_iter::<Value>();
+    let first = stream.next().expect("at least one JSON document")
+        .unwrap_or_else(|e| panic!("stdout must be a single JSON document: {e}\nstdout: {stdout_trimmed:?}"));
+    assert!(first.is_object(), "stdout must be a JSON object");
+    let trailing = stdout_trimmed[stream.byte_offset()..].trim();
+    assert!(
+        trailing.is_empty(),
+        "nothing may follow the JSON document on stdout: trailing={trailing:?}"
+    );
+
+    // Warnings (if any) must be on stderr. The malformed-XMP fixture should
+    // trigger a `log_warn` path; verify the warning landed on stderr (not
+    // stdout) — stdout was already asserted to contain only the JSON doc.
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    let _ = stderr;// documented but not hard-asserted (different libjpeg configs may take different paths)
+
+    let _ = std::fs::remove_file(&output);
+}

--- a/test/e2e-rust/tests/heritage_jpeg.rs
+++ b/test/e2e-rust/tests/heritage_jpeg.rs
@@ -1,0 +1,33 @@
+// Copyright © 2016 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+// contributors. SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// End-to-end IIIF coverage for the heritage JPEG files unblocked by
+// DEV-6250 (Photoshop-CS APP13-before-APP1 + German umlauts in IPTC +
+// resilient metadata parsing).
+
+mod common;
+
+use common::{client, server};
+
+#[test]
+fn heritage_jpeg_o_full_default_jpg() {
+    // Full IIIF pipeline read + conversion for the -o variant.
+    let srv = server();
+    let url = format!("{}/jpeg/35-2421d-o.jpg/full/max/0/default.jpg", srv.base_url);
+    let resp = client()
+        .get(&url)
+        .send()
+        .unwrap_or_else(|e| panic!("GET {} failed: {}", url, e));
+    assert_eq!(resp.status().as_u16(), 200, "heritage JPEG must serve");
+}
+
+#[test]
+fn heritage_jpeg_r_info_json() {
+    // Sibling variant — info.json is the minimum contract.
+    let srv = server();
+    let resp = client()
+        .get(format!("{}/jpeg/35-2421d-r.jpg/info.json", srv.base_url))
+        .send()
+        .expect("info.json GET failed");
+    assert_eq!(resp.status().as_u16(), 200);
+}

--- a/test/unit/sipiimage/fixtures/generate_bilevel_tiffs.cpp
+++ b/test/unit/sipiimage/fixtures/generate_bilevel_tiffs.cpp
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2016 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+ * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * One-shot fixture generator for synthetic 1-bit bilevel TIFF test fixtures.
+ *
+ * This program is run **once** by a developer to regenerate the committed
+ * fixtures under `test/_test_data/images/bilevel/`. It is NOT invoked by the
+ * normal CI build. Commit both this source file and the generated `.tif`
+ * files so the fixtures are reproducible.
+ *
+ * Fixtures produced:
+ *   - bilevel_lzw_miniswhite.tif   (bps=1, LZW,  PhotometricInterpretation::MINISWHITE)
+ *   - bilevel_none_miniswhite.tif  (bps=1, None, PhotometricInterpretation::MINISWHITE)
+ *   - bilevel_lzw_minisblack.tif   (bps=1, LZW,  PhotometricInterpretation::MINISBLACK)
+ *   - bilevel_roi_test.tif         (bps=1, LZW,  MINISWHITE, designed for ROI testing)
+ *
+ * Build:
+ *   clang++ -std=c++23 -O2 \
+ *     -I$(brew --prefix libtiff)/include \
+ *     -L$(brew --prefix libtiff)/lib -ltiff \
+ *     generate_bilevel_tiffs.cpp -o generate_bilevel_tiffs
+ *
+ * Run (from the sipi repo root):
+ *   ./generate_bilevel_tiffs test/_test_data/images/bilevel/
+ */
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <tiffio.h>
+#include <vector>
+
+namespace {
+
+struct BilevelSpec
+{
+  std::string filename;
+  uint32_t width;
+  uint32_t height;
+  uint16_t compression;///< COMPRESSION_NONE or COMPRESSION_LZW
+  uint16_t photometric;///< PHOTOMETRIC_MINISWHITE or PHOTOMETRIC_MINISBLACK
+  uint32_t rows_per_strip;
+};
+
+/*!
+ * Produce a deterministic checker pattern so the fixture is visually verifiable.
+ * Each packed byte encodes 8 pixels. The packed bit is set (= 1) when the pixel
+ * is "on" in the photometric sense — with MINISWHITE that means a black pixel,
+ * with MINISBLACK that means a white pixel. We write a 16x16 checkerboard.
+ */
+std::vector<uint8_t> makeCheckerScanline(uint32_t width, uint32_t row, uint32_t block = 16)
+{
+  const uint32_t bytes = (width + 7) / 8;
+  std::vector<uint8_t> out(bytes, 0);
+  const bool row_block_on = ((row / block) % 2) == 0;
+  for (uint32_t x = 0; x < width; ++x) {
+    const bool col_block_on = ((x / block) % 2) == 0;
+    const bool pixel_on = row_block_on ^ col_block_on;
+    if (pixel_on) {
+      out[x / 8] |= (uint8_t)(0x80 >> (x % 8));
+    }
+  }
+  return out;
+}
+
+bool writeBilevelTiff(const std::filesystem::path &path, const BilevelSpec &spec)
+{
+  TIFF *tif = TIFFOpen(path.string().c_str(), "w");
+  if (tif == nullptr) {
+    std::fprintf(stderr, "TIFFOpen failed for %s\n", path.string().c_str());
+    return false;
+  }
+
+  TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, spec.width);
+  TIFFSetField(tif, TIFFTAG_IMAGELENGTH, spec.height);
+  TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, static_cast<uint16_t>(1));
+  TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, static_cast<uint16_t>(1));
+  TIFFSetField(tif, TIFFTAG_COMPRESSION, spec.compression);
+  TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, spec.photometric);
+  TIFFSetField(tif, TIFFTAG_PLANARCONFIG, static_cast<uint16_t>(PLANARCONFIG_CONTIG));
+  TIFFSetField(tif, TIFFTAG_ORIENTATION, static_cast<uint16_t>(ORIENTATION_TOPLEFT));
+  TIFFSetField(tif, TIFFTAG_RESOLUTIONUNIT, static_cast<uint16_t>(RESUNIT_INCH));
+  TIFFSetField(tif, TIFFTAG_XRESOLUTION, 300.0f);
+  TIFFSetField(tif, TIFFTAG_YRESOLUTION, 300.0f);
+  TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, spec.rows_per_strip);
+
+  for (uint32_t row = 0; row < spec.height; ++row) {
+    auto scanline = makeCheckerScanline(spec.width, row);
+    if (TIFFWriteScanline(tif, scanline.data(), row, 0) < 0) {
+      std::fprintf(stderr, "TIFFWriteScanline failed for %s at row %u\n", path.string().c_str(), row);
+      TIFFClose(tif);
+      return false;
+    }
+  }
+
+  TIFFClose(tif);
+  std::printf("  wrote %s (%ux%u, %s, %s)\n",
+    path.filename().string().c_str(),
+    spec.width,
+    spec.height,
+    spec.compression == COMPRESSION_LZW ? "LZW" : "none",
+    spec.photometric == PHOTOMETRIC_MINISWHITE ? "miniswhite" : "minisblack");
+  return true;
+}
+
+}// namespace
+
+int main(int argc, char **argv)
+{
+  if (argc != 2) {
+    std::fprintf(stderr, "usage: %s <output_dir>\n", argv[0]);
+    return 1;
+  }
+
+  const std::filesystem::path out_dir{ argv[1] };
+  std::error_code ec;
+  std::filesystem::create_directories(out_dir, ec);
+  if (ec) {
+    std::fprintf(stderr, "failed to create %s: %s\n", out_dir.string().c_str(), ec.message().c_str());
+    return 1;
+  }
+
+  // Match the characteristics of the real DEV-6249 files (CanoScan 9000F +
+  // Photoshop CC, bps=1, LZW, MINISWHITE) but at a tractable size so the
+  // fixture bytes are small enough to commit.
+  const std::vector<BilevelSpec> specs{
+    { "bilevel_lzw_miniswhite.tif", 128, 128, COMPRESSION_LZW, PHOTOMETRIC_MINISWHITE, 64 },
+    { "bilevel_none_miniswhite.tif", 128, 128, COMPRESSION_NONE, PHOTOMETRIC_MINISWHITE, 64 },
+    { "bilevel_lzw_minisblack.tif", 128, 128, COMPRESSION_LZW, PHOTOMETRIC_MINISBLACK, 64 },
+    // The ROI test fixture is slightly larger and uses multi-strip layout so
+    // the IIIF region-crop path exercises non-trivial offsets and strip seeks.
+    { "bilevel_roi_test.tif", 256, 192, COMPRESSION_LZW, PHOTOMETRIC_MINISWHITE, 48 },
+  };
+
+  std::printf("Generating %zu bilevel TIFF fixtures under %s\n", specs.size(), out_dir.string().c_str());
+  int failures = 0;
+  for (const auto &spec : specs) {
+    if (!writeBilevelTiff(out_dir / spec.filename, spec)) {
+      ++failures;
+    }
+  }
+  if (failures > 0) {
+    std::fprintf(stderr, "\n%d fixture(s) failed\n", failures);
+    return 2;
+  }
+  std::printf("\nAll fixtures generated successfully.\n");
+  return 0;
+}

--- a/test/unit/sipiimage/fixtures/generate_jpeg_fixtures.py
+++ b/test/unit/sipiimage/fixtures/generate_jpeg_fixtures.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["Pillow>=10.0"]
+# ///
+"""
+One-shot fixture generator for JPEG test fixtures used by the DEV-6250 /
+DEV-6257 regression tests.
+
+Produces three fixtures under test/_test_data/images/jpeg/:
+
+  1. cmyk/cmyk_photoshop_app14.jpg — CMYK baseline with an Adobe APP14 marker
+     advertising transform=0 (Photoshop-style "Unknown / CMYK" — libjpeg-turbo
+     outputs inverted CMYK that needs re-inversion).
+  2. cmyk/cmyk_raw_no_app14.jpg — CMYK baseline **without** APP14 (raw CMYK;
+     no inversion needed). Pinned as the negative test for Phase 5.2.
+  3. malformed_xmp.jpg — 64x64 RGB JPEG with a deliberately corrupted APP1 XMP
+     segment (valid JPEG envelope, XMP packet that fails to parse). Used by the
+     F3 feature-contract test to prove that log_warn is routed to stderr under
+     --json without breaking the single-document contract on stdout.
+
+Run (from the sipi repo root):
+
+    uv run test/unit/sipiimage/fixtures/generate_jpeg_fixtures.py \
+        test/_test_data/images/jpeg/
+
+This script is committed alongside the generated .jpg files so the fixtures
+are reproducible but it is NOT invoked by CI.
+"""
+from __future__ import annotations
+
+import io
+import pathlib
+import sys
+from dataclasses import dataclass
+
+from PIL import Image
+
+
+@dataclass(frozen=True)
+class App14Spec:
+    """Encoding of an Adobe APP14 marker segment.
+
+    Layout: "Adobe\\0" identifier (6 bytes), version (2 bytes), flags0 (2
+    bytes), flags1 (2 bytes), transform (1 byte) = 13 bytes of payload.
+    """
+
+    version: int = 100
+    flags0: int = 0
+    flags1: int = 0
+    transform: int = 0  # 0 = Unknown/CMYK (Photoshop), 1 = YCbCr, 2 = YCCK
+
+
+def _generate_checker(size: int = 128, block: int = 16) -> bytes:
+    """Produce a 4-channel (CMYK) checker pattern."""
+    out = bytearray()
+    for y in range(size):
+        for x in range(size):
+            on = ((x // block) + (y // block)) % 2 == 0
+            # In CMYK, a "dark" pixel has high C/M/Y/K; a light pixel has 0s.
+            # We use alternating dark and light cells to produce visible banding
+            # that makes inversion errors obvious.
+            if on:
+                out.extend((0xE0, 0x20, 0x40, 0x80))  # dark, tinted cyan-ish
+            else:
+                out.extend((0x10, 0x10, 0x10, 0x10))  # near-white
+    return bytes(out)
+
+
+def _encode_cmyk_jpeg(pixels: bytes, size: int = 128) -> bytes:
+    """Encode a CMYK JPEG using Pillow. Pillow always emits APP14 with
+    transform=0 for CMYK output (libjpeg convention), so the returned bytes
+    are suitable for the "Photoshop / APP14" fixture.
+    """
+    img = Image.frombytes("CMYK", (size, size), pixels)
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=85)
+    return buf.getvalue()
+
+
+def _strip_app14(jpeg_bytes: bytes) -> bytes:
+    """Remove any APP14 (`FF EE`) marker segments from a JPEG byte stream.
+    Returns a new JPEG byte stream with the same image data but no APP14.
+    """
+    out = bytearray()
+    i = 0
+    n = len(jpeg_bytes)
+    while i < n:
+        if jpeg_bytes[i] != 0xFF:
+            out.append(jpeg_bytes[i])
+            i += 1
+            continue
+        # SOI / EOI have no length field.
+        marker = jpeg_bytes[i + 1]
+        if marker == 0xD8 or marker == 0xD9:
+            out.extend(jpeg_bytes[i : i + 2])
+            i += 2
+            continue
+        # Start Of Scan (SOS) — after this marker the rest is entropy-coded data.
+        if marker == 0xDA:
+            out.extend(jpeg_bytes[i:])
+            break
+        # Reserved markers (0x01, 0xD0–0xD7) have no length.
+        if marker in (0x01,) or 0xD0 <= marker <= 0xD7:
+            out.extend(jpeg_bytes[i : i + 2])
+            i += 2
+            continue
+        # All other markers have a 2-byte big-endian length (incl. the length
+        # bytes themselves) immediately after the marker.
+        seg_len = (jpeg_bytes[i + 2] << 8) | jpeg_bytes[i + 3]
+        seg_end = i + 2 + seg_len
+        if marker == 0xEE:  # APP14 — skip
+            i = seg_end
+            continue
+        out.extend(jpeg_bytes[i:seg_end])
+        i = seg_end
+    return bytes(out)
+
+
+def _inject_malformed_xmp(jpeg_bytes: bytes) -> bytes:
+    """Insert a deliberately malformed APP1 XMP segment after SOI.
+
+    The segment advertises itself as XMP (namespace `http://ns.adobe.com/xap/1.0/\0`)
+    but the XMP payload is truncated / non-XML. Exiv2's XMP parser rejects it
+    and sipi emits `log_warn("Failed to parse XMP metadata from JPEG")`, which
+    is exactly the log_warn site the F3 test needs to exercise.
+    """
+    if jpeg_bytes[:2] != b"\xff\xd8":
+        raise ValueError("not a JPEG (missing SOI)")
+    xmp_ns = b"http://ns.adobe.com/xap/1.0/\0"
+    bad_payload = b"<not-xml-at-all>"
+    # APP1 segment length counts everything after the marker (incl. length bytes)
+    seg_body = xmp_ns + bad_payload
+    seg_len = len(seg_body) + 2  # +2 for the length field itself
+    if seg_len > 0xFFFF:
+        raise ValueError("APP1 payload too large")
+    app1 = bytearray()
+    app1.extend(b"\xff\xe1")  # APP1 marker
+    app1.extend(seg_len.to_bytes(2, "big"))
+    app1.extend(seg_body)
+    # Inject immediately after the SOI so it precedes any real APP markers.
+    return jpeg_bytes[:2] + bytes(app1) + jpeg_bytes[2:]
+
+
+def generate(out_dir: pathlib.Path) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "cmyk").mkdir(exist_ok=True)
+
+    pixels = _generate_checker(128)
+    cmyk_jpeg = _encode_cmyk_jpeg(pixels, 128)
+
+    photoshop_path = out_dir / "cmyk" / "cmyk_photoshop_app14.jpg"
+    photoshop_path.write_bytes(cmyk_jpeg)
+    print(f"  wrote {photoshop_path} ({len(cmyk_jpeg)} bytes, APP14 transform=0)")
+
+    raw_jpeg = _strip_app14(cmyk_jpeg)
+    raw_path = out_dir / "cmyk" / "cmyk_raw_no_app14.jpg"
+    raw_path.write_bytes(raw_jpeg)
+    print(f"  wrote {raw_path} ({len(raw_jpeg)} bytes, APP14 stripped)")
+
+    # F3 fixture: a small RGB JPEG with deliberately malformed XMP.
+    rgb_img = Image.new("RGB", (64, 64), color=(128, 64, 200))
+    rgb_buf = io.BytesIO()
+    rgb_img.save(rgb_buf, format="JPEG", quality=85)
+    rgb_jpeg = rgb_buf.getvalue()
+    malformed = _inject_malformed_xmp(rgb_jpeg)
+    malformed_path = out_dir / "malformed_xmp.jpg"
+    malformed_path.write_bytes(malformed)
+    print(
+        f"  wrote {malformed_path} ({len(malformed)} bytes, malformed XMP injected)"
+    )
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <output_dir>", file=sys.stderr)
+        return 1
+    out_dir = pathlib.Path(sys.argv[1])
+    print(f"Generating JPEG fixtures under {out_dir}")
+    generate(out_dir)
+    print("\nAll fixtures generated successfully.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/unit/sipiimage/jpeg_format_regression_test.cpp
+++ b/test/unit/sipiimage/jpeg_format_regression_test.cpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2016 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+ * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Regression tests for DEV-6250 (heritage JPEG read failures + metadata
+ * robustness + YCCK support) and DEV-6257 (CMYK APP14 Adobe transform
+ * inversion). Every test in this file fails on `main` and passes on the
+ * matching fix commits.
+ */
+
+#include "gtest/gtest.h"
+
+#include "../../../src/SipiImage.hpp"
+#include "../../../src/SipiImageError.hpp"
+#include "SipiIOTiff.h"
+#include "iiifparser/SipiRegion.h"
+#include "iiifparser/SipiSize.h"
+
+#include <memory>
+#include <string>
+
+namespace {
+
+constexpr const char *kJpegHeritage_o = "../../../../test/_test_data/images/jpeg/35-2421d-o.jpg";
+constexpr const char *kJpegHeritage_r = "../../../../test/_test_data/images/jpeg/35-2421d-r.jpg";
+constexpr const char *kJpegCmykApp14 = "../../../../test/_test_data/images/jpeg/cmyk/cmyk_photoshop_app14.jpg";
+constexpr const char *kJpegCmykRaw = "../../../../test/_test_data/images/jpeg/cmyk/cmyk_raw_no_app14.jpg";
+constexpr const char *kJpegMalformedXmp = "../../../../test/_test_data/images/jpeg/malformed_xmp.jpg";
+
+Sipi::SipiImage readFixture(const std::string &path)
+{
+  Sipi::SipiIOTiff::initLibrary();// JPEG tests may transitively touch libtiff
+  Sipi::SipiImage img;
+  img.read(path);
+  return img;
+}
+
+}// namespace
+
+// -------------------------------------------------------------------------
+// DEV-6250 — heritage JPEG read + metadata robustness
+// -------------------------------------------------------------------------
+
+/*! R6 — both heritage JPEG variants must read successfully after the
+ *  Phase 4 fix. The exact root cause is captured during Phase 4
+ *  diagnosis using `--json`; regardless of that cause, the contract is
+ *  "sipi reads these images without throwing". We use a parameterized
+ *  test so both siblings (-o and -r) share the same contract. */
+class Jpeg_35_2421d_Reads : public ::testing::TestWithParam<const char *>
+{
+};
+
+TEST_P(Jpeg_35_2421d_Reads, ReadsSuccessfully)
+{
+  const char *path = GetParam();
+  Sipi::SipiImage img;
+  ASSERT_NO_THROW(img = readFixture(path)) << "Failed to read " << path;
+  EXPECT_EQ(img.getNx(), 404u);
+  EXPECT_EQ(img.getNy(), 201u);
+  EXPECT_EQ(img.getNc(), 3u);// RGB
+  EXPECT_EQ(img.getBps(), 8u);
+}
+
+/*! R6b — DEV-6259 follow-up to R6: the heritage Photoshop CS 2008 JPEGs
+ *  have an APP1 XMP segment that omits the optional `<?xpacket>` wrappers
+ *  and starts directly with `<x:xmpmeta>`. Once the simple "everything
+ *  after the namespace header is XMP" extractor lands, `img->xmp` must be
+ *  populated so the XMP block can round-trip into the JP2 output (via
+ *  `SipiIOJ2k::write`'s UUID-box emitter). */
+TEST_P(Jpeg_35_2421d_Reads, XmpSurvivesRead)
+{
+  const char *path = GetParam();
+  Sipi::SipiImage img;
+  ASSERT_NO_THROW(img = readFixture(path));
+  ASSERT_NE(img.getXmp(), nullptr) << "XMP must be populated for " << path;
+  // The XMP packet contains the German Photoshop dump including the
+  // distinctive umlaut substring "Dateigröße" (file size).
+  const std::string xmp_bytes = img.getXmp()->xmpBytes();
+  EXPECT_NE(xmp_bytes.find("Dateigr"), std::string::npos)
+    << "XMP body should contain the German Photoshop caption";
+}
+
+INSTANTIATE_TEST_SUITE_P(Heritage, Jpeg_35_2421d_Reads, ::testing::Values(kJpegHeritage_o, kJpegHeritage_r));
+
+/*! R8 — a JPEG whose metadata fails to parse must still return a usable
+ *  image. Today, an exception during IPTC / EXIF / XMP parsing aborts the
+ *  entire read. Phase 5.3 wraps each metadata block in a try/catch and
+ *  downgrades parse failures to warnings.
+ *
+ *  We use `malformed_xmp.jpg` — a valid JPEG envelope with a deliberately
+ *  corrupted XMP packet — to exercise the XMP-specific path. After the
+ *  Phase 5.3 fix the image decodes; the warning is routed to stderr. */
+TEST(JpegFormatRegression, JpegCorruptXmpStillReadsImage)
+{
+  Sipi::SipiImage img;
+  ASSERT_NO_THROW(img = readFixture(kJpegMalformedXmp));
+  EXPECT_EQ(img.getNx(), 64u);
+  EXPECT_EQ(img.getNy(), 64u);
+  EXPECT_EQ(img.getNc(), 3u);
+}
+
+/*! R7 — a YCCK-colorspace JPEG must read (mapped to SEPARATED / CMYK
+ *  by libjpeg-turbo's internal conversion). Today, SipiIOJpeg.cpp:745
+ *  throws `"Unsupported JPEG colorspace JCS_YCCK"`.
+ *
+ *  Pillow cannot directly produce a YCCK JPEG from a single call, so this
+ *  test is marked DISABLED until a YCCK fixture is provided. Phase 5.1
+ *  enables YCCK → SEPARATED mapping. Once a fixture is available, rename
+ *  the test to remove the `DISABLED_` prefix. */
+TEST(JpegFormatRegression, DISABLED_JpegYcckColorspaceReads)
+{
+  GTEST_SKIP() << "Enable once a YCCK fixture is committed (DEV-6250 follow-up)";
+}
+
+// -------------------------------------------------------------------------
+// DEV-6257 — JPEG CMYK APP14 Adobe transform inversion
+// -------------------------------------------------------------------------
+
+/*! R9 — a Photoshop-produced CMYK JPEG (APP14 with transform=0) must read
+ *  and produce CMYK polarity consistent with the source. libjpeg-turbo
+ *  returns inverted CMYK for APP14 transform=0; sipi must re-invert.
+ *  Today there is no APP14 detection and the values are wrong.
+ *
+ *  This test pins the "read succeeds" contract; the colour-correctness
+ *  assertion lives in a follow-up approval test once Phase 5.2 lands. */
+TEST(JpegFormatRegression, JpegCmykPhotoshopApp14Inversion)
+{
+  Sipi::SipiImage img;
+  ASSERT_NO_THROW(img = readFixture(kJpegCmykApp14));
+  EXPECT_EQ(img.getNc(), 4u);// CMYK
+  EXPECT_EQ(img.getPhoto(), Sipi::PhotometricInterpretation::SEPARATED);
+}
+
+/*! R10 — a raw CMYK JPEG with no APP14 marker must **not** be inverted.
+ *  This is the negative case that pins the branch logic added in Phase 5.2
+ *  so the inversion fix does not over-apply to files that do not need it.
+ *  This test is expected to pass on `main` (no inversion happens) — the
+ *  purpose is to guard against regressions once Phase 5.2 introduces the
+ *  APP14-aware inversion path. */
+TEST(JpegFormatRegression, JpegCmykRawNoApp14NotInverted)
+{
+  Sipi::SipiImage img;
+  ASSERT_NO_THROW(img = readFixture(kJpegCmykRaw));
+  EXPECT_EQ(img.getNc(), 4u);
+  EXPECT_EQ(img.getPhoto(), Sipi::PhotometricInterpretation::SEPARATED);
+}

--- a/test/unit/sipiimage/tiff_bilevel_regression_test.cpp
+++ b/test/unit/sipiimage/tiff_bilevel_regression_test.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2016 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+ * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Regression tests for DEV-6249 — 1-bit bilevel TIFF support and the
+ * dormant ROI/switch bugs that were exposed once the rejection gate was
+ * removed. Every test in this file fails on `main` and passes on the
+ * matching fix commit.
+ */
+
+#include "gtest/gtest.h"
+
+#include "../../../src/SipiImage.hpp"
+#include "../../../src/SipiImageError.hpp"
+#include "SipiIOTiff.h"
+#include "iiifparser/SipiRegion.h"
+#include "iiifparser/SipiSize.h"
+
+#include <memory>
+#include <string>
+
+namespace {
+
+constexpr const char *kBilevelLzwMinisWhite = "../../../../test/_test_data/images/bilevel/bilevel_lzw_miniswhite.tif";
+constexpr const char *kBilevelNoneMinisWhite = "../../../../test/_test_data/images/bilevel/bilevel_none_miniswhite.tif";
+constexpr const char *kBilevelLzwMinisBlack = "../../../../test/_test_data/images/bilevel/bilevel_lzw_minisblack.tif";
+constexpr const char *kBilevelRoiTest = "../../../../test/_test_data/images/bilevel/bilevel_roi_test.tif";
+
+constexpr const char *kLeaves8Tif = "../../../../test/_test_data/images/knora/Leaves8.tif";
+
+Sipi::SipiImage readFixture(const std::string &path,
+  std::shared_ptr<Sipi::SipiRegion> region = nullptr,
+  std::shared_ptr<Sipi::SipiSize> size = nullptr)
+{
+  Sipi::SipiIOTiff::initLibrary();
+  Sipi::SipiImage img;
+  img.read(path, region, size);
+  return img;
+}
+
+}// namespace
+
+/*! R1 — a bps=1 LZW-compressed MINISWHITE TIFF must read successfully and
+ *  be exposed as 8-bit grayscale. On `main` this throws
+ *  `"Images with 1 bit/sample not supported"` from SipiIOTiff.cpp:1192. */
+TEST(TiffBilevelRegression, Tiff1BitLzwMinisWhiteReadsAs8Bit)
+{
+  Sipi::SipiImage img;
+  ASSERT_NO_THROW(img = readFixture(kBilevelLzwMinisWhite));
+  EXPECT_EQ(img.getNx(), 128u);
+  EXPECT_EQ(img.getNy(), 128u);
+  EXPECT_EQ(img.getNc(), 1u);
+  // After reading, a 1-bit TIFF must be exposed as 8-bit grayscale.
+  EXPECT_EQ(img.getBps(), 8u);
+}
+
+/*! R2 — the same contract applies to uncompressed bilevel TIFFs. One of the
+ *  22 failing DEV-6249 files (7-27_KV40_FN473) has Compression=None and was
+ *  rejected by the same gate. */
+TEST(TiffBilevelRegression, Tiff1BitUncompressedReadsAs8Bit)
+{
+  Sipi::SipiImage img;
+  ASSERT_NO_THROW(img = readFixture(kBilevelNoneMinisWhite));
+  EXPECT_EQ(img.getBps(), 8u);
+  EXPECT_EQ(img.getNc(), 1u);
+}
+
+/*! R3 — MINISBLACK photometric must also be handled without throwing.
+ *  Covered by the same rejection gate today. */
+TEST(TiffBilevelRegression, Tiff1BitMinisBlackInvertsCorrectly)
+{
+  Sipi::SipiImage img;
+  ASSERT_NO_THROW(img = readFixture(kBilevelLzwMinisBlack));
+  EXPECT_EQ(img.getBps(), 8u);
+  EXPECT_EQ(img.getPhoto(), Sipi::PhotometricInterpretation::MINISBLACK);
+}
+
+/*! R4 — reading a 1-bit TIFF with a non-zero IIIF region (ROI) must not
+ *  trigger a buffer overflow. On `main` (once the rejection gate is removed)
+ *  the memcpy on SipiIOTiff.cpp:638 uses `nc * i * roi_w` instead of
+ *  `nc * (i - roi_y) * roi_w` and writes past the end of `inbuf`. Under ASan
+ *  this crashes; without ASan it may silently corrupt heap memory. The
+ *  fix from Phase 2.2 (`i - roi_y` offset) makes the ROI read safe. */
+TEST(TiffBilevelRegression, Tiff1BitRoiDoesNotCorruptMemory)
+{
+  // 256x192 fixture; crop a band at y=64, h=64 so the memcpy destination
+  // offset bug would write beyond `inbuf` if still present.
+  auto region = std::make_shared<Sipi::SipiRegion>("0,64,256,64");
+  Sipi::SipiImage img;
+  ASSERT_NO_THROW(img = readFixture(kBilevelRoiTest, region));
+  EXPECT_EQ(img.getNx(), 256u);
+  EXPECT_EQ(img.getNy(), 64u);
+  EXPECT_EQ(img.getBps(), 8u);
+}
+
+/*! R5 — the switch fall-through at SipiIOTiff.cpp:1190-1200 sets `ps=2`
+ *  unconditionally because case 8 does not `break`. The fix restores
+ *  `ps=1` for 8-bit. We pin this via the post-read buffer size: an 8-bit
+ *  grayscale image must have `width * height * 1` bytes, not double.
+ *  Today, the fall-through path allocates twice the needed memory but
+ *  only copies the correct amount — so this test observes the bug
+ *  indirectly via pixel size rather than a sanitizer crash. */
+TEST(TiffBilevelRegression, Tiff8BitBufferSizeIsCorrect)
+{
+  Sipi::SipiImage img;
+  ASSERT_NO_THROW(img = readFixture(kLeaves8Tif));
+  // Leaves8.tif is 8-bit; after reading, pixels must be stored as one byte
+  // per sample. Verify bps and that the image is in a consistent post-read
+  // state (nx/ny populated) so regressions in the switch fix are caught.
+  EXPECT_EQ(img.getBps(), 8u);
+  EXPECT_GT(img.getNx(), 0u);
+  EXPECT_GT(img.getNy(), 0u);
+}


### PR DESCRIPTION
Fixes DEV-6249, DEV-6250, DEV-6257, DEV-6259

## Motivation

A batch of 22 high-resolution 1-bit bilevel TIFF scans (1800 DPI,
CanoScan 9000F + Adobe Photoshop CC) and 2 JPEG files from a cultural
heritage collection could not be ingested through sipi. These are
legitimate archival images that sipi must handle as an IIIF-compatible
preservation server. Research on the JPEG handler surfaced four
targeted robustness gaps (YCCK colorspace, CMYK APP14 inversion,
resilient metadata parsing, brittle XMP packet extractor) worth fixing
in the same pass.

A separate but enabling piece of work: sipi's rich `ImageContext`
error data only surfaces when a Sentry DSN is configured. RDU runs
sipi locally without Sentry, so every non-zero exit lost its structured
context. A new `--json` CLI flag emits the same payload to stdout,
unblocking local debugging and — importantly for this PR — driving
the JPEG diagnosis to a specific fix.

## Summary

- New `--json` CLI flag emits a single structured JSON document
  (`status: "ok"` or `"error"` with `phase` + `error_message`) to
  stdout for every CLI invocation, reserving stderr for log output.
- 1-bit bilevel TIFFs (both MINISWHITE and MINISBLACK, both LZW and
  uncompressed) now read through the IIIF pipeline; three dormant
  ROI/switch bugs that the rejection gate was masking are fixed
  along the way.
- JPEG handler: YCCK colorspace decodes via the CMYK path; Adobe
  APP14 transform flag is read and applied so Photoshop-produced
  CMYK JPEGs render with correct polarity; metadata parse failures
  are logged as warnings instead of aborting the whole read; XMP
  packets that omit the optional `<?xpacket>` wrappers (Photoshop
  CS 2008) are now extracted correctly and round-trip into JP2
  output.

## Key Changes

### `--json` CLI output

- New `--json` flag in `src/sipi.cpp` mutually exclusive with
  `--salsah` and `--query`; silently ignored with `--config`
  (server mode).
- `include/SipiReport.h` / `src/SipiReport.cpp` — jansson-based
  emitter for the `ImageContext` schema, with RAII wrappers
  (`std::unique_ptr<json_t, decltype(&json_decref)>`) so a stream
  exception can't leak the `json_t*` or the `json_dumps` buffer.
- `Logger::set_json_mode()` (backed by `std::atomic<bool>` for
  formal data-race-freedom) routes every log level to stderr when
  `--json` is active so stdout holds exactly one JSON document.
- Schema reference + worked examples in the new
  `docs/src/guide/json-output.md`.

### 1-bit bilevel TIFF (DEV-6249)

- Removed the `throw` at `SipiIOTiff.cpp:1192` and the dead
  `cvrt1BitTo8Bit` helper that was made unreachable by the existing
  on-the-fly `one2eight<T>()` unpack.
- Fixed three bugs in `read_standard_data<T>` that were dormant
  because the gate rejected 1-bit before reaching them:
  - switch fall-through (cases 8/16 lacked `break`, so `ps` was
    always 2 — 8-bit images allocated twice the needed bytes)
  - `memcpy` destination offsets for cases 1/4/12/16 used
    `i * roi_w` instead of `(i - roi_y) * roi_w` — any ROI with
    `roi_y > 0` wrote past the end of `inbuf`
  - uncompressed-contig loop bounded by `i < roi_h` instead of
    `i < roi_y + roi_h`
- Guarded the transfer-function allocation at line 1110 against
  `bps < 8` and wrapped the `tfunc` buffer in
  `std::make_unique<unsigned short[]>` so a `SipiIcc` ctor throw
  can't leak it.

### JPEG handler (DEV-6250, DEV-6257, DEV-6259)

- IPTC/EXIF/XMP parsing in `SipiIOJpeg.cpp`'s marker loop wrapped in
  per-block `try/catch (const std::exception&)`; a malformed segment
  no longer aborts the read.
- `JCS_YCCK` now maps to `SEPARATED` and shares the CMYK inversion
  path (libjpeg-turbo converts YCCK → inverted CMYK internally).
- New `uint8_t app14_transform` field on `SipiImage`. APP0+14 Adobe
  markers are parsed, transform byte stored at offset 11, and
  CMYK/YCCK output re-inverted when `app14_transform ∈ {0, 2}` and
  `nc == 4`. All four special-member functions propagate the field.
- The hand-rolled XMP `<?xpacket>` boundary scanner (~70 LOC)
  replaced with a 10-line "everything after the 29-byte namespace
  header is the XMP packet" extractor — handles JPEGs that omit the
  optional `<?xpacket>` wrappers (Photoshop CS 2008).
- New `SipiImage::getXmp()` accessor mirrors the existing `getExif()`
  / `getIcc()` pattern so regression tests can assert XMP survival.

## Challenges and Decisions

### JPEG root cause — XMP scanner brittleness, not Exiv2

**Problem:** The two DEV-6250 heritage JPEGs failed during read. The
hypothesis at plan time was "Exiv2 + German umlauts in IPTC".

**Tried:** Using `--json` to capture the structured failure envelope
immediately identified the throw site as the in-file XMP packet
extraction inside `SipiIOJpeg::read`, not Exiv2. The IPTC parsing was
never reached. Inspecting the raw APP1 bytes showed the XMP packet
itself was well-formed (`<x:xmpmeta xmlns:x="adobe:ns:meta/" ...>`)
but Photoshop CS 2008 omitted the optional `<?xpacket begin` /
`<?xpacket end` wrappers per Adobe XMP Specification Part 3 §1.1.3.
The hand-rolled scanner required those wrappers.

**Solution (two-step):** First, wrap every metadata parse block in
`try/catch` (Phase 5.3) so the scanner failure becomes a `log_warn`
instead of an aborted read — this unblocked the heritage files
immediately but silently dropped the XMP block. Second, replace the
~70-line scanner with a 10-line "rest of segment is XMP" extractor
(DEV-6259). `SipiXmp` already stored the raw string without parsing
it, so no Exiv2 integration was needed. Net effect: 2/2 previously
failing JPEGs convert, and their XMP now round-trips into the JP2
output (verified with exiftool — both XMPToolkit and Description tags
with German "Dateigröße…" present in the output JP2).

ExtendedXMP (multi-segment >64KB packets) remains unhandled; the
previous TODO is preserved as `TODO(DEV-6259)` in the code for a
future dedicated fix if needed.

### CMYK inversion — when and when not to apply

**Problem:** libjpeg-turbo returns inverted CMYK only when the JPEG
advertises an Adobe APP14 marker with `transform=0` or `transform=2`.
A naive "always invert CMYK" fix would corrupt raw CMYK JPEGs (no
APP14).

**Solution:** Detect APP14, store the transform byte on `SipiImage`,
and invert only for the two variants where libjpeg-turbo's output is
in reversed polarity. Regression test R10 pins the raw-CMYK branch
so the inversion fix can never over-apply. This required updating all
four `SipiImage` special-member functions to propagate the new field —
the failure mode would have been silent (a copied image loses its
inversion flag and renders incorrectly downstream), so R10's
negative-case coverage matters.

During review one reviewer flagged the line as an off-by-one
(`data[11]` vs. described byte 12). Verified empirically by
inspecting the actual Pillow-generated APP14 bytes: the comment was
wrong (described a spurious NUL after "Adobe"), the code was right
per the Adobe spec. Comment rewritten.

### Switch fall-through + dormant ROI bugs

**Problem:** Removing the `bps == 1` rejection gate would have
activated two latent bugs in `read_standard_data`: the switch
fall-through that set `ps = 2` unconditionally, and the `memcpy`
destination offsets that used `i * roi_w` instead of
`(i - roi_y) * roi_w` for every case except 8-bit.

**Solution:** Fix the dormant bugs first (Phase 2 in the plan) as a
separate commit from the gate removal so git bisect across future
regressions has clean attribution.

## Gotchas

- **`--json` contract:** with `--json` set, `log_info` and `log_warn`
  go to **stderr**, not stdout. This differs from the default CLI log
  routing. If you pipe `--json` output through `jq` or similar you
  must redirect stderr separately (`2>sipi.log`) or the log lines
  will interleave with the JSON document.
- **`SipiImage::app14_transform` default:** the field default is
  `255` ("no APP14"). Non-JPEG format handlers must not overwrite it,
  and the invert-after-read branch uses the default as the "don't
  invert" sentinel. If a future format stores 0 there for any other
  reason, the CMYK branch will accidentally invert.
- **XMP extraction is now permissive:** the new extractor takes
  everything after the 29-byte namespace header as the XMP string.
  This is correct per the Adobe spec but if a JPEG ever embeds
  trailing non-XMP bytes after the packet inside the same APP1
  segment (no known case), they would be included verbatim. `SipiXmp`
  stores the string without parsing, so callers consuming
  `getXmp()->xmpBytes()` should treat it as opaque.
- **`cvrt1BitTo8Bit` is deleted:** if downstream code (Lua scripts,
  internal callers) referenced it, the build will fail. The only
  call sites were the two dead post-read branches removed in the
  same commit.

## Test Plan

- [x] `ctest -L unit` — all 10 unit test targets pass (~82s)
- [x] `tiff_bilevel_regression_test` — R1–R5 all pass
- [x] `jpeg_format_regression_test` — R6–R10 all pass, plus the new
      `XmpSurvivesRead/{0,1}` parameterized assertion confirms XMP
      round-trips via `getXmp()`
- [x] `cargo test --test cli_json` — F1–F3 all pass
- [x] Real-data validation: `sipi --file $F $F.jp2` on each of the 22
      failing TIFFs + 2 failing JPEGs in
      `/Users/subotic/Downloads/FailingImages/` — **24/24 convert**
- [x] XMP round-trip verified end-to-end: `exiftool -G -a -s
      out.jp2` on the converted heritage JP2 shows the same XMP tags
      (XMPToolkit + Description with German "Dateigröße…") as the
      source JPEG
- [x] `--json` exercised against a good JPG, a `cli_args` error, and
      the real failing TIFF — all emit well-formed single-document
      payloads