### PR TITLE
fix(ci): create GitHub Release if missing in publish-static-release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -201,6 +201,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Create the release if it doesn't exist yet (e.g. after a
+          # manual retag, or if release-please didn't create one).
+          # Race-safe: the parallel matrix arch that loses the race
+          # falls through to `gh release upload --clobber`.
+          if ! gh release view "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            gh release create "${GITHUB_REF_NAME}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --title "${GITHUB_REF_NAME}" \
+              --generate-notes || true
+          fi
           gh release upload "${GITHUB_REF_NAME}" \
             result/*.tar.gz \
             result/*.sha256 \


### PR DESCRIPTION
## Motivation

During the v4.1.0 retag (PR #560 follow-up), `publish-static-release / {amd64,arm64}` failed with:

```
release not found
```

from `gh release upload`. Cause: the release didn't exist because it was previously deleted as part of `gh release delete --cleanup-tag`, and `gh release upload` doesn't create-on-demand. The old `softprops/action-gh-release@v3` step (retired in #560's publish.yml rewrite) did handle this implicitly.

## Summary

- `publish-static-release` now checks for the release with `gh release view` and creates it via `gh release create --generate-notes` if absent.
- `|| true` on the create + `--clobber` on the upload make the two matrix arches race-safe.

## Test Plan

- [ ] Post-merge: rerun the stalled `publish-static-release / {amd64,arm64}` jobs on v4.1.0 and verify the `sipi-v4.1.0-linux-{amd64,arm64}.tar.gz{,.sha256,.debug}` trio lands on the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)