### PR TITLE
fix(http): distinguish client-aborted HTTP writes from real write errors

### DIFF
--- a/src/SipiHttpServer.cpp
+++ b/src/SipiHttpServer.cpp
@@ -2089,6 +2089,16 @@ static void serve_iiif(Connection &conn_obj,
     capture_image_error(err.to_string(), "write", sentry_ctx, SipiMode::Server);
     send_error(conn_obj, Connection::INTERNAL_SERVER_ERROR, err);
     return;
+  } catch (Sipi::SipiImageClientAbortError &) {
+    // Client closed the socket mid-response (matches Traefik HTTP 499).
+    // Not a server error: no Sentry capture, no response (the peer is gone).
+    if (cache != nullptr) {
+      conn_obj.closeCacheFile();
+      unlink(cachefile.c_str());
+    }
+    log_info("Client aborted HTTP response for %s", uri.c_str());
+    SipiMetrics::instance().client_disconnected_total.Increment();
+    return;
   } catch (Sipi::SipiImageError &err) {
     if (cache != nullptr) {
       conn_obj.closeCacheFile();

--- a/src/SipiImageError.hpp
+++ b/src/SipiImageError.hpp
@@ -13,9 +13,23 @@
 namespace Sipi {
 
 /*!
- * This class implements the error handling for the different image formats.
+ * Base class for image-format errors. Subclass this (not `final` — intentional)
+ * to model distinct failure modes as types. The HTTP handler and other catch
+ * sites dispatch by type, so a dedicated subclass is the cheapest way to give
+ * an error a different policy (Sentry capture, HTTP status, client message).
+ *
+ * Pattern for new subclasses:
+ *   - Inherit publicly from `SipiImageError`
+ *   - `using SipiImageError::SipiImageError;` to forward constructors (leaf types
+ *     with no extra state); define explicit constructors if carrying a payload
+ *   - Mark the subclass `final` unless it is itself a further base
+ *   - Place the new `catch (MyError &)` BEFORE `catch (SipiImageError &)` at
+ *     every call site (derived-most first)
+ *
+ * See `docs/src/development/error-model.md` for the full catalog and policy
+ * mapping (HTTP status, Sentry capture, client-facing message).
  */
-class SipiImageError final : public std::exception
+class SipiImageError : public std::exception
 {
 
 public:
@@ -93,6 +107,18 @@ private:
   int errnum_;//!< error number if a system call is the reason for the error
   std::source_location location_;//!< Source location where the error occurs
   std::string fullerrmsg_;
+};
+
+/*!
+ * Signals that a write to an HTTP response failed because the client closed
+ * the connection before we finished sending. Detected at the write site via
+ * shttps::Connection::peerConnected(). The HTTP handler uses the distinct
+ * type to skip Sentry capture — these are not server-side errors.
+ */
+class SipiImageClientAbortError final : public SipiImageError
+{
+public:
+  using SipiImageError::SipiImageError;
 };
 }// namespace Sipi
 

--- a/src/formats/SipiIOJ2k.cpp
+++ b/src/formats/SipiIOJ2k.cpp
@@ -54,6 +54,11 @@ private:
   shttps::Connection *conobj;
 
 public:
+  //! Set when write()/close() fails because the peer closed the socket.
+  //! Read from the top-level SipiIOJ2k::write error handler to distinguish
+  //! client aborts from genuine Kakadu failures.
+  bool client_aborted{ false };
+
   J2kHttpStream(shttps::Connection *conobj_p);
 
   ~J2kHttpStream();
@@ -96,7 +101,8 @@ bool J2kHttpStream::write(const kdu_byte *buf, int num_bytes)
 {
   try {
     conobj->sendAndFlush(buf, num_bytes);
-  } catch (int i) {
+  } catch (int) {
+    if (!conobj->peerConnected()) client_aborted = true;
     return false;
   }
   return true;
@@ -107,7 +113,8 @@ bool J2kHttpStream::close()
 {
   try {
     conobj->flush();
-  } catch (int i) {
+  } catch (int) {
+    if (!conobj->peerConnected()) client_aborted = true;
     return false;
   }
   return true;
@@ -770,6 +777,10 @@ void SipiIOJ2k::write(SipiImage *img, const std::string &filepath, const SipiCom
 
   if ((num_threads = kdu_get_num_processors()) < 2) num_threads = 0;
 
+  // Declared outside the try so the catch below can read `http->client_aborted`
+  // to distinguish client aborts from genuine Kakadu failures.
+  std::unique_ptr<J2kHttpStream> http;
+
   try {
     // Construct code-stream object
     siz_params siz;
@@ -818,11 +829,10 @@ void SipiIOJ2k::write(SipiImage *img, const std::string &filepath, const SipiCom
 
     jp2_family_tgt jp2_ultimate_tgt;
 
-    J2kHttpStream *http = nullptr;
     if (filepath == "HTTP") {
       shttps::Connection *conobj = img->connection();
-      http = new J2kHttpStream(conobj);
-      jp2_ultimate_tgt.open(http, &membroker);
+      http = std::make_unique<J2kHttpStream>(conobj);
+      jp2_ultimate_tgt.open(http.get(), &membroker);
     } else {
       jp2_ultimate_tgt.open(filepath.c_str(), &membroker);
     }
@@ -1264,8 +1274,10 @@ void SipiIOJ2k::write(SipiImage *img, const std::string &filepath, const SipiCom
       delete[] precisions;
       delete[] is_signed;
     }
-    if (http != nullptr) { delete http; }
   } catch (kdu_exception e) {
+    if (http && http->client_aborted) {
+      throw SipiImageClientAbortError("Client aborted HTTP response during JPEG2000 write");
+    }
     throw SipiImageError("Failed writing JPEG2000 image (Kakadu exception " + std::to_string(e) + ")"
       + ", file=" + filepath
       + ", dimensions=" + std::to_string(img->nx) + "x" + std::to_string(img->ny)

--- a/src/formats/SipiIOJpeg.cpp
+++ b/src/formats/SipiIOJpeg.cpp
@@ -290,21 +290,33 @@ static void jpeg_file_src(struct jpeg_decompress_struct *cinfo, int file_id)
  * Struct that is used to hold the variables for defining the
  * private I/O routines which are used to write the the HTTP socket
  */
-typedef struct HtmlBuffer
+/*!
+ * Context for libjpeg's HTTP destination manager. Owned by the caller of
+ * SipiIOJpeg::write via std::unique_ptr declared *before* the setjmp(); that
+ * placement keeps the destructor on the normal C++ unwind path when we throw
+ * from the setjmp handler, avoiding the longjmp-skips-destructors UB that
+ * forced the previous malloc-based design.
+ */
+struct HtmlBuffer
 {
-  JOCTET *buffer;//!< Buffer for holding data to be written out
-  size_t buflen;//!< length of the buffer
-  shttps::Connection *conobj;//!< Pointer to the connection objects
-} HtmlBuffer;
+  explicit HtmlBuffer(shttps::Connection *conn, size_t buflen_p = 65536)
+    : buffer(std::make_unique<JOCTET[]>(buflen_p)), buflen(buflen_p), conobj(conn)
+  {}
+
+  std::unique_ptr<JOCTET[]> buffer;
+  size_t buflen;
+  shttps::Connection *conobj;
+  bool client_aborted{ false };
+};
 
 /*!
  * Function which initializes the structures for managing the IO
  */
 static void init_html_destination(j_compress_ptr cinfo)
 {
-  auto *html_buffer = (HtmlBuffer *)cinfo->client_data;
+  auto *html_buffer = static_cast<HtmlBuffer *>(cinfo->client_data);
   cinfo->dest->free_in_buffer = html_buffer->buflen;
-  cinfo->dest->next_output_byte = html_buffer->buffer;
+  cinfo->dest->next_output_byte = html_buffer->buffer.get();
 }
 
 //=============================================================================
@@ -314,22 +326,24 @@ static void init_html_destination(j_compress_ptr cinfo)
  */
 static boolean empty_html_buffer(j_compress_ptr cinfo)
 {
-  auto *html_buffer = (HtmlBuffer *)cinfo->client_data;
+  auto *html_buffer = static_cast<HtmlBuffer *>(cinfo->client_data);
+  std::string err_msg;
   try {
-    html_buffer->conobj->sendAndFlush(html_buffer->buffer, html_buffer->buflen);
+    html_buffer->conobj->sendAndFlush(html_buffer->buffer.get(), html_buffer->buflen);
+    cinfo->dest->free_in_buffer = html_buffer->buflen;
+    cinfo->dest->next_output_byte = html_buffer->buffer.get();
+    return static_cast<boolean>(true);
   } catch (const std::exception &e) {
-    log_err("JPEG HTTP write failed: %s", e.what());
-    ERREXIT(cinfo, JERR_FILE_WRITE);  // triggers jpegErrorExit → longjmp
-    return FALSE;  // unreachable
+    err_msg = e.what();
   } catch (...) {
-    log_err("JPEG HTTP write failed: unknown error");
-    ERREXIT(cinfo, JERR_FILE_WRITE);
-    return FALSE;  // unreachable
+    // sendAndFlush throws the bare shttps::OUTPUT_WRITE_FAIL enum — not derived
+    // from std::exception, so it reaches this branch.
+    err_msg = "unknown error";
   }
-  cinfo->dest->free_in_buffer = html_buffer->buflen;
-  cinfo->dest->next_output_byte = html_buffer->buffer;
-
-  return static_cast<boolean>(true);
+  if (!html_buffer->conobj->peerConnected()) html_buffer->client_aborted = true;
+  log_err("JPEG HTTP write failed: %s", err_msg.c_str());
+  ERREXIT(cinfo, JERR_FILE_WRITE);  // triggers jpegErrorExit → longjmp
+  return FALSE;  // unreachable
 }
 
 //=============================================================================
@@ -339,63 +353,38 @@ static boolean empty_html_buffer(j_compress_ptr cinfo)
  */
 static void term_html_destination(j_compress_ptr cinfo)
 {
-  auto *html_buffer = (HtmlBuffer *)cinfo->client_data;
-  size_t nbytes = cinfo->dest->next_output_byte - html_buffer->buffer;
+  auto *html_buffer = static_cast<HtmlBuffer *>(cinfo->client_data);
+  const size_t nbytes = cinfo->dest->next_output_byte - html_buffer->buffer.get();
+  std::string err_msg;
   try {
-    html_buffer->conobj->sendAndFlush(html_buffer->buffer, nbytes);
+    html_buffer->conobj->sendAndFlush(html_buffer->buffer.get(), nbytes);
+    return;
   } catch (const std::exception &e) {
-    log_err("JPEG HTTP write (term) failed: %s", e.what());
-    ERREXIT(cinfo, JERR_FILE_WRITE);
-    return;  // unreachable
+    err_msg = e.what();
   } catch (...) {
-    log_err("JPEG HTTP write (term) failed: unknown error");
-    ERREXIT(cinfo, JERR_FILE_WRITE);
-    return;  // unreachable
+    err_msg = "unknown error";
   }
-
-  free(html_buffer->buffer);
-  free(html_buffer);
-  cinfo->client_data = nullptr;
-
-  free(cinfo->dest);
-  cinfo->dest = nullptr;
-}
-
-//=============================================================================
-
-static void cleanup_html_destination(j_compress_ptr cinfo)
-{
-  auto *html_buffer = (HtmlBuffer *)cinfo->client_data;
-  free(html_buffer->buffer);
-  free(html_buffer);
-  cinfo->client_data = nullptr;
-
-  free(cinfo->dest);
-  cinfo->dest = nullptr;
+  if (!html_buffer->conobj->peerConnected()) html_buffer->client_aborted = true;
+  log_err("JPEG HTTP write (term) failed: %s", err_msg.c_str());
+  ERREXIT(cinfo, JERR_FILE_WRITE);
+  // unreachable
 }
 
 //=============================================================================
 
 /*!
- * This function is used to setup the I/O destination to the HTTP socket
+ * Wire libjpeg's destination callbacks to the caller-owned HtmlBuffer and
+ * destination-manager objects. Ownership of both stays with the caller's
+ * std::unique_ptrs — this function only installs pointers into `cinfo`.
  */
-static void jpeg_html_dest(struct jpeg_compress_struct *cinfo, shttps::Connection *conobj)
+static void jpeg_html_dest(struct jpeg_compress_struct *cinfo,
+                           HtmlBuffer *html_buffer,
+                           jpeg_destination_mgr *destmgr)
 {
-  struct jpeg_destination_mgr *destmgr;
-  HtmlBuffer *html_buffer;
-  cinfo->client_data = malloc(sizeof(HtmlBuffer));
-  html_buffer = (HtmlBuffer *)cinfo->client_data;
-
-  html_buffer->buffer = (JOCTET *)malloc(65536 * sizeof(JOCTET));
-  html_buffer->buflen = 65536;
-  html_buffer->conobj = conobj;
-
-  destmgr = (struct jpeg_destination_mgr *)malloc(sizeof(struct jpeg_destination_mgr));
-
+  cinfo->client_data = html_buffer;
   destmgr->init_destination = init_html_destination;
   destmgr->empty_output_buffer = empty_html_buffer;
   destmgr->term_destination = term_html_destination;
-
   cinfo->dest = destmgr;
 }
 
@@ -1075,6 +1064,12 @@ void SipiIOJpeg::write(SipiImage *img, const std::string &filepath, const SipiCo
   // FdGuard for outfile — constructed before setjmp. Its destructor runs
   // during the C++ stack unwinding from the throw SipiImageError after longjmp.
   FdGuard outfile_guard(-1);
+  // HTTP destination owned by the caller via unique_ptr. Declared before
+  // setjmp so destructors are on the normal C++ unwind path when we throw
+  // from the setjmp handler (longjmp would skip destructors of objects
+  // constructed *between* setjmp and longjmp — these live outside that window).
+  std::unique_ptr<HtmlBuffer> html_buffer;
+  std::unique_ptr<jpeg_destination_mgr> destmgr;
   JSAMPROW row_pointer[1];
   int row_stride;
   bool is_http = (filepath == "HTTP");
@@ -1093,17 +1088,19 @@ void SipiIOJpeg::write(SipiImage *img, const std::string &filepath, const SipiCo
   //
   if (setjmp(jerr.error_jmp)) {
     // longjmp landed here — clean up and throw in C++ context
-    if (is_http) {
-      cleanup_html_destination(&cinfo);
-    }
+    const bool client_aborted = html_buffer && html_buffer->client_aborted;
     jpeg_destroy_compress(&cinfo);
-    // outfile_guard destructor closes fd during throw unwinding
+    // html_buffer / destmgr / outfile_guard destructors run during throw unwinding
+    if (client_aborted) {
+      throw SipiImageClientAbortError("Client aborted HTTP response during JPEG write");
+    }
     throw SipiImageError("JPEG write failed: " + std::string(jerr.error_message));
   }
 
   if (is_http) {
-    shttps::Connection *conobj = img->connection();
-    jpeg_html_dest(&cinfo, conobj);
+    html_buffer = std::make_unique<HtmlBuffer>(img->connection());
+    destmgr = std::make_unique<jpeg_destination_mgr>();
+    jpeg_html_dest(&cinfo, html_buffer.get(), destmgr.get());
   } else {
     if (filepath == "stdout:") {
       jpeg_stdio_dest(&cinfo, stdout);

--- a/src/formats/SipiIOPng.cpp
+++ b/src/formats/SipiIOPng.cpp
@@ -412,13 +412,26 @@ void create_text_chunk(PngTextPtr *png_textptr, char *key, char *str, unsigned i
 
 /*==========================================================================*/
 
+/*!
+ * Context passed as the libpng I/O pointer for HTTP writes.
+ * The `client_aborted` flag is set when a send/flush fails because the
+ * peer closed the socket; the top-level setjmp handler reads it to
+ * distinguish client aborts from genuine write errors.
+ */
+struct PngHttpCtx
+{
+  shttps::Connection *conn;
+  bool client_aborted;
+};
+
 static void conn_write_data(png_structp png_ptr, png_bytep data, png_size_t length)
 {
-  shttps::Connection *conn = (shttps::Connection *)png_get_io_ptr(png_ptr);
+  auto *ctx = static_cast<PngHttpCtx *>(png_get_io_ptr(png_ptr));
 
   try {
-    conn->sendAndFlush(data, length);
+    ctx->conn->sendAndFlush(data, length);
   } catch (...) {
+    if (!ctx->conn->peerConnected()) ctx->client_aborted = true;
     // Signal error via libpng's error mechanism → sipi_error_fn → longjmp
     png_error(png_ptr, "HTTP write failed");
   }
@@ -428,11 +441,12 @@ static void conn_write_data(png_structp png_ptr, png_bytep data, png_size_t leng
 
 static void conn_flush_data(png_structp png_ptr)
 {
-  shttps::Connection *conn = (shttps::Connection *)png_get_io_ptr(png_ptr);
+  auto *ctx = static_cast<PngHttpCtx *>(png_get_io_ptr(png_ptr));
 
   try {
-    conn->flush();
+    ctx->conn->flush();
   } catch (...) {
+    if (!ctx->conn->peerConnected()) ctx->client_aborted = true;
     png_error(png_ptr, "HTTP flush failed");
   }
 }
@@ -448,10 +462,14 @@ void SipiIOPng::write(SipiImage *img, const std::string &filepath, const SipiCom
     throw SipiImageError("Error writing PNG file \"" + filepath + "\": png_create_write_struct failed !");
   }
 
+  // HTTP write context: kept on the stack so its address is valid for the
+  // lifetime of SipiIOPng::write. The address is stable across longjmp.
+  PngHttpCtx http_ctx{ img->connection(), false };
+
   if (filepath == "stdout:") {
     outfile = stdout;
   } else if (filepath == "HTTP") {
-    png_set_write_fn(png_ptr, img->connection(), conn_write_data, conn_flush_data);
+    png_set_write_fn(png_ptr, &http_ctx, conn_write_data, conn_flush_data);
   } else {
     if (!(outfile = fopen(filepath.c_str(), "wb"))) {
       png_free_data(png_ptr, nullptr, PNG_FREE_ALL, -1);
@@ -470,6 +488,9 @@ void SipiIOPng::write(SipiImage *img, const std::string &filepath, const SipiCom
   if (setjmp(png_jmpbuf(png_ptr))) {
     png_destroy_write_struct(&png_ptr, &info_ptr);
     if (outfile != nullptr && outfile != stdout) fclose(outfile);
+    if (http_ctx.client_aborted) {
+      throw SipiImageClientAbortError("Client aborted HTTP response during PNG write");
+    }
     throw SipiImageError("PNG write failed for \"" + filepath + "\"");
   }
 

--- a/src/formats/SipiIOTiff.cpp
+++ b/src/formats/SipiIOTiff.cpp
@@ -1739,7 +1739,11 @@ void SipiIOTiff::write(SipiImage *img, const std::string &filepath, const SipiCo
       try {
         img->connection()->sendAndFlush(memtif->data, memtif->flen);
       } catch (int i) {
+        const bool client_aborted = !img->connection()->peerConnected();
         memTiffFree(memtif);
+        if (client_aborted) {
+          throw Sipi::SipiImageClientAbortError("Client aborted HTTP response during TIFF write");
+        }
         throw Sipi::SipiImageError("Sending data failed! Broken pipe?: " + filepath + " !");
       }
     } else {


### PR DESCRIPTION
## Summary

- Introduces `SipiImageClientAbortError` (subclass of `SipiImageError`) to mark HTTP responses that failed because the peer closed the socket.
- Each format's HTTP write path (JPEG, PNG, TIFF, JPEG2000) checks `shttps::Connection::peerConnected()` when `sendAndFlush` throws; the top-level writer throws the subclass when the peer is gone.
- `SipiHttpServer` catches the subclass first, logs at `info`, and skips Sentry capture.

## Why

Sentry issue [SIPI-J / DEV-6274](https://linear.app/dasch/issue/DEV-6274) was escalating — 228 events in 3 days, all `"JPEG write failed: Output file write error --- out of disk space?"`. The message was misleading: there is no disk-space problem. libjpeg substitutes its generic `JERR_FILE_WRITE` string for any output-write failure, including failures on the HTTP socket used by `jpeg_html_dest`.

Traefik access logs on `dsp-prod-01` confirmed every matching event was an **HTTP 499** (client closed connection) from a Baidu crawler farm on `116.179.37.0/24`, aborting after ~6.5 s. The same misleading behaviour existed in the PNG, TIFF, and JPEG2000 writers.

This PR makes Sipi match what Traefik already recognises.

## Design

```
┌── sendAndFlush throws ─┐
│                        │
│  catch → peerConnected()?
│     ├─ false → set client_aborted flag
│     └─ true  → keep current behaviour (real error)
│                        │
│  ERREXIT / png_error / return false
│                        │
│  top-level write()
│     ├─ flag set → throw SipiImageClientAbortError
│     └─ flag clear → throw SipiImageError
│                        │
└── caught in SipiHttpServer ────────────
    catch (SipiImageClientAbortError &)  ← new: log_info, no Sentry
    catch (SipiImageError &)             ← existing: capture + send_error
```

No breaking change — `SipiImageClientAbortError` is-a `SipiImageError`, so any external code catching the base type still works.

## Test plan

- [ ] CI: unit, hurl, and rust e2e suites pass unchanged
- [ ] Manual on `dsp-stage-01` once deployed:
  - `curl --max-time 0.5 -o /dev/null 'https://iiif.dasch-staging.org/<known-large-jpx>/full/max/0/default.jpg'`
  - expect `Client aborted HTTP response for /...` in Sipi logs
  - expect **no** new Sentry event matching the old JERR_FILE_WRITE string
- [ ] Production watch: DEV-6274 event rate on `dsp-prod-01` drops to zero under normal bot traffic over 24 h after release

## Follow-ups (separate tickets)

- **Ops:** rate-limit or UA-gate Baidu ranges (`116.179.37.0/24`) at Traefik.
- **Sentry hygiene:** add a one-release inbound filter on the old message string as a safety net after deploy, then drop it.

Fixes DEV-6274

🤖 Generated with [Claude Code](https://claude.com/claude-code)