### PR TITLE
ci(loadtest): harden sipi startup supervision and log capture

### DIFF
--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -52,16 +52,36 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
         run: |
+          # exec replaces the inner bash with sipi so the tracked PID is sipi's
+          # wrapper (nix develop's direct child), not a throwaway shell.
           nix \
             --extra-experimental-features "nix-command flakes" \
             --option filter-syscalls false \
             develop --command bash -c \
-              "cd test/_test_data && ../../build/sipi --config config/sipi.e2e-test-config.lua &"
-          # Wait for server readiness
+              "cd test/_test_data && exec ../../build/sipi --config config/sipi.e2e-test-config.lua" \
+            > sipi.log 2>&1 &
+          SIPI_PID=$!
+          echo "$SIPI_PID" > sipi.pid
+          echo "Started sipi (wrapper PID $SIPI_PID)"
+
+          # Fail fast: if the wrapper exits before readiness, dump the log and abort.
           for i in $(seq 1 30); do
-            curl -sf http://127.0.0.1:1024/unit/lena512.jp2/info.json > /dev/null 2>&1 && break
+            if ! kill -0 "$SIPI_PID" 2>/dev/null; then
+              echo "::error::sipi exited before becoming ready (after ${i}s)"
+              cat sipi.log
+              exit 1
+            fi
+            if curl -sf http://127.0.0.1:1024/unit/lena512.jp2/info.json > /dev/null 2>&1; then
+              echo "sipi ready after ${i}s"
+              exit 0
+            fi
             sleep 1
           done
+
+          echo "::error::sipi did not become ready within 30s"
+          cat sipi.log
+          kill "$SIPI_PID" 2>/dev/null || true
+          exit 1
 
       - name: Run load tests
         run: |
@@ -94,7 +114,19 @@ jobs:
 
       - name: Stop sipi server
         if: always()
-        run: pkill -f "sipi.*e2e-test-config" || true
+        run: |
+          if [ -f sipi.pid ]; then
+            SIPI_PID=$(cat sipi.pid)
+            pkill -TERM -P "$SIPI_PID" 2>/dev/null || true
+            kill  -TERM    "$SIPI_PID" 2>/dev/null || true
+            for i in $(seq 1 5); do
+              kill -0 "$SIPI_PID" 2>/dev/null || break
+              sleep 1
+            done
+            kill -KILL "$SIPI_PID" 2>/dev/null || true
+          fi
+          # Fallback: name-match in case the PID chain was broken by nix develop.
+          pkill -f "sipi.*e2e-test-config" 2>/dev/null || true
 
       - name: Upload load test results
         if: always()
@@ -103,3 +135,11 @@ jobs:
           name: loadtest-results
           retention-days: 90
           path: loadtest-results/
+
+      - name: Upload sipi startup log (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sipi-server-log
+          retention-days: 30
+          path: sipi.log


### PR DESCRIPTION
Fixes DEV-6027

## Motivation

DEV-6027 raised two concerns against `.github/workflows/loadtest.yml`. The first — "`wrk` is not available in Ubuntu 24.04's default APT repos so the install step will fail" — is **refuted by CI history**: `gh run list --workflow=loadtest.yml` shows 10/10 recent scheduled runs succeeded, all including the `Install wrk` step (wrk lives in `noble`'s `universe` component, enabled by default on GitHub's `ubuntu-24.04` runner image).

The second concern — the sipi startup + readiness-poll pattern is fragile — is real-but-mild CI hygiene. The current curl loop has three gaps: if sipi crashes at startup, the loop runs to 30s and the step still "succeeds"; no sipi log is captured for post-mortem; teardown relies on `pkill -f` name-matching. This PR closes those gaps with a minimal bash-side subset of the supervision pattern already in use in the Rust e2e harness.

## Summary

- Track the sipi wrapper PID and fail the `Start sipi server` step immediately if the wrapper exits before readiness.
- Capture sipi stdout + stderr to `sipi.log`; upload it as an artifact on failure.
- Teardown via the tracked PID (graceful SIGTERM → SIGKILL escalation) with the old `pkill -f` kept as a belt-and-braces fallback.

## Key Changes

### `.github/workflows/loadtest.yml`

- `Start sipi server` — background sipi with `> sipi.log 2>&1`, write `$!` to `sipi.pid`, replace the silent curl loop with a loop that checks `kill -0 $SIPI_PID` on every iteration and `exit 0 / exit 1` to make the step's outcome reflect reality.
- `Stop sipi server` — read `sipi.pid`, SIGTERM the wrapper and its process group, escalate to SIGKILL after 5s; fall back to `pkill -f` if the PID file is missing.
- New `Upload sipi startup log (on failure)` — uploads `sipi.log` under the `sipi-server-log` artifact (30-day retention) whenever the job fails, so startup failures are diagnosable from the run page.

## Challenges and Decisions

### Why not port to the Rust test harness?
`test/e2e-rust/src/lib.rs:32-317` (`SipiServer::start_with_args`) is the gold-standard pattern — stdout readiness signal, `child.try_wait()` supervision, RAII cleanup. It is intentionally *not* reused here: GitHub Actions `run:` blocks can't call Rust, and porting loadtest to a Rust binary would be disproportionate for a nightly workflow with no PR-feedback role. This PR captures the minimum subset expressible in bash (PID tracking + `kill -0` liveness + log capture).

### `exec` inside `bash -c` is load-bearing
Without `exec`, the inner bash is a permanent process between `nix develop` and sipi. `$!` in the outer shell points at `nix develop`'s PID; the intermediate bash shell becomes an extra hop for signals. With `exec`, the inner bash is replaced by sipi, so `nix develop`'s direct child becomes sipi — signals sent to the tracked wrapper PID propagate cleanly via the nix-develop → sipi chain.

## Gotchas

- `nix develop`'s process-chain semantics for signal forwarding are not strictly guaranteed. The `pkill -f "sipi.*e2e-test-config"` fallback in `Stop sipi server` is intentional — do not delete it without first adding process-group tracking via `setsid`.
- The readiness loop polls at 1-second intervals (unchanged). If future work tightens the budget, mirror the Rust harness's 50ms interval.
- `sipi.log` is only uploaded on failure. If a green run still needs log inspection, either change `if: failure()` to `if: always()` temporarily or re-run the workflow with a breaking config.

## Test Plan

- [ ] Trigger manually: `gh workflow run loadtest.yml --ref feature/dev-6027-loadtest-harden-startup --repo dasch-swiss/sipi`
- [ ] Confirm `Start sipi server` logs `Started sipi (wrapper PID …)` and `sipi ready after Ns`
- [ ] Confirm the `loadtest` job completes `success` end-to-end with usable `loadtest-results` artifact
- [ ] Confirm `sipi-server-log` artifact is **not** present on a green run (because of `if: failure()`)
- [ ] (Optional, on throwaway branch) break the config path; confirm `Start sipi server` fails in < 10s with `::error::sipi exited before becoming ready` and the captured log in the job output

Follows commit & PR conventions in `docs/src/development/commit-conventions.md`.