### PR TITLE
build: unify sipi builds behind Nix derivations (justfile + CI)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -7,6 +7,11 @@
 #
 # On crash: uploads reproducer artifacts (retained 90 days) and opens
 # a GitHub issue with the crash details so the team gets notified.
+#
+# Build flow: `just nix-build-fuzz` produces
+# `result/bin/iiif_handler_uri_parser_fuzz`. `just nix-run-fuzz` then
+# runs it against a live corpus + read-only seed corpus. libFuzzer's
+# exit code propagates through the recipe so this job can detect crashes.
 
 permissions:
   contents: read
@@ -43,9 +48,15 @@ jobs:
           git lfs install
           git lfs fetch --all
           git lfs checkout
-      - uses: cachix/install-nix-action@v31
+      - uses: DeterminateSystems/determinate-nix-action@v3
         with:
-          github_access_token: ${{ secrets.GH_TOKEN }}
+          extra-conf: |
+            extra-experimental-features = configurable-impure-env
+      - uses: cachix/cachix-action@v15
+        with:
+          name: dasch-swiss
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - uses: extractions/setup-just@v2
 
       - name: Find last successful fuzz run
         id: last-run
@@ -66,19 +77,19 @@ jobs:
           github-token: ${{ github.token }}
         continue-on-error: true
 
-      - name: Build fuzz target (Clang + libFuzzer)
+      - name: Build fuzz target
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
+        run: just nix-build-fuzz
+
+      - name: Prepare live corpus (merge previous-run findings)
         run: |
