### PR TITLE
docs(domain-model): declare SIPI domain model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 SIPI (Simple Image Presentation Interface) is a multithreaded, high-performance, IIIF-compatible media server written in C++23. It implements IIIF Image API 3.0 and provides efficient image format conversions while preserving metadata. The server can be used both as a command-line tool and as a web server with Lua scripting support.
 
+## Domain Model
+
+Read these before reasoning about names, boundaries, or architectural decisions:
+
+- [`UBIQUITOUS_LANGUAGE.md`](UBIQUITOUS_LANGUAGE.md) — canonical SIPI glossary. Defines Image vs Bitstream, the IIIF pipeline terms (Region / Size / Rotation / Quality / Format / Decode level / Canonical URL / Cache key), Preservation metadata, the three Lua entry points, the seven Permission types, and more. Use these terms in code comments, commit messages, and PR descriptions; aliases listed there are *avoid*.
+- [`CONTEXT-MAP.md`](CONTEXT-MAP.md) — declares two bounded contexts ([SIPI image server](CONTEXT.md) + [shttps embedded HTTP framework](shttps/CONTEXT.md)) with strict one-way SIPI → shttps dependency direction. Lists the four primary seam types and the secondary surface scheduled for re-homing.
+- [`docs/adr/`](docs/adr/) — architectural decision records. Start with [`0001-shttps-as-strangler-fig-target.md`](docs/adr/0001-shttps-as-strangler-fig-target.md).
+
 ## Build System and Common Commands
 
 All targets are in a single `justfile`. Run `just` for a complete list.

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,0 +1,24 @@
+# Context Map
+
+This repository has two bounded contexts. The boundary is real (separate namespace, library, build target, config template, test executable) and is being kept clean ahead of a planned Rust rewrite of the HTTP layer (strangler-fig).
+
+## Contexts
+
+- [SIPI image server](./CONTEXT.md) — IIIF Image API 3.0 implementation, image processing pipeline, cache, preservation metadata, IIIF/file route handlers. Lives under `src/`, `include/`, `include/iiifparser/`, `include/formats/`, `include/metadata/`. Namespace `Sipi::`.
+- [shttps embedded HTTP framework](./shttps/CONTEXT.md) — generic multithreaded HTTP+SSL server, route registration, connection lifecycle, embedded Lua scripting, JWT helpers. Lives under `shttps/`. Namespace `shttps::`. Builds as the standalone `shttp` static library; ships a standalone `shttp-test` executable that proves it can stand alone.
+
+## Direction of dependency
+
+**SIPI → shttps. Strictly one-way.**
+
+SIPI is a *consumer* of shttps: it subclasses `shttps::Server`, registers route handlers (`iiif_handler`, `file_handler`), and uses shttps types (`Connection`, `LuaServer`, `Parsing`, `Hash`) inside its own code. shttps must not name any `Sipi::` symbol or include any `Sipi*.h` header. Today there is one known violation (`shttps/Server.cpp` reaches into `SipiMetrics`); it is a bug, tracked as a layering leak.
+
+## Long-term direction
+
+The medium-term plan is to replace the C++ shttps with a Rust-based HTTP layer using the strangler-fig pattern: route by route, the Rust process takes over traffic until shttps is empty and can be deleted. Until then:
+
+- The seam stays narrow and well-named so the migration can swap implementations route by route.
+- New shttps features should be considered carefully — they expand what the Rust replacement must reproduce.
+- New SIPI code that touches HTTP should go through documented seam types (`Connection`, `LuaServer`, route handlers), not through shttps internals.
+
+See [docs/adr/0001-shttps-as-strangler-fig-target.md](./docs/adr/0001-shttps-as-strangler-fig-target.md).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,39 @@
+# SIPI image server
+
+The IIIF Image API 3.0 implementation: identifier resolution, the IIIF processing pipeline (region, size, rotation, quality, format), the file-based cache, preservation metadata, and the Lua-driven preflight / init / route-handler extensibility surface. Lives under `src/`, `include/`, `include/iiifparser/`, `include/formats/`, `include/metadata/`. Namespace `Sipi::`.
+
+## Language
+
+The canonical SIPI glossary is in [UBIQUITOUS_LANGUAGE.md](./UBIQUITOUS_LANGUAGE.md). It defines: Image vs Bitstream, Identifier (with embedded Page) + Prefix, Image root vs Document root, the IIIF pipeline terms (Region / Size / Rotation / Quality / Format / Decode level / Canonical URL / Cache key), Format handler vs Codec, Preservation metadata (umbrella) over Embedded metadata + Essentials packet, Image / Bitstream Information document, the three Lua entry points (Init script / Preflight script / Route handler), the seven Permission types, and the Backpressure umbrella over Decode memory budget + Rate limiter + Cache.
+
+Prefer the glossary's canonical terms over the variant spellings in older code.
+
+## Boundary with shttps
+
+This context **consumes** [shttps](./shttps/CONTEXT.md) one-way. The four primary seam types are `shttps::Server`, `shttps::Connection`, `shttps::RequestHandler`, and `shttps::LuaServer`; SIPI subclasses `Server` (`SipiHttpServer`), registers `RequestHandler`s (`iiif_handler`, `file_handler`), and runs SIPI's three Lua entry points inside the request-scoped `LuaServer`.
+
+### Cross-boundary naming gotchas
+
+- shttps' **`RequestHandler`** is the C++ function-pointer that dispatches a request. SIPI's **Route handler** (in `UBIQUITOUS_LANGUAGE.md`) is a *Lua script* bound to a URL pattern. They are not the same thing: a SIPI Route handler is *invoked by* a `RequestHandler` that loads and runs the script. Keep both terms when discussing the seam.
+- **"file_handler" is overloaded.** `shttps::file_handler` is the built-in static-file + Lua-in-HTML handler that SIPI registers on the configured `wwwroute` URL prefix; it reads from the **document root**. SIPI's IIIF `/file` endpoint (the **Bitstream** path-through) is the `FILE_DOWNLOAD` case inside `Sipi::iiif_handler` and reads from the **image root**. Same word, two unrelated handlers; always qualify which side.
+- The **document root**, the **init script**, and the **connection-pool knobs** (`keep_alive_timeout`, `queue_timeout`, `max_waiting_connections`) are shttps concepts. SIPI sets their values from its config (`sipi.config.lua`) but does not own the concepts. See `shttps/CONTEXT.md`.
+
+### Re-homing schedule (precondition for the Rust migration)
+
+The following types live in shttps today but are SIPI domain concerns or generic utilities; they are scheduled to move SIPI-side so the planned Rust replacement of shttps does not need to reproduce them:
+
+- `shttps::Hash` / `shttps::HashType` → SIPI preservation module (used by `SipiEssentials::pixel_checksum`).
+- `shttps::Parsing` → SIPI-side support module.
+- `shttps::Error` → folded into SIPI's error hierarchy.
+- `shttps::Global`, `shttps::makeunique` → inline or SIPI-side support.
+
+### Known layering leak
+
+`shttps/Server.cpp` calls `SipiMetrics::instance()`. This violates the one-way SIPI → shttps direction and is a tracked bug, not a sanctioned pattern. The intended shape is a metrics-callback hook on `shttps::Server` that SIPI populates at startup.
+
+## Relationships with shttps
+
+- A SIPI **Image** or **Bitstream** request enters through an `shttps::RequestHandler` (`iiif_handler` / `file_handler`) registered on `shttps::Server`.
+- The handler reads request data from the `shttps::Connection`, runs SIPI's **Preflight script** through the request-scoped `shttps::LuaServer`, and uses the resulting **Permission** to decide what to serve.
+- SIPI's **Route handler** (Lua) is wired through a generic `RequestHandler` that loads the script into the same `LuaServer`.
+- Response bytes (cache hit, decoded image, streamed bitstream) are written back through the same `Connection`.

