### PR TITLE
refactor: consolidate route registration in SipiHttpServer

### DIFF
--- a/shttps/CONTEXT.md
+++ b/shttps/CONTEXT.md
@@ -33,7 +33,7 @@ A built-in `RequestHandler` shipped by shttps that serves files from the *docume
 _Avoid_: confusing this with SIPI's IIIF `/file` endpoint (which serves a Bitstream by IIIF identifier, not a docroot path).
 
 **Document root**:
-The filesystem directory tree that `shttps::file_handler` resolves URL paths into. Owned by shttps, configured by the consumer via `Server::docroot(...)`.
+The filesystem directory tree that `shttps::file_handler` resolves URL paths into. Owned by the consumer; supplied as the second element of the `(wwwroute, docroot)` pair passed via the `handler_data` argument of `Server::add_route(...)`.
 _Avoid_: web root.
 
 **Init script**:

--- a/src/SipiHttpServer.cpp
+++ b/src/SipiHttpServer.cpp
@@ -2261,6 +2261,12 @@ void SipiHttpServer::run()
   add_route(Connection::GET, "/", iiif_handler);
   add_route(Connection::HEAD, "/", iiif_handler);
 
+  if (!_wwwroute.empty() && !_docroot.empty()) {
+    _filehandler_info = { _wwwroute, _docroot };
+    add_route(Connection::GET, _wwwroute, shttps::file_handler, &_filehandler_info);
+    add_route(Connection::POST, _wwwroute, shttps::file_handler, &_filehandler_info);
+  }
+
   user_data(this);
 
   // in shttps::Server::run(), add additional routes are added, namely the ones for the LUA scripts

--- a/src/SipiHttpServer.hpp
+++ b/src/SipiHttpServer.hpp
@@ -41,8 +41,14 @@ class SipiHttpServer : public shttps::Server
 private:
 protected:
   pid_t _pid{};
+  // Document root + URL prefix for shttps::file_handler. Empty = route disabled.
+  std::string _docroot;
   std::string _imgroot;
   std::string _salsah_prefix;
+  std::string _wwwroute;
+  // Stable storage for the (wwwroute, docroot) pair passed to shttps::file_handler
+  // as its handler_data argument (4th arg of add_route). Must outlive the run loop.
+  std::pair<std::string, std::string> _filehandler_info;
   bool _prefix_as_path{};
   std::vector<std::string> _dirs_to_exclude;
   //!< Directories which should have no subdirs even if subdirs are enabled
@@ -90,6 +96,10 @@ public:
 
   pid_t pid() const { return _pid; }
 
+  void docroot(const std::string &docroot_p) { _docroot = docroot_p; }
+
+  std::string docroot() { return _docroot; }
+
   void imgroot(const std::string &imgroot_p) { _imgroot = imgroot_p; }
 
   std::string imgroot() { return _imgroot; }
@@ -97,6 +107,10 @@ public:
   std::string salsah_prefix() { return _salsah_prefix; }
 
   void salsah_prefix(const std::string &salsah_prefix) { _salsah_prefix = salsah_prefix; }
+
+  void wwwroute(const std::string &wwwroute_p) { _wwwroute = wwwroute_p; }
+
+  std::string wwwroute() { return _wwwroute; }
 
   bool prefix_as_path() const { return _prefix_as_path; }
 

--- a/src/SipiHttpServer.hpp
+++ b/src/SipiHttpServer.hpp
@@ -98,19 +98,19 @@ public:
 
   void docroot(const std::string &docroot_p) { _docroot = docroot_p; }
 
-  std::string docroot() { return _docroot; }
+  std::string docroot() const { return _docroot; }
 
   void imgroot(const std::string &imgroot_p) { _imgroot = imgroot_p; }
 
-  std::string imgroot() { return _imgroot; }
+  std::string imgroot() const { return _imgroot; }
 
-  std::string salsah_prefix() { return _salsah_prefix; }
+  std::string salsah_prefix() const { return _salsah_prefix; }
 
   void salsah_prefix(const std::string &salsah_prefix) { _salsah_prefix = salsah_prefix; }
 
   void wwwroute(const std::string &wwwroute_p) { _wwwroute = wwwroute_p; }
 
-  std::string wwwroute() { return _wwwroute; }
+  std::string wwwroute() const { return _wwwroute; }
 
   bool prefix_as_path() const { return _prefix_as_path; }
 

--- a/src/sipi.cpp
+++ b/src/sipi.cpp
@@ -1675,22 +1675,8 @@ int main(int argc, char *argv[])
       server.keep_alive_timeout(sipiConf.getKeepAlive());
       server.max_waiting_connections(sipiConf.getMaxWaitingConnections());
       server.queue_timeout(sipiConf.getQueueTimeout());
-
-      //
-      // now we set the routes for the normal HTTP server file handling
-      //
-      std::string docroot = sipiConf.getDocRoot();
-      std::string wwwroute = sipiConf.getWWWRoute();
-      std::pair<std::string, std::string> filehandler_info;
-
-      // here we add two additional routes for handling files.
-      // (tip: click into add_route to see all the places where routes are added. there are a few places.)
-      if (!(wwwroute.empty() || docroot.empty())) {
-        filehandler_info.first = wwwroute;
-        filehandler_info.second = docroot;
-        server.add_route(shttps::Connection::GET, wwwroute, shttps::file_handler, &filehandler_info);
-        server.add_route(shttps::Connection::POST, wwwroute, shttps::file_handler, &filehandler_info);
-      }
+      server.docroot(sipiConf.getDocRoot());
+      server.wwwroute(sipiConf.getWWWRoute());
 
       // start the server
       log_info("SIPI server starting on port %d...", sipiConf.getPort());