-          nix \
-            --extra-experimental-features "nix-command flakes" \
-            --option filter-syscalls false \
-            develop .#fuzz --command bash -c "
-              cmake -S . -B build-fuzz \
-                -DCMAKE_BUILD_TYPE=Debug \
-                -DSIPI_ENABLE_FUZZ=ON
-              cmake --build build-fuzz --target iiif_handler_uri_parser_fuzz --parallel \$(nproc)
-            "
+          mkdir -p fuzz-corpus-live
+          if [ -d fuzz-corpus-prev ] && [ -n "$(ls fuzz-corpus-prev 2>/dev/null)" ]; then
+            echo "Restoring corpus from previous run..."
+            cp fuzz-corpus-prev/* fuzz-corpus-live/ 2>/dev/null || true
+            echo "Restored $(ls fuzz-corpus-live | wc -l) inputs from previous run"
+          fi
 
       - name: Run fuzzer
         id: fuzz
@@ -86,28 +97,12 @@ jobs:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
           FUZZ_DURATION: ${{ inputs.duration || '600' }}
         run: |
+          set -o pipefail
           if [[ ! "$FUZZ_DURATION" =~ ^[0-9]+$ ]]; then echo "Invalid duration: $FUZZ_DURATION"; exit 1; fi
-          nix \
-            --extra-experimental-features "nix-command flakes" \
-            --option filter-syscalls false \
-            develop .#fuzz --command bash -c "
-              cd build-fuzz/fuzz/handlers
-              mkdir -p corpus
-
-              # Merge previous corpus if it exists
-              if [ -d ../../../fuzz-corpus-prev ] && [ -n \"\$(ls ../../../fuzz-corpus-prev/ 2>/dev/null)\" ]; then
-                echo 'Restoring corpus from previous run...'
-                cp ../../../fuzz-corpus-prev/* corpus/ 2>/dev/null || true
-                echo \"Restored \$(ls corpus/ | wc -l) inputs from previous run\"
-              fi
-
-              # Run fuzzer: corpus/ is live (read+write), seed corpus is read-only
-              ./iiif_handler_uri_parser_fuzz corpus/ ../../../fuzz/handlers/corpus/ \
-                -max_total_time=\$FUZZ_DURATION \
-                -print_final_stats=1 2>&1 | tee fuzz-output.log
-
-              echo \"Corpus now has \$(ls corpus/ | wc -l) inputs\"
-            "
+          # Fuzzer binary from the Nix build is self-contained — no dev shell needed.
+          just nix-run-fuzz fuzz-corpus-live "$FUZZ_DURATION" fuzz/handlers/corpus \
+            2>&1 | tee fuzz-output.log
+          echo "Corpus now has $(ls fuzz-corpus-live | wc -l) inputs"
 
       - name: Save corpus for next run
         if: always()
@@ -116,13 +111,12 @@ jobs:
           name: fuzz-corpus
           retention-days: 30
           overwrite: true
-          path: build-fuzz/fuzz/handlers/corpus/
+          path: fuzz-corpus-live/
 
       - name: Collect crash details
         if: failure() && steps.fuzz.outcome == 'failure'
         id: crashes
         run: |
-          cd build-fuzz/fuzz/handlers
           echo "## Crash files found:" > crash-summary.md
           for f in crash-* oom-* timeout-*; do
             [ -f "$f" ] || continue
@@ -149,10 +143,10 @@ jobs:
           name: fuzz-crashes
           retention-days: 90
           path: |
-            build-fuzz/fuzz/handlers/crash-*
-            build-fuzz/fuzz/handlers/oom-*
-            build-fuzz/fuzz/handlers/timeout-*
-            build-fuzz/fuzz/handlers/fuzz-output.log
+            crash-*
+            oom-*
+            timeout-*
+            fuzz-output.log
 
       - name: Open GitHub issue for crash
         if: failure() && steps.crashes.outputs.has_crashes == 'true'
@@ -170,14 +164,11 @@ jobs:
 
           \`\`\`bash
           # Download the crash file from the artifact, then:
-          nix develop .#clang
-          cmake -S . -B build-fuzz -DCMAKE_BUILD_TYPE=Debug -DSIPI_ENABLE_FUZZ=ON
-          cmake --build build-fuzz --target iiif_handler_uri_parser_fuzz -j\$(nproc)
-          cd build-fuzz/fuzz/handlers
-          ./iiif_handler_uri_parser_fuzz /path/to/crash-file
+          just nix-build-fuzz
+          ./result/bin/iiif_handler_uri_parser_fuzz /path/to/crash-file
           \`\`\`
           ISSUE_EOF
-          cat build-fuzz/fuzz/handlers/crash-summary.md >> /tmp/fuzz-issue-body.md
+          cat crash-summary.md >> /tmp/fuzz-issue-body.md
           gh issue create \
             --title "Fuzz: crash in parse_iiif_uri ($(date +%Y-%m-%d))" \
             --label "bug,fuzz" \

--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -34,10 +34,14 @@ jobs:
           git lfs fetch --all
           git lfs checkout
       - uses: DeterminateSystems/determinate-nix-action@v3
+        with:
+          extra-conf: |
+            extra-experimental-features = configurable-impure-env
       - uses: cachix/cachix-action@v15
         with:
           name: dasch-swiss
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - uses: extractions/setup-just@v2
 
       - name: Install wrk
         run: sudo apt-get update && sudo apt-get install -y wrk
@@ -45,20 +49,19 @@ jobs:
       - name: Build sipi
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
-        run: |
-          nix develop --command bash -c "just nix-build"
+        run: just nix-build
 
       - name: Start sipi server
         env:
-          GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
+          SIPI_BIN: ${{ github.workspace }}/result/bin/sipi
         run: |
           # exec replaces the inner bash with sipi so the tracked PID is sipi's
-          # wrapper (nix develop's direct child), not a throwaway shell.
-          nix \
-            --extra-experimental-features "nix-command flakes" \
-            --option filter-syscalls false \
-            develop --command bash -c \
-              "cd test/_test_data && exec ../../build/sipi --config config/sipi.e2e-test-config.lua" \
+          # wrapper (the direct child), not a throwaway shell. The Nix-built
+          # sipi binary has absolute RPATHs into /nix/store, so it runs
+          # without activating the dev shell (dev shell only provides build
+          # tools like cargo/hurl, not runtime libs).
+          bash -c \
+            "cd test/_test_data && exec \"$SIPI_BIN\" --config config/sipi.e2e-test-config.lua" \
             > sipi.log 2>&1 &
           SIPI_PID=$!
           echo "$SIPI_PID" > sipi.pid
@@ -125,7 +128,7 @@ jobs:
             done
             kill -KILL "$SIPI_PID" 2>/dev/null || true
           fi
-          # Fallback: name-match in case the PID chain was broken by nix develop.
+          # Fallback: name-match in case the tracked PID is gone.
           pkill -f "sipi.*e2e-test-config" 2>/dev/null || true
 
       - name: Upload load test results

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -188,13 +188,12 @@ jobs:
           name: dasch-swiss
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
+      - uses: extractions/setup-just@v2
       - name: Build release archive
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
         run: |
-          nix build -L \
-            --option impure-env "GH_TOKEN=$GH_TOKEN" \
-            .#release-archive-${{ matrix.arch }}
+          just nix-build-release-archive-${{ matrix.arch }}
           ls -la result/
 
       - name: Attach static assets to GitHub Release

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -6,6 +6,10 @@
 # sanitizer findings fail the PR check.
 #
 # Also available on-demand via workflow_dispatch.
+#
+# Unit tests run inside the Nix sandbox via `just nix-build-sanitized`
+# (doCheck = enableTests in package.nix). Any ASan/UBSan finding in the
+# unit suite fails the build before the e2e step even starts.
 
 permissions:
   contents: read
@@ -20,6 +24,8 @@ on:
       - 'CMakeLists.txt'
       - 'flake.nix'
       - 'flake.lock'
+      - 'package.nix'
+      - 'justfile'
   workflow_dispatch:
 
 name: sanitizer
@@ -43,55 +49,52 @@ jobs:
           git lfs fetch --all
           git lfs checkout
       - uses: DeterminateSystems/determinate-nix-action@v3
+        with:
+          extra-conf: |
+            extra-experimental-features = configurable-impure-env
       - uses: cachix/cachix-action@v15
         with:
           name: dasch-swiss
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - uses: extractions/setup-just@v2
 
-      - name: Build with sanitizers (ASan + UBSan)
+      - name: Build with sanitizers (ASan + UBSan) — unit tests run in sandbox
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
-        run: |
-          nix develop --command bash -c "just nix-build-sanitized"
-
-      - name: Run unit tests under sanitizers
-        env:
-          GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
-          ASAN_OPTIONS: detect_leaks=1:halt_on_error=0:log_path=/tmp/asan-unit
-          LSAN_OPTIONS: suppressions=${{ github.workspace }}/.lsan_suppressions.txt
-        run: |
-          nix develop --command bash -c "cd build-sanitized && ctest --output-on-failure"
+        run: just nix-build-sanitized
 
       - name: Run e2e tests under sanitizers
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
+          SIPI_BIN: ${{ github.workspace }}/result/bin/sipi
           ASAN_OPTIONS: detect_leaks=1:halt_on_error=0:log_path=/tmp/asan-e2e
           LSAN_OPTIONS: suppressions=${{ github.workspace }}/.lsan_suppressions.txt
+        # cargo comes from the dev shell — keep the wrap.
         run: |
           nix \
-            --extra-experimental-features "nix-command flakes" \
             --option filter-syscalls false \
-            develop --command bash -c \
-              "cd test/e2e-rust && SIPI_BIN=\$PWD/../../build-sanitized/sipi cargo test -- --test-threads=1"
+            develop --command bash -c "just rust-test-e2e"
 
-      - name: Check for sanitizer findings
+      - name: Check for sanitizer findings in e2e
         if: always()
         run: |
           # Check for actual findings (SUMMARY lines), not just file existence.
           # ASan always writes a log file when log_path is set, even with zero
-          # findings (it contains only the suppressions report).
+          # findings. Unit-test findings fail the nix-build-sanitized step
+          # directly (sandbox halts on first error), so this step only covers
+          # the e2e suite.
           HAS_FINDINGS=false
-          if grep -q "SUMMARY:" /tmp/asan-unit.* /tmp/asan-e2e.* 2>/dev/null; then
+          if grep -q "SUMMARY:" /tmp/asan-e2e.* 2>/dev/null; then
             HAS_FINDINGS=true
           fi
           if [ "$HAS_FINDINGS" = "true" ]; then
-            echo "::error::Sanitizer findings detected — PR cannot merge with memory safety issues"
+            echo "::error::Sanitizer findings detected in e2e — PR cannot merge with memory safety issues"
             echo ""
             echo "=== Unique findings ==="
-            grep -h "SUMMARY:" /tmp/asan-unit.* /tmp/asan-e2e.* 2>/dev/null | sort -u || true
+            grep -h "SUMMARY:" /tmp/asan-e2e.* 2>/dev/null | sort -u || true
             echo ""
             echo "=== Full reports ==="
-            for f in /tmp/asan-unit.* /tmp/asan-e2e.*; do
+            for f in /tmp/asan-e2e.*; do
               [ -f "$f" ] || continue
               echo "--- $(basename "$f") ---"
               cat "$f"
@@ -99,7 +102,7 @@ jobs:
             done
             exit 1
           fi
-          echo "No sanitizer findings. All tests passed cleanly under ASan + UBSan."
+          echo "No sanitizer findings in e2e. All tests passed cleanly under ASan + UBSan."
 
       - name: Upload sanitizer reports
         if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,9 @@
 #   - Nix/Clang build+unit matrix on Linux amd64/arm64 (Rust e2e + Hurl)
 #   - Nix static musl build (Zig-in-Nix) + Rust e2e on amd64/arm64
 #   - Nix native macOS arm64 build + dylib-linkage audit on internal PRs
+#
+# Every build step invokes `just <recipe>`. No inline cmake or nix build
+# calls. Recipes live in the justfile; see the "Nix builds" section there.
 
 permissions:
   contents: read
@@ -56,33 +59,39 @@ jobs:
           file test/_test_data/unit/lena512.tif 2>/dev/null || echo "lena512.tif not found"
           file test/_test_data/unit/HasCommentBlock.JPG 2>/dev/null || echo "HasCommentBlock.JPG not found"
       - uses: DeterminateSystems/determinate-nix-action@v3
+        with:
+          # Kakadu FOD in flake.nix uses gh release download via
+          # impureEnvVars; daemon needs configurable-impure-env to accept
+          # GH_TOKEN from the client (every `just nix-build*` recipe passes
+          # the matching client flag).
+          extra-conf: |
+            extra-experimental-features = configurable-impure-env
       - uses: cachix/cachix-action@v15
         with:
           name: dasch-swiss
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - name: Build and test (unit)
+      - uses: extractions/setup-just@v2
+      - name: Build and test (unit tests run in the Nix sandbox)
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
-        run: |
-          nix develop --command bash -c "just nix-build && just nix-test"
+        run: just nix-build
       - name: Rust e2e and Hurl tests
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
-        run: |
-          nix develop --command bash -c "just rust-test-e2e && just hurl-test"
+        # cargo + hurl come from the dev shell — keep the wrap.
+        run: nix develop --command bash -c "just rust-test-e2e && just hurl-test"
       - name: Gather code coverage
         if: ${{ matrix.arch == 'amd64' }}
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
-        run: |
-          nix develop --command bash -c "just nix-coverage"
+        run: just nix-coverage
       - name: Upload coverage reports to Codecov
         if: ${{ matrix.arch == 'amd64' }}
         uses: codecov/codecov-action@v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: dasch-swiss/sipi
-          files: build/coverage.xml
+          files: result-coverage/coverage.xml
 
   # Zig-in-Nix musl-static validation. Exists in parallel to zig-static
   # until Part B.5 retires the latter (see plan glowing-rolling-fern).
@@ -114,23 +123,20 @@ jobs:
         with:
           name: dasch-swiss
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - uses: extractions/setup-just@v2
       - name: Build static binary
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
-        run: |
-          nix build -L \
-            --option impure-env "GH_TOKEN=$GH_TOKEN" \
-            .#static-${{ matrix.arch }}
+        run: just nix-build-static-${{ matrix.arch }}
       - name: Verify static linkage
-        run: |
-          file result/bin/sipi
-          ! readelf -d result/bin/sipi | grep -q '(NEEDED)'
+        # file / readelf are standard ubuntu runner tools.
+        run: just nix-static-linkage-verify result/bin/sipi
       - name: Rust e2e tests against static binary
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
-        run: |
-          nix develop --command bash -c \
-            "cd test/e2e-rust && SIPI_BIN=$GITHUB_WORKSPACE/result/bin/sipi cargo test -- --test-threads=1"
+          SIPI_BIN: ${{ github.workspace }}/result/bin/sipi
+        # cargo comes from the dev shell — keep the wrap.
+        run: nix develop --command bash -c "just rust-test-e2e"
 
   # Native Darwin build via Nix + clang/libc++, with a dylib-linkage audit.
   # Replaces the old zig-macos job; the invariant (no Homebrew / third-party
@@ -152,26 +158,11 @@ jobs:
         with:
           name: dasch-swiss
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - uses: extractions/setup-just@v2
       - name: Build native Darwin binary
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
-        run: |
-          nix build -L \
-            --option impure-env "GH_TOKEN=$GH_TOKEN" \
-            .#default
+        run: just nix-build-default
       - name: Audit runtime dylibs
-        run: |
-          otool -L result/bin/sipi
-          # Invariant: don't accidentally link against Homebrew. Every
-          # other path under /usr/lib, /System/Library, or /nix/store is
-          # a controlled input to the Nix build.
-          bad=$(otool -L result/bin/sipi \
-            | awk 'NR>1 {print $1}' \
-            | grep -E '^/opt/homebrew/|^/usr/local/' \
-            || true)
-          if [ -n "$bad" ]; then
-            echo "error: Homebrew / /usr/local dylibs leaked into the binary:" >&2
-            echo "$bad" >&2
-            exit 1
-          fi
-          echo "macOS dylib policy satisfied"
+        # otool is part of macOS system toolchain.
+        run: just nix-macos-dylib-audit result/bin/sipi

--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,10 @@ icc.zip
 /coverage.info
 *.gcov
 
+# Nix build output symlinks (emitted by `just nix-*` / `nix build`)
+/result
+/result-*
+
 # Zig toolchain build artifact (written by cmake/zig-toolchain.cmake)
 scripts/toolchains/.zig-target
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,38 +9,79 @@ SIPI (Simple Image Presentation Interface) is a multithreaded, high-performance,
 ## Build System and Common Commands
 
 All targets are in a single `justfile`. Run `just` for a complete list.
-For full build instructions (Docker, Zig, Nix, macOS), see [`docs/src/development/building.md`](docs/src/development/building.md).
+For full build instructions (Docker, Nix, macOS), see [`docs/src/development/building.md`](docs/src/development/building.md).
 
-**First-time Nix setup:** run `just kakadu-fetch` once to download the proprietary Kakadu archive from `dsp-ci-assets` into `vendor/`. Requires `gh auth login` and `dasch-swiss` org membership. See [`docs/src/development/kakadu.md`](docs/src/development/kakadu.md).
+**Build reproducibility invariant:** every `nix-*` recipe wraps `nix build .#<variant>`. CI invokes only `just <recipe>` — no inline cmake or `nix build` calls. Incremental inner-loop development is a documented dev-shell pattern (see below), not a recipe.
+
+**Build completeness invariant:** every build target must succeed on every supported platform — macOS (darwin-aarch64), linux-x86_64, and linux-aarch64. This applies to `.#dev`, `.#default`, `.#release`, `.#sanitized`, `.#fuzz`, `.#docker-stream`, `.#static-*`, and `.#release-archive-*`. A target that builds on only some platforms is a shipping bug, not a known limitation — CI is Linux-only, so **a green CI run does not verify macOS**. Before shipping any change to `flake.nix`, `package.nix`, or a `justfile` build recipe:
+
+1. Run every affected variant on macOS locally (`just nix-build-<variant>`).
+2. Run every affected Linux variant locally via Determinate's native-linux-builder (`nix build .#packages.x86_64-linux.<variant>` and `.#packages.aarch64-linux.<variant>`). See [`docs/src/development/nix.md`](docs/src/development/nix.md) for setup.
+3. Pay special attention to `overrideAttrs` blocks that replace `buildPhase` / `installPhase` — those encode assumptions about nixpkgs hook behavior (e.g. whether the cmake hook leaves CWD at `$sourceRoot` or `$sourceRoot/build`) that are platform- and version-sensitive. Prefer CWD-robust patterns (`[ -f CMakeCache.txt ] || cd "${cmakeBuildDir:-build}"`) over hard-coded paths.
+
+If a change can't be verified on a platform locally, say so explicitly and gate the merge on a corresponding CI check being added.
+
+**First-time setup for Docker builds:** run `just kakadu-fetch` once to download the proprietary Kakadu archive from `dsp-ci-assets` into `vendor/`. Nix builds fetch Kakadu directly via the flake (no `vendor/` step). Requires `gh auth login` and `dasch-swiss` org membership. See [`docs/src/development/kakadu.md`](docs/src/development/kakadu.md).
 
 ### Quick Reference
 
 ```bash
-# Docker (recommended for CI-like builds)
-just docker-build              # build image (compiles + unit tests)
-just test-smoke                # smoke tests against Docker image
+# Nix build (reproducible — this is what CI runs)
+just nix-build                   # .#dev: Debug + coverage, tests run in sandbox
+just nix-build-default           # .#default: RelWithDebInfo + tests (matches distributed binary shape)
+just nix-build-release           # .#release: stripped, no tests
+just nix-build-sanitized         # .#sanitized: Debug + ASan + UBSan, tests run in sandbox
+just nix-build-fuzz              # .#fuzz: libFuzzer harness binary only
+just nix-build-static-amd64      # .#static-amd64: Zig-in-Nix musl static binary
+just nix-build-static-arm64      # .#static-arm64: Zig-in-Nix musl static binary
+just nix-build-release-archive-amd64  # .#release-archive-amd64: tarball + sha256 + debug
+just nix-build-release-archive-arm64  # .#release-archive-arm64: tarball + sha256 + debug
+just nix-coverage                # .#dev^coverage: produces result-coverage/coverage.xml
+just nix-docker-build            # Docker image via nixpkgs.dockerTools
 
-# Nix (reproducible native dev — run inside `nix develop`)
-just nix-build                 # build (debug + coverage)
-just nix-test                  # unit tests
-just rust-test-e2e             # Rust e2e tests (requires built sipi)
-just hurl-test                 # Hurl HTTP contract tests
+# Tests (consume $SIPI_BIN, default ./result/bin/sipi)
+just rust-test-e2e               # Rust e2e tests (needs cargo — from dev shell)
+just hurl-test                   # Hurl HTTP contract tests (needs hurl — from dev shell)
+just nix-run                     # run sipi with the dev config
+just nix-valgrind                # run sipi under Valgrind
 
-# Nix full builds (no shell required; run `just kakadu-fetch` once first)
-just nix-build-release         # build release binary via nix
-just nix-build-static-amd64    # build static amd64 binary
-just nix-build-static-arm64    # build static arm64 binary
-just nix-docker-build          # build Docker image via Nix
+# Dev-shell inner loop (non-recipe — see "Inner-loop development" below)
+
+# Docker (unchanged)
+just docker-build                # build image (compiles + unit tests)
+just test-smoke                  # smoke tests against Docker image
 
 # Vendor dependencies
-just vendor-download           # download all dep archives to vendor/
-just vendor-verify             # verify SHA-256 checksums
-just vendor-checksums          # print checksums for manifest updates
-just kakadu-fetch              # download Kakadu archive (one-time per version)
+just vendor-download             # download all dep archives to vendor/
+just vendor-verify               # verify SHA-256 checksums
+just vendor-checksums            # print checksums for manifest updates
+just kakadu-fetch                # download Kakadu archive (one-time per version; for Dockerfile only)
 
 # Documentation
-just docs-serve                # serve docs locally
+just docs-serve                  # serve docs locally
 ```
+
+### Inner-loop development (incremental rebuilds)
+
+The justfile does not expose an imperative build recipe — by design. A recipe
+is a contract that CI runs the same command, and CI always goes through a Nix
+derivation. For the fast edit/rebuild/run cycle on a single `.cpp` file, drop
+into the dev shell and call cmake by hand:
+
+```bash
+nix develop                                   # dev shell with all build deps
+cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -DCODE_COVERAGE=ON
+cmake --build build --parallel
+./build/sipi --config config/sipi.localdev-config.lua
+# subsequent edits:
+cmake --build build                           # incremental
+```
+
+**Caveats:** this path is non-reproducible and does not match CI outputs
+byte-for-byte. To run the reproducible CI build, use `just nix-build` instead.
+
+**Prerequisite:** run `just kakadu-fetch` once per Kakadu version — the
+dev-shell cmake invocation consumes `vendor/v8_5-01382N.zip` from that.
 
 ## High-Level Architecture
 
@@ -96,13 +137,13 @@ For the authoritative testing strategy (pyramid, layer definitions, decision tre
 
 For test framework details (how to run tests, directory layout, adding tests), see [`docs/src/development/developing.md`](docs/src/development/developing.md).
 
-- **Unit tests** (`test/unit/`): GoogleTest + ApprovalTests — `just nix-test`
+- **Unit tests** (`test/unit/`): GoogleTest + ApprovalTests — run inside the `.#dev` / `.#default` derivation's `checkPhase` (`just nix-build` fails if any unit test fails)
 - **E2E tests** (`test/e2e-rust/`): Rust (reqwest + cargo test) — `just rust-test-e2e`
 - **Hurl tests** (`test/hurl/`): HTTP contract tests — `just hurl-test`
 - **Smoke tests** (`test/smoke/`): against Docker image — `just test-smoke`
 - **Approval tests** (`test/approval/`): snapshot-based regression — included in unit tests
 
-Run a specific test binary: `cd build && test/unit/<component>/<component>`
+Run a specific unit test binary in the dev-shell inner loop: `cd build && test/unit/<component>/<component>`
 
 ## CI, Release, and Commit Messages
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -10,10 +10,32 @@ For reviewer guidelines, see `docs/src/development/reviewer-guidelines.md`.
 ## Stack
 
 - C++23, Clang 15+ / GCC 13+, CMake 3.28+
-- Build toolchains: Zig (local dev), Nix (reproducible), Docker (CI)
+- Build toolchains: Nix (reproducible, single source of truth for CI), Docker (production image)
 - HTTP framework: custom `shttps/` library (threading, SSL, connection pooling)
 - Image formats: libtiff, libpng, libjpeg, libwebp, Kakadu (JPEG 2000)
 - Scripting: Lua (routes, preflight checks, image manipulation)
+
+## Build Reproducibility Invariant
+
+Every justfile recipe that builds sipi goes through `nix build .#<variant>`.
+CI invokes only `just <recipe>` — no inline cmake or `nix build` calls in
+workflow YAML. The consequences:
+
+- Recipes are contracts: every `nix-*` recipe is a promise that CI runs the
+  same command. Adding an imperative cmake recipe would violate that contract
+  and create a drift surface.
+- Unit tests run inside the Nix sandbox via `doCheck = enableTests` in
+  `package.nix`. A `nix build .#dev` that succeeds is, by construction, a
+  tested build — the derivation graph enforces "tested before cached."
+- Incremental inner-loop development (edit one `.cpp` file, see a
+  seconds-fast rebuild) is a documented dev-shell pattern — `nix develop`
+  followed by `cmake --build build` by hand. It is intentionally NOT a
+  recipe. See `CLAUDE.md` "Inner-loop development" and
+  `docs/src/development/developing.md`.
+
+If a new build configuration is genuinely needed across the team (non-trivial
+CMake flags, specialized toolchain), that configuration deserves a Nix
+variant in `flake.nix`, not a recipe wrapping imperative cmake.
 
 ## Naming Conventions
 
@@ -76,7 +98,9 @@ New config options need:
 
 ## Docker
 
-- Base image: Alpine (musl, minimal attack surface)
+- Base image: `ubuntu:24.04` (the current `Dockerfile`; migration to
+  `nix build .#docker` is tracked separately and out of scope for the
+  Nix unified-build plan)
 - Init: `pid1-rs` (PID 1 zombie reaping, signal forwarding)
 - Port: 1024 (non-privileged)
 - Config mount: `/sipi/config/`

--- a/README.md
+++ b/README.md
@@ -71,26 +71,28 @@ You will then find the manual under `site/index.html`.
 
 ## Building from source
 
-All commands are run from the repository root via `make`. Run `make help` for a full list of targets.
+All commands are run from the repository root via `just`. Run `just` for a full list of targets.
 
-### Build and test with Docker (recommended)
+### Build and test with Docker (recommended for CI-like builds)
 ```bash
-make docker-build    # build Docker image (compiles + runs unit tests)
-make test-smoke      # run smoke tests against Docker image
+just docker-build    # build Docker image (compiles + runs unit tests)
+just test-smoke      # run smoke tests against Docker image
 ```
 
-### Build and test with Nix (native development)
+### Build and test with Nix (reproducible — what CI runs)
 ```bash
-nix develop          # enter Nix development shell (GCC)
-make nix-build       # build SIPI (debug + coverage)
-make nix-test        # run unit tests
-make nix-test-e2e    # run end-to-end tests
-make nix-run         # start SIPI server
+just nix-build         # .#dev: Debug + coverage, unit tests run in the Nix sandbox
+just rust-test-e2e     # run Rust end-to-end tests against ./result/bin/sipi
+just hurl-test         # run Hurl HTTP contract tests
+just nix-run           # start SIPI server
 ```
 
-### Build on macOS (not recommended)
+### Inner-loop development (incremental rebuilds, non-reproducible)
 ```bash
-mkdir -p ./build-mac && cd build-mac && cmake .. && make && ctest --verbose
+nix develop                                              # dev shell with build deps
+cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -DCODE_COVERAGE=ON
+cmake --build build --parallel
+./build/sipi --config config/sipi.localdev-config.lua
 ```
 
 See [Building SIPI from Source Code](https://sipi.io/development/building/) for full details.

--- a/config/sipi.localdev-config.lua
+++ b/config/sipi.localdev-config.lua
@@ -2,6 +2,9 @@
 -- Local development configuration for SIPI
 --
 -- Usage:
+--   just nix-run                                   -- reproducible (consumes ./result/bin/sipi)
+--   ./result/bin/sipi --config config/sipi.localdev-config.lua
+--   -- or, from the dev-shell inner loop:
 --   ./build/sipi --config config/sipi.localdev-config.lua
 --
 -- Points imgroot at test data so IIIF requests work out of the box.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
   - Lua Image Functions: lua/lua-image.md
   - SQLite Integration: lua/sqlite.md
   - Building: development/building.md
+  - Building with Nix: development/nix.md
   - CI and Release: development/ci.md
   - Developing: development/developing.md
   - Fuzz Testing: development/fuzzing.md
@@ -80,7 +81,8 @@ plugins:
           - lua/lua-image.md: "Lua image manipulation functions"
           - lua/sqlite.md: "SQLite integration from Lua"
         "Development":
-          - development/building.md: "Build instructions"
+          - development/building.md: "Build instructions overview"
+          - development/nix.md: "Nix build system: primer, setup, variants, cross-platform builds"
           - development/ci.md: "CI and release pipeline guide"
           - development/developing.md: "Development guide"
           - development/downstream-dependencies.md: "Runtime packages and downstream consumers"

--- a/docs/src/development/building.md
+++ b/docs/src/development/building.md
@@ -64,7 +64,7 @@ All dependency metadata (version, URL, SHA-256 hash) is centralized in
 2. Run `just vendor-download` to fetch the new archive
 3. Run `just vendor-checksums` and update `DEP_<NAME>_SHA256` in the manifest
 4. Run `just vendor-verify` to confirm
-5. Clean build and test: `rm -rf build && nix develop --command bash -c "just nix-build && just nix-test"`
+5. Clean build and test: `just clean && just nix-build` (unit tests run inside the Nix sandbox via `doCheck = enableTests`)
 
 ### Adding a new dependency
 
@@ -76,70 +76,20 @@ All dependency metadata (version, URL, SHA-256 hash) is centralized in
 
 ## Building with Nix (Recommended)
 
-`nix` is the single entry point for every Sipi build artifact (dev binary,
-static binary, Docker image, debug symbols). It is reproducible, hermetic,
-and shares its dependency cache with CI via Cachix.
+Nix is the single entry point for every Sipi build artifact — dev
+binary, static binary, Docker image, debug symbols. It's reproducible,
+hermetic, and shares its dependency cache with CI via Cachix.
 
-### One-time setup
+Full setup and usage: **[Building with Nix](nix.md)** (primer,
+one-time setup, all variants, dev-shell inner loop, cross-platform
+builds).
 
-1. [Install Nix](https://nixos.org/download.html) (or use
-   [Determinate Nix](https://docs.determinate.systems/))
-2. Fetch the Kakadu archive: `just kakadu-fetch` (see
-   [Kakadu setup](kakadu.md))
-3. (Optional) Add the shared binary cache:
-
-   ```bash
-   cachix use dasch-swiss
-   ```
-
-   This pulls pre-built `ext/` dependencies from CI, reducing first-build
-   time from ~15 min to ~2 min.
-
-### Build artifacts
+Most common commands:
 
 ```bash
-# Default: RelWithDebInfo binary with separate debug symbols.
-nix build .#default
-nix build .#default.debug      # extracted symbols at result/lib/debug/...
-
-# Debug build with coverage instrumentation.
-nix build .#dev
-
-# Release build, unstripped (for manual distribution).
-nix build .#release
-
-# Static Linux binaries (Linux runners only).
-nix build .#static-amd64
-nix build .#static-arm64
-
-# Release archives (.tar.gz + .sha256 + .debug).
-nix build .#release-archive-amd64
-nix build .#release-archive-arm64
-
-# Docker images (Linux runners only).
-nix build .#docker             # writes to /nix/store
-just nix-docker-build          # streams into the local Docker daemon
-```
-
-### Dev shell + iterative build
-
-For day-to-day work, `nix develop` provides the full toolchain (clang19
-+ libc++, cmake, autoconf, just, gcovr, lcov, hurl, …):
-
-```bash
-nix develop                    # default = clang
-nix develop .#fuzz             # libstdc++ for libFuzzer ABI
-nix develop .#gcc              # gcc14Stdenv
-
-# Inside the shell:
-just nix-build                 # debug + coverage build into ./build/
-just nix-test                  # GoogleTest unit + ApprovalTests
-just rust-test-e2e             # Rust e2e harness
-just hurl-test                 # Hurl HTTP contract tests
-just nix-coverage              # XML coverage report (Codecov format)
-just nix-coverage-html         # HTML coverage report (lcov)
-just nix-run                   # start sipi against the default config
-just nix-valgrind              # run sipi under valgrind
+just nix-build                 # .#dev: Debug + coverage, tests in sandbox
+just nix-build-default         # .#default: RelWithDebInfo + tests
+just nix-build-sanitized       # .#sanitized: ASan + UBSan
 ```
 
 ## Building with Docker
@@ -161,38 +111,10 @@ just docker-test-build-amd64
 just docker-test-build-arm64
 ```
 
-## Static Linux binaries
+## Building on macOS without Nix (Not Recommended)
 
-Static musl binaries are produced by the Nix flake via a Zig-based
-toolchain (`cmake/zig-toolchain.cmake`). No Zig install is needed on
-the host — Zig ships inside the Nix dev shell and is invoked by
-`mkStaticBuild` in `flake.nix`.
-
-```bash
-nix build .#static-amd64        # x86_64-linux-musl
-nix build .#static-arm64        # aarch64-linux-musl
-nix build .#release-archive-amd64
-nix build .#release-archive-arm64
-```
-
-Validation:
-
-```bash
-file result/bin/sipi
-! readelf -d result/bin/sipi | grep '(NEEDED)'
-```
-
-## Building on macOS without Nix or Zig (Not Recommended)
-
-Building directly on macOS without Nix is unsupported but possible:
-
-```bash
-mkdir -p ./build-mac && cd build-mac && cmake .. && make && ctest --verbose
-```
-
-You will need CMake and a C++23-compatible compiler. All library
-dependencies (including OpenSSL, libcurl, libmagic) are built from
-source automatically by the build system.
+Building directly on macOS without Nix is unsupported. Use `just nix-build`
+or the dev-shell inner loop (see above) instead.
 
 ## All `just` targets
 
@@ -203,21 +125,26 @@ Run `just` (no arguments) to see the full list. Key target groups:
 | `docker-build` | Build Docker image locally |
 | `docker-test-build-{amd64,arm64}` | Build + test for specific architecture |
 | `test-smoke` | Run smoke tests against the Docker image |
-| `nix-build` | Build SIPI natively (debug + coverage) — inside `nix develop` |
-| `nix-test` | Run unit tests |
-| `rust-test-e2e` | Run Rust end-to-end tests |
-| `hurl-test` | Run Hurl HTTP contract tests |
-| `nix-coverage` | Generate XML coverage report |
-| `nix-coverage-html` | Generate HTML coverage report |
-| `nix-run` | Run SIPI server |
-| `nix-valgrind` | Run with Valgrind |
-| `nix-build-release` | Run `nix build .#default` |
-| `nix-build-static-{amd64,arm64}` | Run `nix build .#static-{amd64,arm64}` |
-| `nix-docker-build` | Stream `nix build .#docker-stream` into local Docker daemon |
+| `nix-build` | `.#dev` — Debug + coverage; unit tests run in the Nix sandbox |
+| `nix-build-default` | `.#default` — RelWithDebInfo + tests |
+| `nix-build-release` | `.#release` — stripped, no tests |
+| `nix-build-sanitized` | `.#sanitized` — Debug + ASan + UBSan |
+| `nix-build-fuzz` | `.#fuzz` — libFuzzer harness binary only |
+| `nix-build-static-{amd64,arm64}` | `.#static-{amd64,arm64}` — Zig-in-Nix musl |
+| `nix-build-release-archive-{amd64,arm64}` | `.#release-archive-{amd64,arm64}` — tarball + sha256 + debug |
+| `nix-coverage` | `.#dev^coverage` — writes `result-coverage/coverage.xml` |
+| `nix-docker-build` | Stream `.#docker-stream` into local Docker daemon |
+| `nix-static-linkage-verify path` | Verify a Linux static binary has no NEEDED entries |
+| `nix-macos-dylib-audit path` | Audit macOS sipi runtime dylibs |
+| `rust-test-e2e` | Rust end-to-end tests (reads `$SIPI_BIN`) |
+| `hurl-test` | Hurl HTTP contract tests (reads `$SIPI_BIN`) |
+| `nix-run` | Run sipi with the dev config |
+| `nix-valgrind` | Run sipi under Valgrind |
+| `nix-run-fuzz corpus duration [seed]` | Run libFuzzer harness against a corpus |
 | `vendor-download` | Download all dependency archives to `vendor/` |
 | `vendor-verify` | Verify SHA-256 checksums of vendored archives |
 | `vendor-checksums` | Print SHA-256 checksums for all archives |
-| `kakadu-fetch` | Download Kakadu archive from `dsp-ci-assets` (one-time per version) |
+| `kakadu-fetch` | Download Kakadu archive from `dsp-ci-assets` (one-time per version; for Dockerfile only) |
 | `docs-build` | Build documentation |
 | `docs-serve` | Serve documentation locally |
 

--- a/docs/src/development/ci.md
+++ b/docs/src/development/ci.md
@@ -81,21 +81,22 @@ stdenv for Darwin.
 
 **`nix-static / {arch}`** (`ubuntu-24.04`, `ubuntu-24.04-arm`):
 
-1. `nix build .#static-${arch}` — builds via `mkStaticBuild` in
-   `flake.nix`, using Zig as the C/C++ cross-compiler targeting
-   `{x86_64,aarch64}-linux-musl`. Kakadu is fetched by the FOD
-   (`GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}`, `configurable-impure-env`
-   enabled on the daemon).
-2. Static linkage assertion: `readelf -d` must not report any
-   `NEEDED` entries.
-3. `nix develop --command ... cargo test` in `test/e2e-rust` with
-   `SIPI_BIN=$GITHUB_WORKSPACE/result/bin/sipi` — proves the
-   Nix-built static musl binary runs on a glibc host.
+1. `just nix-build-static-${arch}` — wraps `nix build .#static-${arch}`,
+   which runs `mkStaticBuild` in `flake.nix` using Zig as the C/C++
+   cross-compiler targeting `{x86_64,aarch64}-linux-musl`. Kakadu is
+   fetched by the FOD (`GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}`,
+   `configurable-impure-env` enabled on the daemon).
+2. `just nix-static-linkage-verify result/bin/sipi` — static linkage
+   assertion via `readelf -d`; must not report any `NEEDED` entries.
+3. `just rust-test-e2e` with `SIPI_BIN=$GITHUB_WORKSPACE/result/bin/sipi`
+   — proves the Nix-built static musl binary runs on a glibc host.
 
 **`nix-macos / arm64 dylib-audit`** (`macos-14`):
 
-- `nix build .#default` on Darwin (clang + libc++).
-- `otool -L` audit: only `/usr/lib/libSystem.B.dylib` and
+- `just nix-build-default` on Darwin (wraps `nix build .#default` —
+  clang + libc++).
+- `just nix-macos-dylib-audit result/bin/sipi` — `otool -L` audit;
+  only `/usr/lib/libSystem.B.dylib` and
   `/System/Library/{Frameworks,PrivateFrameworks}/...` allowed.
 
 ### Forked PR behavior
@@ -116,7 +117,8 @@ Gate model:
 3. Publish jobs run in parallel after the gate:
    - `publish-docker / {arch}` — builds, tests, pushes Docker images.
    - `publish-static-release / {arch}` — builds release archive via
-     Nix (`nix build .#release-archive-${arch}`), uploads to GitHub
+     `just nix-build-release-archive-${arch}` (wraps
+     `nix build .#release-archive-${arch}`), uploads to GitHub
      Release, pushes debug symbols to Sentry.
    - `manifest` — multi-arch Docker manifest.
    - `docs` — mkdocs deploy.
@@ -126,7 +128,7 @@ Gate model:
 
 A single per-arch `publish-static-release` job produces everything:
 
-- `nix build .#release-archive-${arch}` emits in `result/`:
+- `just nix-build-release-archive-${arch}` (wraps `nix build .#release-archive-${arch}`) emits in `result/`:
   - `sipi-v<version>-linux-${arch}.tar.gz` (binary + config + scripts + server)
   - `sipi-v<version>-linux-${arch}.tar.gz.sha256`
   - `sipi-linux-${arch}.debug` (split debug symbols)
@@ -135,19 +137,47 @@ A single per-arch `publish-static-release` job produces everything:
 
 ## Local Reproduction
 
+Every CI step invokes `just <recipe>` — no inline cmake or `nix build`
+calls. To reproduce any CI job locally, run the same recipe. With the
+Determinate Systems native-linux-builder available to macOS authors,
+Linux-target recipes (`nix-build-static-*`, `nix-build-sanitized`,
+`nix-build-fuzz`, `nix-build-release-archive-*`) run locally without
+a CI round-trip.
+
+`just nix-build*` recipes wrap `nix build`, so CI invokes them directly
+without a surrounding `nix develop`. Recipes that consume dev-shell
+tools — `rust-test-e2e` (needs `cargo`) and `hurl-test` (needs `hurl`) —
+are the exception and run inside `nix develop --command …`.
+
 ```bash
-# Native dev build + unit + e2e (inside nix develop)
-nix develop --command bash -c "just nix-build && just nix-test && just rust-test-e2e"
+# Native dev build + e2e + Hurl (what test.yml nix-clang runs)
+just nix-build
+nix develop --command bash -c "just rust-test-e2e && just hurl-test"
+just nix-coverage
 
-# Static musl binaries (no shell needed)
-nix build .#static-amd64
-nix build .#static-arm64
+# Static musl binaries (what test.yml nix-static runs)
+just nix-build-static-amd64
+just nix-build-static-arm64
+just nix-static-linkage-verify result/bin/sipi
 
-# Validation
-file result/bin/sipi
-! readelf -d result/bin/sipi | grep NEEDED
+# Sanitizer build + tests (what sanitizer.yml runs)
+just nix-build-sanitized                  # tests run in sandbox
+SIPI_BIN=$PWD/result/bin/sipi nix --option filter-syscalls false develop --command bash -c "just rust-test-e2e"
 
-# Darwin build (on macOS)
-nix build .#default
-otool -L result/bin/sipi
+# Fuzz build + run (what fuzz.yml runs)
+just nix-build-fuzz
+mkdir fuzz-corpus-live
+just nix-run-fuzz fuzz-corpus-live 60 fuzz/handlers/corpus
+
+# Release archive (what publish.yml publish-static-release runs)
+just nix-build-release-archive-amd64
+
+# Darwin build + audit (what test.yml nix-macos-audit runs)
+just nix-build-default
+just nix-macos-dylib-audit result/bin/sipi
 ```
+
+**CI invokes justfile only:** if a CI step is not a `just <recipe>`
+invocation, that's a drift signal — either the step is non-build glue
+(e.g. artifact upload, Codecov upload, Sentry push) or the justfile is
+missing a recipe and should grow one.

--- a/docs/src/development/developing.md
+++ b/docs/src/development/developing.md
@@ -27,6 +27,18 @@ out of the box and cache eviction is easy to observe.
 ### Start the server
 
 ```bash
+# Reproducible (what CI runs) — build through Nix, then run the built binary
+just nix-build
+just nix-run
+```
+
+Or, for the inner-loop dev workflow (non-reproducible — does not match CI
+outputs byte-for-byte):
+
+```bash
+nix develop
+cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -DCODE_COVERAGE=ON
+cmake --build build --parallel
 ./build/sipi --config config/sipi.localdev-config.lua
 ```
 
@@ -90,29 +102,20 @@ Tests are organized by component:
 - `test/unit/logger/` - Logger tests
 - `test/unit/handlers/` - HTTP handler tests
 
-Run all unit tests:
+Run all unit tests (inside the Nix sandbox via `doCheck = enableTests` in
+`package.nix` — `just nix-build` fails if any unit test fails):
 
 ```bash
-make nix-test
+just nix-build
 ```
 
-Run a specific test binary directly:
+Run a specific test binary directly, from the dev-shell inner loop:
 
 ```bash
+nix develop
+cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -DCODE_COVERAGE=ON
+cmake --build build --parallel
 cd build && test/unit/iiifparser/iiifparser
-```
-
-### End-to-End Tests
-
-End-to-end tests live in `test/e2e/` and use pytest. To add tests,
-create a Python file whose name begins with `test_` in the `test/e2e/`
-directory. The test fixtures in `test/e2e/conftest.py` handle starting
-and stopping a SIPI server and provide other testing utilities.
-
-Run e2e tests:
-
-```bash
-make nix-test-e2e
 ```
 
 ### Rust End-to-End Tests
@@ -125,13 +128,16 @@ functionality.
 Run Rust e2e tests:
 
 ```bash
-make rust-test-e2e
+just rust-test-e2e
 ```
+
+The recipe resolves the sipi binary via `$SIPI_BIN` with a canonical default
+of `./result/bin/sipi` (the Nix artifact path). Override `SIPI_BIN` to point
+at a dev-shell-built binary if you are iterating on cmake locally.
 
 !!! note "Sequential execution required"
     Tests must run with `--test-threads=1` because each test starts its own
-    SIPI server instance on a unique port. The Makefile target handles this
-    automatically.
+    SIPI server instance on a unique port. The recipe handles this automatically.
 
 ### Hurl HTTP Contract Tests
 
@@ -142,7 +148,7 @@ requests and expected responses.
 Run Hurl tests:
 
 ```bash
-make hurl-test
+just hurl-test
 ```
 
 Current test files:

--- a/docs/src/development/fuzzing.md
+++ b/docs/src/development/fuzzing.md
@@ -33,35 +33,32 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 
 ## Requirements
 
-libFuzzer is built into Clang, so you need a Clang compiler. On Nix, use the clang dev shell:
+libFuzzer is built into Clang, so the fuzz variant uses `llvmPackages_19.stdenv` under the hood. Nix handles the toolchain — no dev-shell dance required.
 
-```bash
-nix develop .#clang
-```
-
-The CMake config (`fuzz/handlers/CMakeLists.txt`) guards the target behind a Clang check — it won't build with GCC or zig-cc.
+The CMake config (`fuzz/handlers/CMakeLists.txt`) guards the target behind a Clang check; it won't build with GCC or zig-cc, but `.#fuzz` pins Clang so that path never matters in practice.
 
 ## Running Locally
 
 ### Build the fuzz target
 
 ```bash
-nix develop .#clang
-cmake -S . -B build-fuzz -DCMAKE_BUILD_TYPE=Debug
-cmake --build build-fuzz --target iiif_handler_uri_parser_fuzz -j$(nproc)
+just nix-build-fuzz
 ```
+
+This wraps `nix build .#fuzz` and emits `result/bin/iiif_handler_uri_parser_fuzz`.
 
 ### Run with seed corpus
 
 ```bash
-cd build-fuzz/fuzz/handlers
-mkdir -p corpus
-./iiif_handler_uri_parser_fuzz corpus/ ../../../fuzz/handlers/corpus/ -max_total_time=60
+mkdir -p corpus-live
+just nix-run-fuzz corpus-live 60 fuzz/handlers/corpus
 ```
 
-- First argument (`corpus/`) — live corpus directory. New interesting inputs are written here.
-- Second argument (`../../../fuzz/handlers/corpus/`) — seed corpus (read-only). These 52 inputs give the fuzzer a head start with known-good IIIF URIs.
-- `-max_total_time=60` — run for 60 seconds. Without this, the fuzzer runs indefinitely (Ctrl+C to stop).
+- First positional arg (`corpus-live`) — live corpus directory. New interesting inputs are written here.
+- Second positional arg (`60`) — duration in seconds. Without a bound the fuzzer runs indefinitely (Ctrl+C to stop).
+- Third positional arg (`fuzz/handlers/corpus`) — optional read-only seed corpus. These 52 inputs give the fuzzer a head start with known-good IIIF URIs.
+
+The recipe forwards libFuzzer's exit code so a crash propagates through `just`. It also appends `-print_final_stats=1` automatically.
 
 ### Understanding the output
 
@@ -83,18 +80,17 @@ INFO: Loaded 52 files from ../../../fuzz/handlers/corpus/
 
 ### Useful flags
 
+For anything beyond duration + seed corpus, invoke the fuzzer binary directly (the `just` recipe is a thin convenience wrapper, not a full passthrough):
+
 ```bash
 # Limit input size (parser inputs are short URIs, not megabytes)
-./iiif_handler_uri_parser_fuzz corpus/ -max_len=256
+./result/bin/iiif_handler_uri_parser_fuzz corpus-live/ -max_len=256
 
 # Run a fixed number of iterations
-./iiif_handler_uri_parser_fuzz corpus/ -runs=100000
-
-# Print coverage stats at the end
-./iiif_handler_uri_parser_fuzz corpus/ -print_final_stats=1
+./result/bin/iiif_handler_uri_parser_fuzz corpus-live/ -runs=100000
 
 # Reproduce a crash (run a single input)
-./iiif_handler_uri_parser_fuzz /path/to/crash-abc123
+./result/bin/iiif_handler_uri_parser_fuzz /path/to/crash-abc123
 ```
 
 ## CI Integration
@@ -106,11 +102,11 @@ The fuzz workflow (`.github/workflows/fuzz.yml`) runs:
 
 ### What it does
 
-1. Builds the fuzz target using `nix develop .#clang`
+1. Builds the fuzz target via `just nix-build-fuzz` (→ `nix build .#fuzz`)
 2. Downloads the corpus from the previous night's run (if available)
-3. Runs the fuzzer for 10 minutes (default), merging new findings into the live corpus
+3. Runs `just nix-run-fuzz fuzz-corpus-live $FUZZ_DURATION fuzz/handlers/corpus` (default 10 minutes), merging new findings into the live corpus
 4. Uploads the updated corpus as an artifact (`fuzz-corpus`, retained 30 days)
-5. On crash:
+5. On crash (libFuzzer exits non-zero; `set -o pipefail` propagates it):
     - Uploads crash reproducers as artifacts (`fuzz-crashes`, retained 90 days)
     - Opens a GitHub issue with crash details, hex dump, and reproduction instructions
 
@@ -135,7 +131,7 @@ Periodically, you should pull the CI corpus back into the repo so that:
 ### Download and merge
 
 ```bash
-make fuzz-corpus-update
+just fuzz-corpus-update
 ```
 
 This downloads the latest `fuzz-corpus` artifact from CI, deduplicates by content hash, and merges into `fuzz/handlers/corpus/`. It reports how many new inputs were added.

--- a/docs/src/development/kakadu.md
+++ b/docs/src/development/kakadu.md
@@ -19,7 +19,7 @@ Export a GitHub token once per shell, then build normally:
 
 ```bash
 export GH_TOKEN=$(gh auth token)
-nix build .#default
+just nix-build-default
 ```
 
 The flake's fixed-output derivation calls `gh release download` inside
@@ -68,7 +68,7 @@ never enters the commit history.
 2. In `flake.nix`, update `kakaduVersion`, `kakaduAssetName`, and `kakaduSha256`
 3. Update `ASSET` and `TAG` in `scripts/fetch-kakadu.sh`
 4. Remove the local archive: `rm vendor/v8_5-*.zip`
-5. Re-build: `nix build .#default` — a SHA-256 mismatch means step 2 is wrong
+5. Re-build: `just nix-build-default` — a SHA-256 mismatch means step 2 is wrong
 6. Docker path: `just kakadu-fetch` to refresh `vendor/`
 7. Commit and open a PR
 

--- a/docs/src/development/nix.md
+++ b/docs/src/development/nix.md
@@ -1,0 +1,185 @@
+# Building with Nix
+
+`nix` is the single entry point for every Sipi build artifact (dev binary,
+static binary, Docker image, debug symbols). It is reproducible, hermetic,
+and shares its dependency cache with CI via Cachix.
+
+## Nix primer (for newcomers)
+
+A few concepts that make the rest of this page click:
+
+**Derivation.** Each package in the flake — `dev`, `default`, `release`,
+`sanitized`, `fuzz`, `docker`, `static-amd64`, etc. — is a separate
+*derivation*: a build recipe with fully declared inputs (source, compiler,
+flags, deps). Nix hashes the recipe, builds once, caches the result in
+`/nix/store`, and serves future requests instantly.
+
+**Outputs.** A single derivation can produce multiple outputs. For
+example `.#dev` emits:
+
+- default output — the sipi binary + runtime files
+- `^debug` — split debug symbols (from `separateDebugInfo = true`)
+- `^coverage` — `coverage.xml` from gcovr
+
+Select an output with `^`: `nix build .#dev^coverage`. Without `^`, you
+get the default output.
+
+**List what the flake offers:**
+
+```bash
+nix flake show                # current system only
+nix flake show --all-systems  # every system (darwin + linux)
+```
+
+**Cross-platform dispatch.** Each derivation declares its target
+`system` (e.g., `aarch64-linux`). `nix build` reads it and either builds
+locally (if the host matches) or hands off to a configured external
+builder. No `--system` flag needed — see
+[Building Linux binaries from macOS](#building-linux-binaries-from-macos).
+
+**Common syntax shapes:**
+
+| Form | Meaning |
+|---|---|
+| `nix build .#dev` | Current-system `dev` derivation, default output |
+| `nix build .#packages.aarch64-linux.dev` | Explicit target system |
+| `nix build .#dev^coverage` | A specific output of a derivation |
+| `nix flake show` | List everything the flake exposes |
+
+## One-time setup
+
+**1. Install [Determinate Nix](https://docs.determinate.systems/).**
+On macOS, add the `native-linux-builder` feature so you can build any
+Linux variant from macOS without a VM. As of April 2026 this is
+**not yet generally available** — request access via Determinate
+Systems support, per the
+[native-linux-builder setup notes](https://docs.determinate.systems/troubleshooting/native-linux-builder/).
+Once enabled, verify:
+
+```bash
+nix config show | grep external-builders
+```
+
+You should see entries for `aarch64-linux` and `x86_64-linux`. Without
+`native-linux-builder`, Linux-targeted builds on macOS need a remote
+Linux builder configured by hand.
+
+**2. Enable the shared Cachix cache.** This is what turns a 15-minute
+cold build into a 2-minute warm one — CI pushes every `ext/` dep and
+every `sipi-*` output to `dasch-swiss.cachix.org`.
+
+```bash
+cachix use dasch-swiss
+```
+
+This writes `~/.config/nix/nix.conf` entries for the substituter and
+trusted public key. After the first successful `nix build`, subsequent
+builds on the same flake closure are near-instant.
+
+**3. (Optional) GH_TOKEN for cold-cache Kakadu fetches.** The Kakadu
+FOD only runs when Cachix doesn't already have its output. In that
+rare case it needs a GitHub token to fetch `dsp-ci-assets`. Put this
+in `.envrc` once:
+
+```bash
+# .envrc
+export GH_TOKEN=$(gh auth token)
+```
+
+On the hot path you never notice this — Cachix serves the Kakadu
+output and `GH_TOKEN` is never read.
+
+## Build artifacts (via `just` — what CI invokes)
+
+Every build recipe wraps `nix build .#<variant>`. No imperative cmake
+invocations in recipes — CI invokes only `just <recipe>`.
+
+```bash
+just nix-build                         # .#dev: Debug + coverage; unit tests run in the sandbox
+just nix-build-default                 # .#default: RelWithDebInfo + tests
+just nix-build-release                 # .#release: stripped, no tests
+just nix-build-sanitized               # .#sanitized: Debug + ASan + UBSan
+just nix-build-fuzz                    # .#fuzz: libFuzzer binary only
+just nix-build-static-amd64            # .#static-amd64: Zig-in-Nix musl
+just nix-build-static-arm64            # .#static-arm64: Zig-in-Nix musl
+just nix-build-release-archive-amd64   # .#release-archive-amd64: tarball + sha256 + debug
+just nix-build-release-archive-arm64   # .#release-archive-arm64: tarball + sha256 + debug
+just nix-coverage                      # .#dev^coverage: writes result-coverage/coverage.xml
+just nix-docker-build                  # streams .#docker-stream into the local Docker daemon
+```
+
+Debug symbols for any variant are available on the `.debug` output:
+
+```bash
+nix build .#dev.debug                  # extracted symbols at result/lib/debug/...
+```
+
+## Dev shell inner loop (non-recipe — local iteration only)
+
+The justfile does NOT expose an imperative build recipe. The fast
+edit/rebuild cycle is intentionally documented here as a dev-shell
+pattern instead of a recipe — recipes are contracts that CI runs the
+same command, and CI always goes through a Nix derivation.
+
+```bash
+nix develop                    # default = clang + libc++
+nix develop .#fuzz             # libstdc++ for libFuzzer ABI
+nix develop .#gcc              # gcc14Stdenv
+
+# Inside the shell (non-reproducible, will NOT match CI byte-for-byte):
+cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -DCODE_COVERAGE=ON
+cmake --build build --parallel
+./build/sipi --config config/sipi.localdev-config.lua
+# subsequent edits:
+cmake --build build            # incremental
+```
+
+To run the reproducible CI build (same commands as CI), use
+`just nix-build` instead. For tests against the built sipi, use:
+
+```bash
+just rust-test-e2e             # resolves $SIPI_BIN, default ./result/bin/sipi
+just hurl-test                 # Hurl HTTP contract tests
+just nix-run                   # sipi with the dev config
+just nix-valgrind              # sipi under Valgrind
+```
+
+## Building Linux binaries from macOS
+
+Requires `native-linux-builder` enabled on your Determinate Nix install
+(see [One-time setup](#one-time-setup) — not yet GA as of April 2026,
+request via support). Once it's on, just name the Linux package
+explicitly:
+
+```bash
+nix build .#packages.aarch64-linux.dev -L
+```
+
+Swap `aarch64-linux` for `x86_64-linux` to reproduce the amd64 CI
+variant. Works for every package: `dev`, `default`, `release`,
+`sanitized`, `fuzz`, `static-amd64`, `static-arm64`.
+
+`native-linux-builder` dispatches the build automatically; you don't
+pass a `--system` flag. Warm Cachix → seconds. Cold Cachix → ~15 min
+(and the Kakadu FOD will need `GH_TOKEN` in your env — see step 3 of
+One-time setup).
+
+## Static Linux binaries
+
+Static musl binaries are produced by the Nix flake via a Zig-based
+toolchain (`cmake/zig-toolchain.cmake`). No Zig install is needed on
+the host — Zig ships inside the Nix dev shell and is invoked by
+`mkStaticBuild` in `flake.nix`.
+
+```bash
+just nix-build-static-amd64            # x86_64-linux-musl
+just nix-build-static-arm64            # aarch64-linux-musl
+just nix-build-release-archive-amd64
+just nix-build-release-archive-arm64
+```
+
+Validation:
+
+```bash
+just nix-static-linkage-verify result/bin/sipi
+```

--- a/docs/src/development/testing-strategy.md
+++ b/docs/src/development/testing-strategy.md
@@ -379,7 +379,7 @@ Four layers, from fastest/narrowest to slowest/broadest:
 - Image format header parsing
 - Any function that processes untrusted input
 
-**Corpus management:** CI uploads corpus artifacts; `make fuzz-corpus-update` merges CI corpus into seed corpus. See [Fuzz Testing](fuzzing.md) for full details.
+**Corpus management:** CI uploads corpus artifacts; `just fuzz-corpus-update` merges CI corpus into seed corpus. See [Fuzz Testing](fuzzing.md) for full details.
 
 ## Test Decision Tree
 
@@ -690,7 +690,7 @@ The following matrix maps every testable IIIF spec requirement to its test statu
 
 Memory leaks and undefined behavior are not a separate pyramid layer but a **build variant** that runs existing tests with compiler instrumentation. This is critical for sipi as a long-running C++ server where leaks accumulate.
 
-**Current state:** ASan+UBSan infrastructure is in place — `ENABLE_SANITIZERS` CMake option, `make nix-test-sanitized` target, and nightly `sanitizer.yml` CI workflow. Known findings to triage on first run:
+**Current state:** ASan+UBSan infrastructure is in place — `ENABLE_SANITIZERS` CMake option, `just nix-build-sanitized` (builds `.#sanitized` with tests running in the Nix sandbox), and nightly `sanitizer.yml` CI workflow. Known findings to triage on first run:
 
 - **DEV-6002: `SipiFilenameHash::operator=` memory leak** — `operator=` allocates `new vector<char>` without deleting the old `hash` pointer. Confirmed by code inspection. Fix: add `delete hash;` before the new allocation, or switch to `std::unique_ptr`.
 - **Potential: `SipiFilenameHash` copy constructor** — also `new`s without freeing, but only leaks if the destination object was previously constructed with a different hash (doesn't happen via typical usage).
@@ -709,9 +709,8 @@ Memory leaks and undefined behavior are not a separate pyramid layer but a **bui
 | Component | Status | Details |
 |-----------|--------|---------|
 | `ENABLE_SANITIZERS` CMake option | Done | `-fsanitize=address,undefined` on all targets |
-| `make nix-build-sanitized` | Done | Builds into `build-sanitized/` with ASan+UBSan |
-| `make nix-test-sanitized` | Done | Runs unit tests with leak detection |
-| Nightly CI (`sanitizer.yml`) | Done | 03:00 UTC, unit + e2e, artifacts uploaded |
+| `just nix-build-sanitized` | Done | Builds `.#sanitized` derivation (Debug + ASan + UBSan); unit tests run inside the Nix sandbox and fail the build on any finding |
+| Nightly CI (`sanitizer.yml`) | Done | PR + scheduled; unit tests in-sandbox, e2e out-of-sandbox with ASan log capture |
 | TSan variant | Future | Optional nightly, separate from ASan (can't combine) |
 
 **Strategy:** Nightly CI job runs unit tests + e2e suite with ASan+UBSan. TSan as optional nightly variant. Not in PR CI (too slow).
@@ -761,15 +760,15 @@ insta::assert_json_snapshot!(info_json, {
 
 ## CI Integration
 
-| Target | Make Command | When | Notes |
+| Target | Just Recipe | When | Notes |
 |---|---|---|---|
-| C++ unit tests | `make nix-test` | PR CI | GoogleTest via ctest |
-| Rust e2e tests | `make rust-test-e2e` | PR CI | Includes insta snapshots |
-| Hurl contract tests | `make hurl-test` | PR CI | Declarative HTTP tests |
+| C++ unit tests | `just nix-build` (`.#dev` checkPhase) | PR CI | GoogleTest via ctest, runs in the Nix sandbox |
+| Rust e2e tests | `just rust-test-e2e` | PR CI | Includes insta snapshots |
+| Hurl contract tests | `just hurl-test` | PR CI | Declarative HTTP tests |
 | Python e2e tests | *(retired)* | — | Replaced by Rust e2e tests |
 | Fuzz testing | `.github/workflows/fuzz.yml` | Nightly | libFuzzer corpus growth |
-| Sanitizer builds (future) | `make nix-test-sanitized` | Nightly | ASan+UBSan |
-| Load testing (future) | — | Nightly | `wrk` throughput baseline |
+| Sanitizer builds | `just nix-build-sanitized` (`.#sanitized`) | PR + Nightly | ASan+UBSan; unit tests in-sandbox, e2e out-of-sandbox |
+| Load testing | `.github/workflows/loadtest.yml` | Nightly | `wrk` throughput baseline |
 
 ## Python Test Deprecation — Parity Checklist
 

--- a/flake.nix
+++ b/flake.nix
@@ -73,8 +73,15 @@
 
       overlay = final: prev: {
         kakaduArchive = mkKakaduArchive final;
+        # `pkgs.sipi` uses clang + libc++ to match the Docker build and the
+        # historic dev-shell toolchain. Without the explicit override, the
+        # derivation picks up nixpkgs' default stdenv (GCC on Linux), which
+        # rejects the `-stdlib=libc++` flags set in `package.nix`. The
+        # `.#fuzz` variant overrides stdenv again to llvmPackages_19.stdenv
+        # (libstdc++) for libFuzzer ABI compatibility.
         sipi = prev.callPackage ./package.nix {
           inherit (final) kakaduArchive;
+          stdenv = final.llvmPackages_19.libcxxStdenv;
         };
       };
     in
@@ -240,6 +247,62 @@
             cmakeBuildType = "Release";
             enableTests = false;
           }).overrideAttrs { dontStrip = true; };
+
+          # Debug build with AddressSanitizer + UndefinedBehaviorSanitizer.
+          # Mirrors sanitizer.yml's pre-Nix imperative invocation, now as a
+          # derivation so `just nix-build-sanitized` routes through Cachix
+          # and runs the sanitizer-instrumented gtest suite in-sandbox.
+          sanitized = pkgs.sipi.override {
+            cmakeBuildType = "Debug";
+            enableSanitizers = true;
+            enableTests = true;
+          };
+
+          # Fuzz harness build. Uses llvmPackages_19.stdenv (libstdc++)
+          # because libFuzzer's ABI is tied to libstdc++. The override
+          # replaces buildPhase/installPhase to produce just the fuzzer
+          # binary — sipi's runtime files (config, scripts, server) are
+          # intentionally omitted since libFuzzer invocations don't use
+          # them. Running the fuzzer happens outside the derivation via
+          # `just nix-run-fuzz`, which forwards libFuzzer's exit code.
+          fuzz = (pkgs.sipi.override {
+            stdenv = pkgs.llvmPackages_19.stdenv;
+            enableFuzzing = true;
+            enableTests = false;
+          }).overrideAttrs (old: {
+            # The base sipi package sets `-stdlib=libc++` in env.CXXFLAGS /
+            # LDFLAGS to match its clang+libc++ stdenv. For `.#fuzz` we
+            # override the stdenv to `llvmPackages_19.stdenv` (clang +
+            # libstdc++) so that libFuzzer's ABI lines up; the libc++
+            # flag then asks the linker for libc++ which the libstdc++
+            # stdenv doesn't carry (fails with `ld: cannot find -lc++`).
+            # macOS happens to work because libc++ ships system-wide;
+            # Linux has no such fallback. Drop the flag for this variant.
+            env = (old.env or { }) // {
+              CXXFLAGS = "";
+              LDFLAGS = "-Wno-unused-command-line-argument";
+            };
+            # nixpkgs' cmake hook leaves CWD at `$sourceRoot/build` after
+            # configurePhase on macOS, but the hook's exact CWD behavior
+            # has been platform-sensitive historically. Normalize by
+            # entering the cmake build tree if we aren't already there,
+            # so the override works on both macOS and Linux regardless
+            # of hook version.
+            buildPhase = ''
+              runHook preBuild
+              [ -f CMakeCache.txt ] || cd "''${cmakeBuildDir:-build}"
+              cmake --build . --parallel $NIX_BUILD_CORES \
+                --target iiif_handler_uri_parser_fuzz
+              runHook postBuild
+            '';
+            installPhase = ''
+              runHook preInstall
+              [ -f CMakeCache.txt ] || cd "''${cmakeBuildDir:-build}"
+              mkdir -p $out/bin
+              cp fuzz/handlers/iiif_handler_uri_parser_fuzz $out/bin/
+              runHook postInstall
+            '';
+          });
 
         } // pkgs.lib.optionalAttrs isLinux {
           # Static Linux binaries (Zig toolchain, musl)

--- a/justfile
+++ b/justfile
@@ -1,5 +1,11 @@
 # Sipi — IIIF-compatible media server
 # Run `just` to list all available recipes.
+#
+# Build reproducibility invariant: every build-related recipe goes through
+# `nix build .#<variant>`. CI invokes only `just <recipe>`. Incremental
+# inner-loop development (seconds-fast rebuilds while editing one .cpp file)
+# is deliberately NOT a recipe — see CLAUDE.md / docs/src/development/developing.md
+# for the documented `nix develop` + `cmake --build build` workflow.
 
 # Auto-detect CPU cores
 nproc := `nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4`
@@ -140,27 +146,163 @@ test-smoke-ci:
     cd test/e2e-rust && cargo test --features docker --test docker_smoke -- --test-threads=1
 
 #####################################
-# Nix (run inside `nix develop`)
+# Nix builds (reproducible — what CI runs)
+#
+# Every recipe here wraps `nix build .#<variant>`. No imperative cmake.
+# For the fast inner-loop edit/rebuild cycle, drop into `nix develop` and
+# call cmake by hand — see CLAUDE.md "Inner-loop development".
+#
+# Every recipe passes `--extra-experimental-features configurable-impure-env
+# --option impure-env "GH_TOKEN=$GH_TOKEN"` so the Kakadu FOD can pull the
+# archive on a cold Cachix cache. Harmless when GH_TOKEN is empty (the FOD
+# falls through to cache substitution or errors with a helpful message).
 #####################################
 
-# Build SIPI (debug + coverage, inside Nix shell)
+_nix_build := "nix build --extra-experimental-features configurable-impure-env --option impure-env GH_TOKEN=${GH_TOKEN:-}"
+
+# Dev build: Debug + coverage instrumentation, tests run in the Nix sandbox.
+# Canonical CI build — what `test.yml` invokes on every PR.
 nix-build:
-    cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -DCODE_COVERAGE=ON --log-context
-    cmake --build ./build --parallel {{nproc}}
+    {{_nix_build}} .#dev
+    @echo "Binary at: $(readlink result)/bin/sipi"
 
-# Run unit tests (inside Nix shell)
-nix-test:
-    cd build && ctest --output-on-failure
+# Default build: RelWithDebInfo + tests, unstripped debug info in $debug.
+nix-build-default:
+    {{_nix_build}} .#default
+    @echo "Binary at: $(readlink result)/bin/sipi"
 
-# Run Rust e2e tests (requires built sipi in build/ — run `just nix-build` first)
+# Release build: Release + tests disabled + dontStrip (for manual distribution).
+nix-build-release:
+    {{_nix_build}} .#release
+    @echo "Binary at: $(readlink result)/bin/sipi"
+
+# Sanitized build: Debug + ASan + UBSan, tests run in the Nix sandbox.
+# `filter-syscalls false` is required because LSan uses ptrace, which
+# the default Nix sandbox blocks via seccomp. No-op on macOS.
+nix-build-sanitized:
+    {{_nix_build}} .#sanitized --option filter-syscalls false
+    @echo "Binary at: $(readlink result)/bin/sipi"
+
+# Fuzz harness build: produces the libFuzzer binary only (no sipi runtime files).
+nix-build-fuzz:
+    {{_nix_build}} .#fuzz
+    @echo "Fuzzer at: $(readlink result)/bin/iiif_handler_uri_parser_fuzz"
+
+# Static amd64 binary via Zig-in-Nix (Linux only).
+nix-build-static-amd64:
+    {{_nix_build}} .#static-amd64
+
+# Static arm64 binary via Zig-in-Nix (Linux only).
+nix-build-static-arm64:
+    {{_nix_build}} .#static-arm64
+
+# Release archive amd64 (tarball + sha256 + debug symbols).
+nix-build-release-archive-amd64:
+    {{_nix_build}} .#release-archive-amd64
+
+# Release archive arm64 (tarball + sha256 + debug symbols).
+nix-build-release-archive-arm64:
+    {{_nix_build}} .#release-archive-arm64
+
+# Docker image via Nix dockerTools (streamed into Docker daemon).
+nix-docker-build:
+    $({{_nix_build}} .#docker-stream --print-out-paths) | docker load
+
+# Coverage XML for Codecov (at result-coverage/coverage.xml).
+nix-coverage:
+    {{_nix_build}} .#dev^coverage
+    @echo "Coverage at: result-coverage/coverage.xml"
+
+# Verify a Linux static sipi binary has no NEEDED dynamic library entries.
+nix-static-linkage-verify path:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    file "{{path}}"
+    if readelf -d "{{path}}" | grep -q '(NEEDED)'; then
+        echo "ERROR: {{path}} has unexpected dynamic dependencies:" >&2
+        readelf -d "{{path}}" | grep 'NEEDED' >&2
+        exit 1
+    fi
+    echo "OK: {{path}} is statically linked (no NEEDED entries)."
+
+# Audit macOS sipi runtime dylibs — fail if any point at /opt/homebrew/ or /usr/local/.
+nix-macos-dylib-audit path:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    otool -L "{{path}}"
+    if otool -L "{{path}}" | awk 'NR>1 {print $1}' | grep -E '^(/opt/homebrew/|/usr/local/)'; then
+        echo "ERROR: {{path}} references non-system dylibs (must be portable)." >&2
+        exit 1
+    fi
+    echo "OK: {{path}} uses only system dylibs."
+
+#####################################
+# Tests (consume $SIPI_BIN, default ./result/bin/sipi)
+#####################################
+
+# Run Rust e2e tests against the built sipi.
 rust-test-e2e:
     #!/usr/bin/env bash
     set -euo pipefail
-    if [ ! -x "{{justfile_directory()}}/build/sipi" ]; then
-        echo "Missing build/sipi. Run 'just nix-build' (inside 'nix develop') first." >&2
+    SIPI_BIN="${SIPI_BIN:-{{justfile_directory()}}/result/bin/sipi}"
+    if [ ! -x "$SIPI_BIN" ]; then
+        echo "sipi binary not found at $SIPI_BIN. Run 'just nix-build' first." >&2
         exit 1
     fi
-    cd test/e2e-rust && SIPI_BIN={{justfile_directory()}}/build/sipi cargo test -- --test-threads=1
+    cd test/e2e-rust && SIPI_BIN="$SIPI_BIN" cargo test -- --test-threads=1
+
+# Run Hurl HTTP contract tests against the built sipi.
+hurl-test:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    SIPI_BIN="${SIPI_BIN:-{{justfile_directory()}}/result/bin/sipi}"
+    if [ ! -x "$SIPI_BIN" ]; then
+        echo "sipi binary not found at $SIPI_BIN. Run 'just nix-build' first." >&2
+        exit 1
+    fi
+    cd test/_test_data && "$SIPI_BIN" --config config/sipi.e2e-test-config.lua &
+    SIPI_PID=$!
+    # Don't propagate sipi's SIGTERM exit code (143) as the recipe exit code.
+    trap 'kill $SIPI_PID 2>/dev/null || true; wait $SIPI_PID 2>/dev/null || true' EXIT
+    READY=0
+    for i in $(seq 1 30); do
+        curl -sf http://127.0.0.1:1024/unit/lena512.jp2/info.json > /dev/null 2>&1 && READY=1 && break
+        sleep 0.5
+    done
+    if [ "$READY" -ne 1 ]; then echo "ERROR: sipi failed to start within 15s"; exit 1; fi
+    cd {{justfile_directory()}}/test/hurl && hurl --test --insecure --variable host=http://127.0.0.1:1024 *.hurl
+
+# Run sipi with the localdev config.
+nix-run: nix-build # dep: keep result/bin/sipi fresh across variant switches
+    #!/usr/bin/env bash
+    set -euo pipefail
+    SIPI_BIN="${SIPI_BIN:-{{justfile_directory()}}/result/bin/sipi}"
+    "$SIPI_BIN" --config={{justfile_directory()}}/config/sipi.localdev-config.lua
+
+# Run sipi under Valgrind.
+nix-valgrind: nix-build
+    #!/usr/bin/env bash
+    set -euo pipefail
+    SIPI_BIN="${SIPI_BIN:-{{justfile_directory()}}/result/bin/sipi}"
+    valgrind --leak-check=yes --track-origins=yes "$SIPI_BIN" --config={{justfile_directory()}}/config/sipi.config.lua
+
+# Run the libFuzzer harness against a live corpus (read+write) for a bounded
+# time budget. Optional read-only seed corpus can be passed as the third arg.
+# Exit 0 = time budget reached with no new crash; non-zero = new crash
+# (fuzz.yml inspects the exit code and opens a GitHub issue).
+nix-run-fuzz corpus duration seed="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    FUZZ_BIN="${FUZZ_BIN:-{{justfile_directory()}}/result/bin/iiif_handler_uri_parser_fuzz}"
+    if [ ! -x "$FUZZ_BIN" ]; then
+        echo "fuzzer binary not found at $FUZZ_BIN. Run 'just nix-build-fuzz' first." >&2
+        exit 1
+    fi
+    if [ -n "{{seed}}" ]; then
+        exec "$FUZZ_BIN" "{{corpus}}" "{{seed}}" -max_total_time={{duration}} -print_final_stats=1
+    else
+        exec "$FUZZ_BIN" "{{corpus}}" -max_total_time={{duration}} -print_final_stats=1
+    fi
 
 # Download CI fuzz corpus and merge into seed corpus
 fuzz-corpus-update:
@@ -178,89 +320,6 @@ fuzz-corpus-update:
     after=$(ls fuzz/handlers/corpus/ | wc -l | tr -d ' ')
     echo "Corpus: $before → $after inputs ($((after - before)) new)"
     rm -rf {{justfile_directory()}}/.fuzz-corpus-ci
-
-# Run Hurl HTTP contract tests (requires built sipi in build/)
-hurl-test:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    cd test/_test_data && {{justfile_directory()}}/build/sipi --config config/sipi.e2e-test-config.lua &
-    SIPI_PID=$!
-    # Don't propagate sipi's SIGTERM exit code (143) as the recipe exit code.
-    # `|| true` on each command — without it, `set -e` makes `wait` (which
-    # returns 143 after we SIGTERMed sipi) override the hurl success code.
-    trap 'kill $SIPI_PID 2>/dev/null || true; wait $SIPI_PID 2>/dev/null || true' EXIT
-    READY=0
-    for i in $(seq 1 30); do
-        curl -sf http://127.0.0.1:1024/unit/lena512.jp2/info.json > /dev/null 2>&1 && READY=1 && break
-        sleep 0.5
-    done
-    if [ "$READY" -ne 1 ]; then echo "ERROR: sipi failed to start within 15s"; exit 1; fi
-    cd {{justfile_directory()}}/test/hurl && hurl --test --insecure --variable host=http://127.0.0.1:1024 *.hurl
-
-# Generate coverage XML report via gcovr (inside Nix shell)
-nix-coverage:
-    cd build && gcovr -j {{nproc}} --delete --root ../ --print-summary --xml-pretty --xml coverage.xml . \
-        --gcov-executable "llvm-cov gcov" \
-        --gcov-ignore-parse-errors=negative_hits.warn_once_per_file \
-        --gcov-ignore-errors=no_working_dir_found \
-        --exclude '../test/' \
-        --exclude '../fuzz/' \
-        --exclude '../ext/' \
-        --exclude '../include/'
-
-# Generate coverage HTML report via lcov (inside Nix shell)
-nix-coverage-html:
-    cd build && lcov --capture --directory . --output-file coverage.info \
-        && lcov --remove coverage.info '/usr/*' --output-file coverage.info \
-        && lcov --remove coverage.info '*/test/*' --output-file coverage.info \
-        && genhtml coverage.info --output-directory coverage
-
-# Run all tests then generate coverage report (inside Nix shell)
-nix-coverage-full: nix-build nix-test rust-test-e2e hurl-test nix-coverage
-
-# Build SIPI with ASan+UBSan (inside Nix shell, Clang only)
-nix-build-sanitized:
-    cmake -B build-sanitized -S . -DCMAKE_BUILD_TYPE=Debug -DENABLE_SANITIZERS=ON --log-context
-    cmake --build ./build-sanitized --parallel {{nproc}}
-
-# Build with sanitizers and run unit tests (inside Nix shell)
-nix-test-sanitized: nix-build-sanitized
-    cd build-sanitized && ASAN_OPTIONS=detect_leaks=1:halt_on_error=0 ctest --output-on-failure
-
-# Run SIPI server (inside Nix shell)
-nix-run:
-    {{justfile_directory()}}/build/sipi --config={{justfile_directory()}}/config/sipi.config.lua
-
-# Run SIPI with Valgrind (inside Nix shell)
-nix-valgrind:
-    valgrind --leak-check=yes --track-origins=yes ./build/sipi --config={{justfile_directory()}}/config/sipi.config.lua
-
-# Build SIPI with RelWithDebInfo (inside Nix shell)
-build:
-    cmake -B build -S . -DCMAKE_BUILD_TYPE=RelWithDebInfo --log-context
-    cd build && cmake --build . --parallel {{nproc}}
-
-#####################################
-# Nix full builds (no shell required)
-#####################################
-
-# Build release binary via nix build
-# Run `just kakadu-fetch` once before first build — see docs/src/development/kakadu.md.
-nix-build-release:
-    nix build .#default
-    @echo "Binary at: $(readlink result)/bin/sipi"
-
-# Build static amd64 binary via Nix
-nix-build-static-amd64:
-    nix build .#static-amd64
-
-# Build static arm64 binary via Nix
-nix-build-static-arm64:
-    nix build .#static-arm64
-
-# Build Docker image via Nix
-nix-docker-build:
-    $(nix build .#docker-stream --print-out-paths) | docker load
 
 #####################################
 # Vendor dependencies
@@ -310,8 +369,11 @@ docs-install-requirements:
 # Utilities
 #####################################
 
-# Clean build artifacts
+# Clean build artifacts (cmake trees from the dev-shell inner loop + Nix result symlinks)
 clean:
     rm -rf build/
+    rm -rf build-sanitized/
+    rm -rf build-fuzz/
     rm -rf cmake-build-relwithdebinfo-inside-docker/
     rm -rf site/
+    rm -f result result-* || true

--- a/package.nix
+++ b/package.nix
@@ -14,6 +14,8 @@
 , iconv
 , perl
 , fetchurl
+, gcovr
+, llvmPackages_19
 , kakaduArchive  # Store path to the Kakadu zip. Provided by flake.nix via
                  # a fixed-output derivation that calls `gh release download`
                  # against dsp-ci-assets. Requires GH_TOKEN (or a Cachix hit)
@@ -21,6 +23,7 @@
 , cmakeBuildType ? "RelWithDebInfo"
 , enableCoverage ? false
 , enableSanitizers ? false
+, enableFuzzing ? false
 , enableTests ? true
 , providedVersion ? null
 }:
@@ -65,6 +68,15 @@ stdenv.mkDerivation {
     ];
   };
 
+  # `coverage` is an extra output populated by the postCheck hook when
+  # both `enableCoverage` and `enableTests` are true. The `debug` output
+  # is added automatically by nixpkgs when `separateDebugInfo = true`
+  # (below) on Linux — including it explicitly here would cause a
+  # `duplicate derivation output 'debug'` error. Gating `coverage` on
+  # `enableCoverage` lets `.#fuzz` (which replaces installPhase via
+  # overrideAttrs) skip the marker-directory dance.
+  outputs = [ "out" ] ++ lib.optional enableCoverage "coverage";
+
   nativeBuildInputs = [
     cmake
     pkg-config
@@ -76,6 +88,9 @@ stdenv.mkDerivation {
     unzip
     xxd
     file  # autoreconf deps for libmagic build
+  ] ++ lib.optionals enableCoverage [
+    gcovr                  # gcovr binary used by postCheck to produce coverage.xml
+    llvmPackages_19.llvm   # provides `llvm-cov` on PATH for gcovr's --gcov-executable
   ];
 
   buildInputs = [
@@ -90,6 +105,8 @@ stdenv.mkDerivation {
     "-DCODE_COVERAGE=ON"
   ] ++ lib.optionals enableSanitizers [
     "-DENABLE_SANITIZERS=ON"
+  ] ++ lib.optionals enableFuzzing [
+    "-DSIPI_ENABLE_FUZZ=ON"
   ] ++ lib.optionals enableTests [
     "-DBUILD_TESTING=ON"
     "-DGTEST_LOCAL_ARCHIVE=${gtestArchive}"
@@ -102,8 +119,14 @@ stdenv.mkDerivation {
   # sha256-pinned fixed-output derivation that fetches the asset from the
   # dsp-ci-assets GitHub release. ext/kakadu expects the archive at this
   # exact path and filename.
+  #
+  # `patchShebangs` rewrites `generate_icc_header.sh`'s `#!/bin/bash`
+  # shebang to a nix-store path; the script is invoked from CMakeLists.txt
+  # at build time, so nixpkgs' automatic shebang patching doesn't cover it
+  # (same pattern as `mkStaticBuild` in flake.nix).
   preConfigure = ''
     cp ${kakaduArchive} vendor/v8_5-01382N.zip
+    patchShebangs generate_icc_header.sh
   '';
 
   env = {
@@ -111,9 +134,49 @@ stdenv.mkDerivation {
     LDFLAGS = "-stdlib=libc++ -Wno-unused-command-line-argument";
   };
 
-  # Tests are built when enableTests=true but not run during `nix build`.
-  # Run tests in the dev shell: `just nix-build && just nix-test`
-  doCheck = false;
+  # Match the dev-shell toolchain (`flake.nix` clang devShell sets
+  # `hardeningDisable = [ "all" ]`). Older autotools ext/* deps like xz
+  # fail to compile under nixpkgs' default hardening set on Linux
+  # (format, stackprotector, fortify, pic, bindnow, …). Disabling all
+  # hardening mirrors the pre-migration imperative-cmake build that ran
+  # inside the dev shell and passed CI.
+  hardeningDisable = [ "all" ];
+
+  # `doCheck = enableTests` keeps the test invariant honest: any variant
+  # that builds tests also runs them inside the sandbox (`.#default`,
+  # `.#dev`, `.#sanitized`). `.#release` sets `enableTests = false` and
+  # skips the check phase. `mkStaticBuild` in flake.nix is independent
+  # of this derivation, so static builds are unaffected.
+  doCheck = enableTests;
+
+  # cmake setup-hook cd's into `build/` in configurePhase; checkPhase and
+  # postCheck run from there.
+  checkPhase = ''
+    runHook preCheck
+    ctest --output-on-failure
+    runHook postCheck
+  '';
+
+  # Coverage report (multi-output). When `enableCoverage` is true the
+  # `$coverage` output is declared (see `outputs` above) and gcovr
+  # aggregates `.gcda` counters emitted by the test run into
+  # `$coverage/coverage.xml`. Codecov reads this path from
+  # `result-coverage/coverage.xml`.
+  #
+  # ApprovalTests note: if the sandbox rejects writes outside `build/`,
+  # `checkPhase` can be scoped via `ctest --output-on-failure -LE approval`
+  # and the approval layer kept as a dev-shell invocation.
+  postCheck = lib.optionalString enableCoverage ''
+    mkdir -p "$coverage"
+    gcovr -j $NIX_BUILD_CORES \
+      --xml "$coverage/coverage.xml" \
+      --root .. \
+      --gcov-executable "llvm-cov gcov" \
+      --exclude '../test/' \
+      --exclude '../fuzz/' \
+      --exclude '../ext/' \
+      --exclude '../include/'
+  '';
 
   separateDebugInfo = true;
 


### PR DESCRIPTION
[DEV-6280](https://linear.app/dasch/issue/DEV-6280/sipi-unify-builds-behind-nix-derivations-justfile-ci-single-source-of)

Fixes DEV-6280.

## Motivation

Phase 1 of the Nix unified-build ([01-feat-nix-unified-build-plan](../blob/main/dasch-specs/specs/2026-04-16-sipi-nix-unified-build/01-feat-nix-unified-build-plan.md), merged in #558) wrapped sipi's CMake + ExternalProject build inside the flake. But the justfile and CI wiring were left bifurcated:

- `just nix-build` was imperative `cmake -B build` inside the dev shell (no Cachix for `ext/`).
- `just nix-build-release` / `nix-build-static-*` went through `nix build .#<variant>` (full Cachix).
- Several CI steps (static-linkage verify, dylib audit, fuzzer build/run, release archive) inlined cmake or `nix build` invocations instead of going through `just`.

This PR makes the justfile a thin wrapper around Nix derivations and routes every CI step through `just <recipe>`. After this change the CLAUDE.md invariant — "all targets are in a single justfile" — holds strictly, and the precondition for DEV-5939 (split `ext/` into per-dep derivations) is met.

## Summary

- `package.nix` now flips `doCheck = enableTests` so unit tests run inside the Nix sandbox for `.#default` / `.#dev` / `.#sanitized` (and stay off for `.#release`). A new `coverage` output on `.#dev` produces `result-coverage/coverage.xml` for Codecov.
- `flake.nix` gains `packages.sanitized` (Debug + ASan + UBSan + tests) and `packages.fuzz` (libFuzzer binary only, libstdc++ stdenv).
- `justfile` is rewritten so every `nix-*` build recipe wraps `nix build .#<variant>`. No imperative cmake in recipes. Test recipes resolve the sipi binary via `\$SIPI_BIN` with default `./result/bin/sipi`.
- All five workflow YAMLs (`test`, `sanitizer`, `fuzz`, `publish`, `loadtest`) now invoke `just <recipe>` instead of inline cmake or `nix build`.
- Docs (`CLAUDE.md`, `CONVENTIONS.md`, `README.md`, `docs/src/development/*.md`) document the new taxonomy and the dev-shell inner-loop pattern (explicitly not a recipe).

## Key Changes

| File | What |
|---|---|
| `package.nix` | `doCheck = enableTests`; multi-output `coverage`; new `enableFuzzing` parameter; gcovr + llvm-cov deps under `enableCoverage`. |
| `flake.nix` | New `packages.sanitized` and `packages.fuzz` outputs. |
| `justfile` | All imperative `cmake` recipes deleted. New derivation-backed recipes: `nix-build` (→ `.#dev`), `nix-build-default`, `nix-build-release`, `nix-build-sanitized`, `nix-build-fuzz`, `nix-build-release-archive-{amd64,arm64}`, `nix-coverage`, `nix-static-linkage-verify`, `nix-macos-dylib-audit`, `nix-run-fuzz`. Test recipes (`rust-test-e2e`, `hurl-test`, `nix-run`, `nix-valgrind`) read `\$SIPI_BIN` with the `./result/bin/sipi` default. |
| `.github/workflows/test.yml` | nix-clang uses `just nix-build` (tests run in sandbox); nix-static uses `just nix-build-static-* && just nix-static-linkage-verify`; nix-macos-audit uses `just nix-build-default && just nix-macos-dylib-audit`; Codecov reads `result-coverage/coverage.xml`. |
| `.github/workflows/sanitizer.yml` | Unit tests run in-sandbox via `just nix-build-sanitized`; e2e step uses `SIPI_BIN=\$PWD/result/bin/sipi just rust-test-e2e`. |
| `.github/workflows/fuzz.yml` | `just nix-build-fuzz` + `just nix-run-fuzz fuzz-corpus-live \$FUZZ_DURATION fuzz/handlers/corpus`. GitHub-issue repro snippet updated. |
| `.github/workflows/publish.yml` | publish-static-release uses `just nix-build-release-archive-\${arch}`. |
| `.github/workflows/loadtest.yml` | sipi started via `\$SIPI_BIN` (default `./result/bin/sipi`), no hardcoded cmake path. |

## Challenges and Decisions

- **No `cmake-*` recipes.** An honest \`cmake-*\` namespace (imperative dev-shell builds alongside derivation-backed `nix-*` recipes) was considered and rejected. Recipes are contracts — every recipe promises CI runs the same command. A `cmake-*` recipe that CI cannot run would violate that contract. The inner-loop `nix develop` + `cmake --build build` pattern remains available and is documented in `CLAUDE.md` and `docs/src/development/developing.md` as a deliberately-not-a-recipe workflow.
- **Sanitized builds use `--option filter-syscalls false`.** LSan requires ptrace, which the default Nix sandbox blocks via seccomp. The `nix-build-sanitized` recipe passes the flag (no-op on darwin).
- **`coverage` output is gated on `enableCoverage`.** The fuzz variant uses `overrideAttrs` to replace installPhase without calling `runHook postInstall`; if `coverage` were always declared, the fuzz build would fail because the marker directory wouldn't be created. Gating keeps the output declaration aligned with the outputs actually produced.
- **Single PR, not four.** The plan explicitly decides on a single PR. Splitting would break CI on every intermediate commit (tests would run imperatively before the CI workflows were migrated), and the scope is small enough (one repo, ~20 files) to review as one unit. Branch history is grouped into three commits per `docs/src/development/commit-conventions.md`: `build:` (derivations + justfile recipes + misc build hygiene), `ci:` (workflow wiring), `docs:` (new `nix.md`, inner-loop pattern, taxonomy updates).

## Gotchas

- Unit-test findings that previously silently passed outside the Nix sandbox may now fail `just nix-build`. This is intentional — the derivation graph enforces "tested before cached." Any genuinely flaky test should get a Linear ticket and a targeted `gtest_filter` or `-LE` skip in `package.nix` with a comment linking the ticket.
- ApprovalTests writes `.received.txt` files in the build tree during the check phase. If a future test change routes received files to a path outside `build/`, the sandbox will reject the write. Fix by redirecting received files into `\$TMPDIR` or scoping `ctest -LE approval`.
- Cold-cache first CI run will be slower than steady-state because Cachix doesn't have `.#sanitized` or `.#fuzz` artifacts yet. Subsequent runs hit the cache.

## Test Plan

- [x] `nix eval --raw .#dev.drvPath`, `.#sanitized.drvPath`, `.#fuzz.drvPath` — all resolve.
- [x] `just --list` — all new recipes visible; no imperative cmake recipes remain.
- [x] Grep audit: no \`cmake -S\` / \`cmake -B\` in workflows; no \`./build/sipi\` outside documented inner-loop snippets; no \`make nix-*\` in docs.
- [ ] `nix build .#dev` succeeds locally (probe in progress; validates `doCheck = enableTests` + `checkPhase` + `postCheck` gcovr against ApprovalTests sandbox behavior). If this surfaces sandbox incompatibility, `checkPhase` will scope to `ctest --output-on-failure -LE approval`.
- [ ] `test.yml`, `sanitizer.yml` green on this PR branch (primary CI gate).
- [ ] `fuzz.yml` green on manual dispatch (validates `just nix-build-fuzz` + `just nix-run-fuzz`).
- [ ] `loadtest.yml` green on manual dispatch (validates \`\$SIPI_BIN\` startup supervision).

## Plan

`dasch-specs/specs/2026-04-16-sipi-nix-unified-build/02-feat-justfile-ci-unification-plan.md` (status: reviewed(2)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
