### PR TITLE
build(nix): drop unused apacheHttpd from dev shells

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -421,7 +421,6 @@
               # Additional test dependencies
               nginx
               graphicsmagick
-              apacheHttpd
               imagemagick
               libxml2
               libxslt
@@ -451,7 +450,6 @@
               hurl
               nginx
               graphicsmagick
-              apacheHttpd
               imagemagick
               libxml2
               libxslt
@@ -481,7 +479,6 @@
               hurl
               nginx
               graphicsmagick
-              apacheHttpd
               imagemagick
               libxml2
               libxslt


### PR DESCRIPTION
## Motivation

`direnv reload` / `nix develop` started failing on macOS (aarch64-darwin) with a hard build error in `apr-util-1.6.3` — its K&R-style `dbm/sdbm/sdbm_pair.c` no longer compiles under nixpkgs-unstable's current Clang (implicit-int and K&R declarations are now errors by default). This blocks every local dev shell entry on macOS until the dep is removed or worked around. CI runs Linux only, so the breakage doesn't show up there but is still real.

## Summary

- Drop `apacheHttpd` from the `default`, `fuzz`, and `gcc` dev shells in `flake.nix`.

## Key Changes

### flake.nix

- Removed `apacheHttpd` from the `packages` list of all three dev shells (3 line deletions). No other change.

## Challenges and Decisions

### Why removal rather than override or pin

**Problem:** nixpkgs-unstable's Clang rejects `apr-util-1.6.3`'s sdbm K&R code; this transitively breaks `apacheHttpd` and therefore the dev shell that depends on it.

**Tried/considered:**
- *Pin nixpkgs back* to a pre-Clang-bump revision — regresses every other dep we get from nixpkgs and contradicts our `nixos-unstable` channel choice.
- *Override apr-util* with `NIX_CFLAGS_COMPILE = "-Wno-implicit-int -Wno-implicit-function-declaration"` via the overlay — works but adds a maintenance tail (we'd own a workaround for code we don't use).

**Solution:** Delete the dependency. A repo-wide search (`grep -rn 'apache\|httpd\|ApacheBench\|\bab\b'`) confirmed nothing actually invokes `httpd` or `ab`:
- The only `ab` hits in the tree are German prose (`ab 2020`) in `test/_test_data/images/unit/test.csv`.
- One unrelated comment in `shttps/Connection.cpp:337` mentions ApacheBench historically but no test depends on it.

Removing the dep is the smallest change with no functional loss — aligns with the KISS guidance in `CLAUDE.md` (don't carry build inputs we don't use).

## Gotchas

- If anyone later wants `ab` for ad-hoc benchmarking, **add a more targeted package** (e.g. `pkgs.apacheHttpd` reintroduced, or a smaller `ab`-only alternative) rather than assuming it's still there. Don't reflexively put `apacheHttpd` back without checking that the underlying nixpkgs/Clang issue has been fixed upstream — otherwise you'll re-break the macOS dev shell.
- The change only touches dev shells, not any `nix build .#<variant>` derivation, so it falls outside the build-completeness invariant in `CLAUDE.md` ("every build target must succeed on every supported platform"). If a future change moves `apacheHttpd` into a build derivation, that invariant kicks in and macOS must be re-verified.

## Test Plan

- [x] `nix eval .#devShells.aarch64-darwin.default.name` succeeds locally
- [x] `direnv reload` in the sipi worktree on macOS (aarch64-darwin) succeeds — confirmed by reporter
- [ ] CI green (Linux dev shell + builds unaffected)