### PR DESCRIPTION
## Motivation
`shttps/CONTEXT.md` declares shttps route-blind: SIPI chooses every URL path; the framework only ships handlers and the `add_route` mechanism. Today SIPI's route registration was split across two files for no domain reason — `SipiHttpServer.cpp` registered the IIIF/health/metrics/favicon routes, and `sipi.cpp` reached into `add_route` for the static-file route. The split made "what routes does SIPI expose?" a multi-grep question and let unrelated code in `main()` hold the lifetime of `add_route`'s `handler_data` argument.

## Summary
- All seven `add_route(...)` calls in SIPI now live in `SipiHttpServer::run()`. `sipi.cpp` has zero.
- The `(wwwroute, docroot)` pair previously held in a `main()`-frame local is now a `SipiHttpServer` member, so its lifetime is tied to the server object that owns the run loop reading it.
- No behaviour change: when `wwwroute` and `docroot` are both non-empty, all seven routes are registered; otherwise only the five fixed routes.

## Key Changes

### Route consolidation
- `src/SipiHttpServer.hpp` — three protected members (`_docroot`, `_wwwroute`, `_filehandler_info`) + setter/getter pairs.
- `src/SipiHttpServer.cpp` — consolidated `add_route` block in `run()`; conditional `GET|POST {wwwroute}` registration only when both `wwwroute` and `docroot` are non-empty (De Morgan equivalent of the previous gate).
- `src/sipi.cpp` — replaced the 14-line route-registration block with two setter calls.

### Convention follow-up (from review)
- `src/SipiHttpServer.hpp` — added `const` to `imgroot()`, `salsah_prefix()`, `docroot()`, `wwwroute()` getters per REVIEW.md "apply `const` everywhere it is valid". The plan asked for parity with the existing non-const `imgroot()` pattern; review pointed out the broader class convention is `const` accessors, so the cluster was modernized in one pass.
- `shttps/CONTEXT.md` — corrected the Document-root description: shttps does not own the docroot string and exposes no `Server::docroot(...)` setter; the consumer owns it and supplies it as the second element of the `(wwwroute, docroot)` pair passed via `handler_data` to `Server::add_route(...)`.

## Challenges and Decisions

### Where to store `(wwwroute, docroot)` for handler_data lifetime
**Problem:** `shttps::file_handler` reads its `(route, docroot)` from the per-route `handler_data` pointer (4th arg of `add_route`). The previous code passed `&filehandler_info`, where `filehandler_info` was a `std::pair<std::string, std::string>` local in `main()`. The lifetime was correct only because the `main()` frame outlived `server.run()`, but the dependency was implicit.
**Tried:** Storing the pair in `shttps::Server` itself was rejected — that would push consumer-domain state (a docroot path SIPI cares about, that shttps is otherwise route-blind to) into the framework, violating the strangler-fig boundary that plan 01 just enforced.
**Solution:** Make the pair a `SipiHttpServer` protected member (`_filehandler_info`). The pointer handed to `add_route` now lives as long as the server object that owns the run loop. The dependency is structural, not implicit.

### Mirror `imgroot()` vs apply REVIEW.md `const` rule
**Problem:** The plan asked the new `docroot()` / `wwwroute()` getters to mirror the existing `imgroot()` pattern (non-const). REVIEW.md says "apply `const` everywhere it is valid". The class is mostly const-accessor (`pid()`, `prefix_as_path()`, `jpeg_quality()`, …); only `imgroot()` and `salsah_prefix()` were non-const.
**Solution:** Make all four getters `const` in one pass — the new pair plus the two existing siblings. Following the dominant class convention beats propagating a two-member exception.

## Gotchas
- `_filehandler_info` must outlive the run loop. It is intentionally a member of `SipiHttpServer`, not a local in `run()` — the pointer handed to `add_route` is read on every request that hits `wwwroute`. Keep it a member if any future refactor moves the registration block.
- The `(wwwroute, docroot)` pair has `wwwroute` first, `docroot` second. `shttps::file_handler` (`shttps/Server.cpp:248-268`) unpacks `pair.first` as the URL prefix and `pair.second` as the filesystem root; do not reverse them.
- `shttps::Server` does not expose a `docroot(...)` setter. The consumer (here, `SipiHttpServer`) stores the value and passes it as `handler_data`. `shttps/CONTEXT.md` was updated in this PR to describe this accurately.

## Test Plan
- [x] `just shttps-context-check` — plan 01 boundary still green
- [x] `just nix-build` — unit tests pass in the Nix sandbox (rerun after follow-up commit)
- [x] `just hurl-test` — 5 files / 9 requests, 100% pass
- [x] `just rust-test-e2e` — 238 tests pass, 0 failed
- [x] `grep -cE '\badd_route\(' src/sipi.cpp` returns `0`
- [x] `grep -cE '\badd_route\(' src/SipiHttpServer.cpp` returns `7`, all inside `SipiHttpServer::run()`