--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -1,0 +1,142 @@
+# Ubiquitous Language
+
+Canonical terminology for the SIPI repository. SIPI is a IIIF Image API 3.0 server first; the rest of the surface (file streaming, embedded webserver, Lua extensibility) is layered on top.
+
+## Resources and identification
+
+| Term | Definition | Aliases to avoid |
+| --- | --- | --- |
+| **Image** | A pixel-bearing artefact processed through the IIIF pipeline (region, size, rotation, quality, format). | resource, media, asset |
+| **Bitstream** | An opaque byte stream served as-is via the `/file` endpoint, bypassing IIIF processing. | file (as a domain noun), blob, payload |
+| **Identifier** | The per-resource string carried in the URL between `{prefix}` and the IIIF parameters. Embeds an optional page ordinal for multi-page resources (PDF, multi-page TIFF). | id, fileid, file_id |
+| **Prefix** | The URL segment in front of the identifier. Routes the request to a directory subtree under the image root and namespaces preflight resolution. | path prefix, route |
+| **Image root** | The filesystem directory tree that identifiers and `/file` requests resolve into, with traversal validation. | imgroot (variable name only), storage root, repository root |
+| **Document root** | The filesystem directory the embedded webserver serves static pages from. Distinct from the image root. | docroot (variable name only), web root |
+
+## IIIF processing pipeline
+
+| Term | Definition | Aliases to avoid |
+| --- | --- | --- |
+| **Region** | The rectangle of the image to be returned, expressed in IIIF form (`full` / `square` / `x,y,w,h` / `pct:x,y,w,h`). The same term covers the parsed form and the form clamped to image bounds. | crop, ROI, crop coords |
+| **Size** | The output dimensions, expressed in IIIF form (`max` / `pct:n` / `w,` / `,h` / `w,h` / `!w,h`, optionally `^`-prefixed for upscale). | scale, dimensions |
+| **Rotation** | The IIIF rotation parameter: a non-negative decimal `n`, optionally `!`-prefixed to mirror before rotating. | rotate, angle |
+| **Quality** | The IIIF quality parameter: `default` / `color` / `gray` / `bitonal`. Independent of format. | colorspace |
+| **Format** | The IIIF output format: `jpg` / `tif` / `png` / `jp2`. Independent of quality. Also reachable as `jpx` (alias of `jp2`). | output type, encoding |
+| **Decode level** | The log2 downsampling factor applied at decode time so a smaller output can be produced without decoding full-resolution pixels. Negotiated by the size parser with the codec; meaningful for JPEG2000 and pyramid TIFF. | reduce, reduce factor, decimation |
+| **Canonical URL** | The IIIF Image API canonical URL for a request. The IIIF spec form. | canonical-with-watermark |
+| **Cache key** | The string SIPI uses to key the cache. Extends the canonical URL with a `/0` or `/1` watermark suffix, since watermark presence affects bytes but is not in the IIIF spec. | canonical URL (in cache contexts) |
+
+## Format handling
+
+| Term | Definition | Aliases to avoid |
+| --- | --- | --- |
+| **Format handler** | A SipiIO subclass that adapts a codec to SIPI's read/write contract (SipiIOJ2k, SipiIOTiff, SipiIOPng, SipiIOJpeg). | IO backend, format driver |
+| **Codec** | A third-party library that performs the actual encode/decode (kakadu, libtiff, libpng, libjpeg, libwebp). A format handler *uses* a codec. | library, backend |
+
+## Metadata and preservation
+
+| Term | Definition | Aliases to avoid |
+| --- | --- | --- |
+| **Preservation metadata** | Umbrella term for all metadata SIPI manages across format conversions for long-term preservation. Comprises *embedded metadata* and the *Essentials packet*. | sidecar metadata, image metadata |
+| **Embedded metadata** | Third-party metadata standards SIPI carries through unchanged where possible: EXIF, IPTC, XMP, and ICC color profiles. | header metadata |
+| **Essentials packet** | The SIPI-specific record embedded in image headers: original filename, original mimetype, hash type, pixel checksum, and (optionally) an ICC profile when the destination format cannot embed one natively. C++ class: `SipiEssentials`. | preservation packet, sipi metadata |
+| **Pixel checksum** | A checksum (e.g. SHA-256) over the *uncompressed* pixel values, stored in the Essentials packet to verify that a format conversion did not alter image content. | data checksum, content hash |
+
+## Endpoints and documents
+
+| Term | Definition | Aliases to avoid |
+| --- | --- | --- |
+| **Image Information document** | The IIIF-spec JSON returned at `{prefix}/{identifier}/info.json` for an Image. Advertises supported region/size/rotation/quality/format forms via `extraFeatures` and `extraFormats`. | info.json (the file name), info doc |
+| **Bitstream Information document** | The SIPI-specific JSON returned at `{prefix}/{identifier}/info.json` for a Bitstream: `@context`, `id`, `internalMimeType`, `fileSize`. Same URL shape as the Image Information document, distinct schema (`http://sipi.io/api/file/3/context.json`). | file info, bitstream info |
+| **`/file` endpoint** | The URL form `{prefix}/{identifier}/file` that streams the underlying Bitstream as-is, bypassing IIIF processing. | file pass-through, raw endpoint |
+
+## Lua extensibility
+
+| Term | Definition | Aliases to avoid |
+| --- | --- | --- |
+| **Init script** | A Lua script (`sipi.init.lua`) executed once at server startup. Sets up global state shared across requests. | startup script, bootstrap |
+| **Preflight script** | A Lua script invoked per request before serving. Returns a Permission and resolves the on-disk path of the resource. Implemented by the Lua function `pre_flight` (Image / IIIF) or `file_pre_flight` (Bitstream). | pre-flight script, authorization hook |
+| **Route handler** | A Lua script bound to a URL pattern, used to implement custom RESTful endpoints (e.g. upload, admin) on top of the embedded webserver. | route, custom endpoint |
+| **Permission** | The verdict and shaping output returned by a preflight script. Carries a *permission type* and optional sub-fields: `infile` (resolved on-disk path), `watermark` (overlay PNG path), and access-restricting size caps. | access policy, ACL result |
+
+### Permission types
+
+The seven valid permission-type strings a preflight script may return:
+
+| Type | Meaning |
+| --- | --- |
+| **allow** | Full access. Serve the requested representation. |
+| **login** | Require user authentication, then serve. |
+| **clickthrough** | Require an explicit user gesture (e.g. terms acceptance), then serve. |
+| **kiosk** | Unauthenticated public-terminal mode. |
+| **external** | Defer authorization to an external service. |
+| **restrict** | Serve a degraded representation (size cap and/or watermark) instead of the requested one. |
+| **deny** | Refuse the request (HTTP 401/403). |
+
+## Operational concerns
+
+| Term | Definition | Aliases to avoid |
+| --- | --- | --- |
+| **Backpressure** | Umbrella term for SIPI's admission-control mechanisms that protect the server under load. Comprises the *decode memory budget* and the *rate limiter*. | flow control, throttling |
+| **Decode memory budget** | A process-wide, lock-free accounting of memory currently committed to in-flight image decodes, with an RAII guard. Rejects requests that would push concurrent decode memory over a configured ceiling. | memory budget, decode budget |
+| **Rate limiter** | The per-client request-rate ceiling enforced before decode admission. | throttle |
+| **Cache** | A file-based LRU of generated representations, keyed by *cache key*, with dual-limit eviction (total size **and** file count) and crash recovery. | response cache, output cache |
+
+## Platform context
+
+| Term | Definition | Aliases to avoid |
+| --- | --- | --- |
+| **IIIF** | International Image Interoperability Framework. SIPI implements IIIF Image API 3.0 at conformance Level 2. | (none) |
+| **DaSCH** | The Swiss National Data and Service Center for the Humanities. The organisation that develops and maintains SIPI. | DASCH |
+| **DSP** | DaSCH Service Platform. The broader platform SIPI is a component of. | DaSCH platform |
+
+## Deprecated / legacy
+
+These terms still appear in shipping surface but are not intended for new use.
+
+| Term | Status | Note |
+| --- | --- | --- |
+| **Knora** | Deprecated | Legacy name for the data layer. Replaced by DSP. Do not coin new uses. |
+| **knora.json document** | Deprecated | Legacy DSP-specific information document at `{prefix}/{identifier}/knora.json`. New consumers should use the Image Information document. |
+| **`--knorapath` / `--knoraport`** | Deprecated | CLI flags / config keys (`knora_path`, `knora_port`) retained for compatibility. |
+
+## Relationships
+
+- An **Image** is served through the IIIF pipeline; a **Bitstream** is served via the `/file` endpoint.
+- An **Identifier** plus a **Prefix** locates exactly one Image *or* Bitstream under the **Image root**.
+- A request resolves to a **Permission** via the **Preflight script** before any decode happens.
+- A **Format handler** uses exactly one **Codec** to read or write its format.
+- **Preservation metadata** = **Embedded metadata** ∪ **Essentials packet**; both travel with an Image across format conversions.
+- The **Cache key** extends the **Canonical URL** with a watermark bit; the **Cache** is keyed by it.
+- **Backpressure** = **Decode memory budget** + **Rate limiter**; both gate admission to decode.
+
+## Example dialogue
+
+> **Dev:** A request comes in for `/iiif/abc123/full/!500,500/0/default.jpg` — what's the first thing that runs?
+
+> **Maintainer:** The **preflight script**. It receives the **prefix** (`iiif`), the **identifier** (`abc123`), and the request headers, and returns a **permission**. If the type is `restrict`, the permission carries a size cap and possibly a **watermark** path, both of which shape what we eventually serve.
+
+> **Dev:** And the resolved on-disk file?
+
+> **Maintainer:** Same permission — the `infile` field. The preflight script may rewrite it; we then validate the resolved path stays inside the **image root** before any I/O.
+
+> **Dev:** What about `/iiif/abc123/file`?
+
+> **Maintainer:** That's the **bitstream** surface. We treat `abc123` as a **bitstream**, not an **image**: no IIIF pipeline, no **decode level**, no cache. The `file_pre_flight` script runs instead of `pre_flight`, and `info.json` for that resource returns a **bitstream information document**, not an **image information document**.
+
+> **Dev:** When does the **decode memory budget** come in?
+
+> **Maintainer:** Just before we instantiate the **format handler** to decode. If admitting the decode would push us over the budget, we reject with backpressure — the request never touches the **codec**.
+
+> **Dev:** And the **essentials packet** — that's only on write?
+
+> **Maintainer:** Mostly, yes. We embed it when SIPI produces a converted file, so the **pixel checksum** and original filename travel with the new artefact. On read, we extract any existing essentials packet — that's how we recover an ICC profile when a JPEG2000 source couldn't natively embed one.
+
+## Flagged ambiguities
+
+- **"canonical URL"** was used in code for two different things: the IIIF-spec form and the SIPI cache-keying string with a watermark suffix. Resolved: **Canonical URL** = IIIF spec form only; **Cache key** = the SIPI extension. Code variables like `cannonical_watermark` (sic) are implementation; not part of the language.
+- **"info.json"** is a single URL shape with two distinct response schemas depending on whether the resource is an Image or a Bitstream. Resolved by introducing two domain terms: **Image Information document** vs **Bitstream Information document**. Refer to them by their domain term, not the file name.
+- **"preservation metadata"** was sometimes used narrowly (the Essentials packet) and sometimes broadly (everything embedded). Resolved: **Preservation metadata** is the umbrella; **Essentials packet** is the SIPI-specific subset; **Embedded metadata** is the third-party-standards subset.
+- **"file"** is overloaded between the URL endpoint (`/file`), the on-disk artefact (`infile`, `imgroot`), and the served byte stream. Resolved: as a domain noun, **Bitstream** names the served byte stream; *file* survives only in URL paths and filesystem-level discussion.
+- **"reduce"** appears as both a JPEG2000 codestream parameter and a TIFF resolution-level concept. Resolved: **Decode level** is the canonical domain term; *reduce* survives only as a codec-API parameter name.
+- **Knora** terms still ship in CLI flags, config, and the `knora.json` endpoint. Resolved: kept under the *Deprecated / legacy* section. Do not coin new uses.

