### PR TITLE
ci: fetch Kakadu from dsp-ci-assets release in checkout action

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -1,8 +1,8 @@
 name: "Checkout"
-description: "Checkout code, LFS objects, and ci-assets"
+description: "Checkout code, LFS objects, and the Kakadu archive"
 inputs:
   DASCHBOT_PAT:
-    description: "daschbot's private access token"
+    description: "daschbot's private access token (used to download Kakadu from dsp-ci-assets releases)"
     required: true
 
 runs:
@@ -24,12 +24,8 @@ runs:
       run: |
         git lfs install --local
         git lfs pull
-    - name: checkout private ci-assets
-      uses: actions/checkout@v4
-      with:
-        repository: dasch-swiss/dsp-ci-assets
-        token: ${{ inputs.DASCHBOT_PAT }}
-        path: ci
-    - name: copy ci-assets
+    - name: Fetch Kakadu archive from dsp-ci-assets release
       shell: bash
-      run: cp $GITHUB_WORKSPACE/ci/kakadu/{v8_4_1-01382N,v8_5-01382N}.zip $GITHUB_WORKSPACE/vendor/
+      env:
+        GH_TOKEN: ${{ inputs.DASCHBOT_PAT }}
+      run: ./scripts/fetch-kakadu.sh

--- a/scripts/fetch-kakadu.sh
+++ b/scripts/fetch-kakadu.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Fetch the proprietary Kakadu archive from dsp-ci-assets release into vendor/.
+# Idempotent: skips download if the file is already present.
+#
+# Local: requires `gh auth login` and dasch-swiss org membership.
+# CI: set GH_TOKEN to a PAT with read access to dsp-ci-assets (DASCHBOT_PAT).
+#
+# Re-run after bumping the asset name / sha256 in flake.nix.
+set -euo pipefail
+
+ASSET="v8_5-01382N.zip"
+TAG="kakadu-v8.5"
+REPO="dasch-swiss/dsp-ci-assets"
+DEST="vendor/$ASSET"
+
+if [ ! -f "$DEST" ]; then
+    if ! command -v gh >/dev/null 2>&1; then
+        echo "error: gh CLI not found; install GitHub CLI to fetch Kakadu" >&2
+        exit 1
+    fi
+
+    echo "Fetching $ASSET from $REPO ($TAG)..."
+    gh release download "$TAG" \
+        --repo "$REPO" \
+        --pattern "$ASSET" \
+        --dir vendor/
+
+    echo "$DEST downloaded ($(wc -c < "$DEST") bytes)"
+else
+    echo "$DEST already present — skipping download"
+fi
+
+# Nix flake source filtering excludes gitignored files (see .gitignore:
+# "vendor/v8_5-*.zip"). Use git's intent-to-add to make the file visible to
+# Nix's flake source without staging it for commit. The file is still
+# protected by the gitignore entry against accidental `git add`.
+if [ -d .git ] || git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git add --intent-to-add --force "$DEST"
+fi


### PR DESCRIPTION
## Summary

The composite action `.github/actions/checkout` was sub-checking-out `dsp-ci-assets` and copying `ci/kakadu/{v8_4_1,v8_5}-01382N.zip` into `vendor/`. Phase 1c of the Nix unified build ([DEV-6265](https://linear.app/dasch/issue/DEV-6265)) rewrote `dsp-ci-assets` to drop the proprietary Kakadu archives from the git tree — they now live as GitHub release assets only.

As a result, **every workflow run on `main` is currently failing** with:

```
cp: cannot stat '.../ci/kakadu/v8_5-01382N.zip': No such file or directory
```

## Changes

- Replace the sub-checkout + cp with a new `scripts/fetch-kakadu.sh` — a small idempotent wrapper around `gh release download` that pulls the pinned Kakadu archive into `vendor/`.
- The script also runs `git add --intent-to-add --force` so Nix's flake source filter sees the gitignored archive (used by the upcoming `nix build .#default`-based workflow in #558).
- Auth: re-uses the existing `DASCHBOT_PAT` input via `GH_TOKEN`.

This is a strict improvement on its own — the old sub-checkout pulled the entire dsp-ci-assets working tree just for two zip files, and now only `v8_5` is needed (`v8_4_1` is no longer referenced by the build).

## Test plan

- [ ] Merge → confirm CI on `main` (and other PRs) goes green again
- [ ] Unblocks #558 (Nix unified build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)