--- a/docs/adr/0001-shttps-as-strangler-fig-target.md
+++ b/docs/adr/0001-shttps-as-strangler-fig-target.md
@@ -1,0 +1,7 @@
+# shttps is a separate context, slated for strangler-fig replacement by Rust
+
+`shttps/` is treated as its own bounded context with its own namespace, library, language, and test surface — not an internal subdirectory of SIPI. The dependency direction is strictly SIPI → shttps; SIPI must never be named or included from shttps.
+
+We accept this stricter boundary because the medium-term plan is to replace the C++ HTTP layer with a Rust implementation using the strangler-fig pattern. Every leak across the boundary today (e.g. `shttps/Server.cpp` calling `SipiMetrics::instance()`) becomes a migration cost tomorrow, so leaks are tracked as bugs rather than tolerated.
+
+The alternative — treating `shttps/` as a courtesy namespace inside one big SIPI codebase — was rejected because it would erase the seam the migration depends on.

--- a/shttps/CONTEXT.md
+++ b/shttps/CONTEXT.md
@@ -1,0 +1,95 @@
+# shttps embedded HTTP framework
+
+A small, multithreaded HTTP/HTTPS server with route registration and embedded Lua scripting. Generic — knows nothing about IIIF, images, or SIPI-specific concepts. Lives in namespace `shttps::`. SIPI is a consumer; the dependency is one-way.
+
+## Language
+
+**Server**:
+The HTTP/HTTPS lifecycle owner. Owns the listening socket, thread pool, route table, SSL context, and global Lua functions. Subclassed by consumers (e.g. `Sipi::SipiHttpServer`) to add domain configuration.
+_Avoid_: app, listener (too vague), HTTP server (use the canonical type name).
+
+**Connection**:
+The I/O surface for one HTTP request/response. Carries request headers, query, body, route parameters, and the response stream. Every request handler receives one. Single-use per request.
+_Avoid_: request, response, context, ctx (Connection is request *and* response, not either).
+
+**RequestHandler**:
+The function-pointer shape `void (Connection &, LuaServer &, void *user_data, void *handler_data)` registered against a `(method, path)` pair via `Server::add_route`. The unit of dispatch.
+_Avoid_: handler (overloaded — see *Lua route handler* in the SIPI context), callback, endpoint.
+
+**LuaServer**:
+A per-request Lua interpreter. Wraps a `lua_State`, exposes the current `Connection` to Lua, and executes either inline Lua code or a `.lua` file. Despite the name it is *not* a server; it is created and torn down per request.
+_Avoid_: Lua VM (correct conceptually but the type is `LuaServer`), Lua context.
+
+**Route**:
+A `(HTTP method, path)` pair bound to either a `RequestHandler` (C++ function pointer) or a `LuaRoute` (path → Lua script). Owned by the `Server`.
+_Avoid_: endpoint, mapping.
+
+**LuaRoute**:
+A route whose handler is a Lua script file rather than a C++ `RequestHandler`. Resolved through the per-request `LuaServer`.
+_Avoid_: script route, Lua endpoint.
+
+**`shttps::file_handler`**:
+A built-in `RequestHandler` shipped by shttps that serves files from the *document root* and renders Lua-in-HTML pages. Generic — knows nothing about IIIF or images. Consumers register it on a chosen URL prefix (e.g. `wwwroute` in SIPI's config).
+_Avoid_: confusing this with SIPI's IIIF `/file` endpoint (which serves a Bitstream by IIIF identifier, not a docroot path).
+
+**Document root**:
+The filesystem directory tree that `shttps::file_handler` resolves URL paths into. Owned by shttps, configured by the consumer via `Server::docroot(...)`.
+_Avoid_: web root.
+
+**Init script**:
+The Lua source file loaded once at server startup, registered via `Server::initscript(path)`. shttps owns the lifecycle (load-once-at-boot); the script's *content* is the consumer's responsibility.
+_Avoid_: bootstrap, startup script.
+
+**Connection-pool knobs**:
+The set of `Server` configuration points that shape admission and lifecycle of inbound HTTP connections: `keep_alive_timeout`, `queue_timeout`, `max_waiting_connections`, the worker-thread count. Owned by shttps.
+_Avoid_: tuning, throttling (those are SIPI-side **Backpressure** concerns, separate concept).
+
+## Route ownership
+
+shttps is **route-blind**. It ships handlers (`shttps::file_handler` and any other future built-ins) and the registration mechanism (`Server::add_route`), but never registers a route by itself. Consumers choose every path and method. This keeps domain policy out of the framework: paths like `/iiif`, `/health`, `/metrics`, `/favicon.ico`, and the configured `wwwroute` are SIPI policy decisions, not framework defaults.
+
+## Primary seam (load-bearing across the planned Rust rewrite)
+
+These four types are the *contract* SIPI consumes. The strangler-fig replacement must reproduce them semantically (not necessarily symbol-for-symbol):
+
+- **Server** — for lifecycle and route registration.
+- **Connection** — for request/response I/O.
+- **RequestHandler** — for the C++/native dispatch shape.
+- **LuaServer** — for embedded Lua scripting (preflight, init, route scripts).
+
+## Secondary surface (scheduled for re-homing into SIPI before the Rust migration)
+
+These currently live in shttps but are not seam types. They are utilities or domain-flavoured types that ended up in shttps for historical reasons. The migration plan re-homes them into SIPI so the Rust replacement does not need to reproduce them:
+
+- `Hash` / `HashType` — used by `SipiEssentials::pixel_checksum`. Belongs to SIPI's preservation domain, not the HTTP framework.
+- `Parsing` — URL decoding, mime-type magic, header parsing helpers. Generic utilities; can move to a SIPI-side `support/` module.
+- `Error` — base class of `SipiError`. Re-home as part of SIPI's error hierarchy.
+- `Global`, `makeunique` — pure utilities. Inline or move to SIPI-side support.
+
+## Relationships
+
+- A **Server** owns many **Routes**. Each **Route** binds a method+path to one **RequestHandler** *or* one **LuaRoute**.
+- A **Server** dispatches each accepted request on a worker thread, constructs a **Connection** for it, and (when the route is a Lua route) spins up a **LuaServer** scoped to that request.
+- A **RequestHandler** receives the **Connection** and a **LuaServer** by reference. Both die when the request completes.
+- A **LuaRoute** is resolved by loading and executing its script inside the request-scoped **LuaServer**.
+
+## Example dialogue
+
+> **Dev:** "I want to add a `/health` endpoint. What do I touch in shttps?"
+
+> **Maintainer:** "Nothing. Register a **Route** from the SIPI side: pass a **RequestHandler** to `add_route(GET, '/health', my_handler)`. Your handler reads from / writes to the **Connection** it gets. shttps shouldn't grow knowledge of `/health`."
+
+> **Dev:** "And if I want to expose request count to Prometheus?"
+
+> **Maintainer:** "Same answer at the boundary. shttps must not call `SipiMetrics`. The clean shape is: shttps exposes a metrics-callback hook on **Server**; SIPI installs a callback that drives `SipiMetrics`. Today shttps reaches into `SipiMetrics` directly — that is a tracked layering leak."
+
+> **Dev:** "Why is `LuaServer` called a server if it isn't one?"
+
+> **Maintainer:** "Historical. It is a per-request Lua interpreter — created when the route fires, torn down when the **Connection** closes. The name predates the current architecture. Don't read 'server' into it."
+
+## Flagged ambiguities
+
+- **`LuaServer` is not a server.** It is a per-request Lua interpreter (a VM wrapper). The name predates the current model and cannot be renamed without breaking consumers; in conversation, prefer "Lua interpreter" or "Lua VM" and reserve "server" for `shttps::Server`.
+- **"Handler" is overloaded across the boundary.** In shttps, **RequestHandler** is a C++ function pointer. In SIPI's user-facing language ("Route handler" in `UBIQUITOUS_LANGUAGE.md`), it is a *Lua script* bound to a URL. They are distinct concepts: a SIPI Lua route handler is *invoked by* a shttps `RequestHandler` that loads and runs the script.
+- **"file_handler" is overloaded.** `shttps::file_handler` serves arbitrary files from the **document root** (generic static-file + Lua-in-HTML). SIPI's IIIF `/file` endpoint (`handlers::iiif_handler::FILE_DOWNLOAD`, sipi-side) serves a **Bitstream** keyed by an IIIF identifier under the **image root**. Same word, two unrelated handlers; never use "file_handler" without qualifying which side.
+- **`SipiMetrics` is referenced from `shttps/Server.cpp`.** This violates the one-way dependency direction and is a tracked layering leak, not a sanctioned pattern.


### PR DESCRIPTION
## Motivation

The repository had no written domain model. Conversation about the codebase reused overloaded terms ("canonical URL", "info.json", "preservation metadata", "file", "reduce") to mean different things in different contexts, and the boundary between the SIPI image server and the embedded `shttps` HTTP framework was implicit — even though a concrete migration plan (Rust replacement of `shttps`) makes that boundary load-bearing.

This PR captures the domain model on disk so future contributors and reviewers share a vocabulary and a layering rule.

## Summary

- Add a canonical SIPI glossary (`UBIQUITOUS_LANGUAGE.md`).
- Declare a two-context architecture (`CONTEXT-MAP.md`, two `CONTEXT.md` files, `docs/adr/0001-shttps-as-strangler-fig-target.md`) with strict one-way SIPI → shttps dependency direction.
- Document the existing `SipiMetrics` layering leak in `shttps/Server.cpp` as a tracked bug, not a pattern (companion plans in `dasch-specs` add a CI gate and a route-consolidation refactor).

## Key Changes

### Ubiquitous language

`UBIQUITOUS_LANGUAGE.md` (repo root) — opinionated glossary covering Image vs Bitstream, Identifier (with embedded Page) + Prefix, Image root vs Document root, the IIIF pipeline (Region / Size / Rotation / Quality / Format / Decode level / Canonical URL / Cache key), Format handler + Codec, Preservation metadata (umbrella over Embedded metadata + Essentials packet), Image / Bitstream Information document, the three Lua entry points (Init script / Preflight script / Route handler), the seven Permission types, and the Backpressure umbrella over decode-memory-budget + rate-limiter + cache. Includes a relationships graph, an example dialogue, and a `## Flagged ambiguities` section.

### Bounded contexts

- `CONTEXT-MAP.md` — names the two contexts and the long-term direction.
- `CONTEXT.md` (root, SIPI side) — points at `UBIQUITOUS_LANGUAGE.md`, names the four primary seam types, schedules the secondary surface for re-homing, and lists the cross-boundary naming gotchas.
- `shttps/CONTEXT.md` — captures shttps's own language (Server, Connection, RequestHandler, LuaServer, Route, LuaRoute, file_handler, document root, init script, connection-pool knobs), declares shttps **route-blind**, and flags four ambiguities (LuaServer naming trap, "handler" overload, "file_handler" overload, current `SipiMetrics` leak).
- `docs/adr/0001-shttps-as-strangler-fig-target.md` — records the decision and rationale.

## Challenges and Decisions

### "Canonical URL" was overloaded inside the codebase

**Problem:** `SipiHttpServer.cpp` uses "canonical URL" both for the IIIF-spec form *and* for the SIPI cache-keying string that extends it with a `/0` or `/1` watermark suffix (lines 776-781). Two different things, same name.

**Tried:** Considered keeping one term qualified by origin ("IIIF canonical URL" vs "SIPI canonical URL"), and considered hiding the cache extension as an internal detail.

**Solution:** Two distinct terms in the glossary. **Canonical URL** = the IIIF spec form only. **Cache key** = the SIPI cache-keying string that extends it. The `cannonical_watermark` (sic) variable in code is implementation noise, not part of the language.

### `info.json` returns two unrelated documents on the same URL shape

**Problem:** `{prefix}/{identifier}/info.json` returns the IIIF Image Information document for an Image resource and a SIPI-specific schema (`http://sipi.io/api/file/3/context.json`) for a Bitstream. Same URL, different schemas.

**Tried:** Considered one umbrella "info document" term with two variants, and considered demoting the Bitstream variant to a SIPI extension documented elsewhere.

**Solution:** Two first-class domain terms — **Image Information document** and **Bitstream Information document** — referenced by domain term, never by file name.

### "Preservation metadata" was used at two different scopes

**Problem:** Some uses meant just the SIPI Essentials packet (origname, mimetype, pixel checksum). Other uses meant everything embedded in image headers (EXIF / IPTC / XMP / ICC + Essentials).

**Tried:** Considered making Essentials a sub-kind of "embedded metadata"; considered narrowing "preservation metadata" to mean only the SIPI subset.

**Solution:** **Preservation metadata** is the umbrella. **Embedded metadata** (EXIF/IPTC/XMP/ICC) is the third-party-standards subset. **Essentials packet** is the SIPI-specific subset. **Pixel checksum** is the canonical name for the hash field — it covers uncompressed pixel values, not file bytes, so "data checksum" was misleading.

### "File" was overloaded as URL endpoint, on-disk artefact, and served byte stream

**Problem:** `/file` is a URL endpoint, `infile` is an on-disk path, "the file" sometimes meant the served byte stream. Same word at three layers.

**Tried:** Considered keeping "file" as a single term and disambiguating by qualifier each time.

**Solution:** **Bitstream** is the canonical noun for the served byte stream that goes through `/file`. *file* survives only in URL paths and filesystem-level discussion, never as a domain noun.

### "Reduce" was a JPEG2000 codec parameter that leaked into domain reasoning

**Problem:** `reduce` is a Kakadu codestream parameter for log2 downsampling at decode time; it also appears in pyramid-TIFF resolution levels. Code talked about "reducing" the image at the IIIF size-parser layer, mixing codec mechanics with domain reasoning.

**Tried:** Considered treating `reduce` as a standard domain term given how often it appears.

**Solution:** **Decode level** is the canonical domain term across formats. *reduce* survives only as a codec-API parameter name.

### shttps's relationship to SIPI was unwritten

**Problem:** shttps lives in its own namespace, has its own library, build target, test executable, and config template — but a `SipiMetrics` reference in `shttps/Server.cpp` shows the boundary had been silently crossed without a recorded decision either way.

**Tried:** Considered (a) shttps as a separate bounded context with strict one-way dependency, (b) shttps as an internal subsystem with a courtesy namespace, (c) accepting current coupling and freezing shttps for deletion.

**Solution:** (a) with (c) as long-term direction — shttps is a separate context **and** is the strangler-fig target for a Rust replacement. ADR-0001 records this. The boundary is sharper now precisely *because* of the planned migration: every leak is a future migration cost. The four primary seam types (`Server`, `Connection`, `RequestHandler`, `LuaServer`) are named load-bearing; the secondary surface (`Hash`, `Parsing`, `Error`, `Global`, `makeunique`) is scheduled for re-homing into SIPI before the migration.

## Gotchas

- **`shttps::LuaServer` is not a server.** It is a per-request Lua interpreter (a VM wrapper) created and torn down per request. Reserve "server" for `shttps::Server`. Prefer "Lua interpreter" or "Lua VM" in conversation.
- **"Handler" means two different things across the boundary.** `shttps::RequestHandler` is a C++ function pointer registered against a `(method, path)` route. SIPI's "Route handler" (in the glossary) is a *Lua script* bound to a URL pattern. They are distinct: a Route handler is *invoked by* a `RequestHandler` that loads and runs the script. Never use "handler" without saying which side.
- **"file_handler" means two different things across the boundary.** `shttps::file_handler` serves arbitrary files from the **document root** (generic static-file + Lua-in-HTML). SIPI's IIIF `/file` endpoint serves a **Bitstream** keyed by an IIIF identifier under the **image root**. Same word, two unrelated handlers; never reference "file_handler" without qualifying which side.
- **Do not add SIPI symbols inside `shttps/`.** The dependency is one-way. The current `SipiMetrics` reference in `shttps/Server.cpp` is a tracked layering leak, not a pattern to extend; a companion plan adds a CI gate that prevents new leaks.
- **shttps is route-blind.** Built-in handlers (`shttps::file_handler`) are shipped, but no built-in *routes*. The consumer always chooses paths — do not add path strings to shttps.

## Test Plan

- [ ] Skim `UBIQUITOUS_LANGUAGE.md` against your mental model — flag any term whose definition or "aliases to avoid" reads wrong.
- [ ] Confirm the five resolutions in `## Flagged ambiguities` (canonical URL / info.json / preservation metadata / file / reduce) match intent.
- [ ] Skim `CONTEXT-MAP.md` and `docs/adr/0001-shttps-as-strangler-fig-target.md` — confirm the two-context framing and the strangler-fig direction match intent.
- [ ] Skim `shttps/CONTEXT.md` — confirm the four primary seam types, the secondary-surface re-homing list, and the route-blind rule match intent.
- [ ] Confirm file locations (repo root for SIPI-side files, `shttps/CONTEXT.md` for the framework, `docs/adr/` for the ADR).