### PR TITLE
ci: install just via Nix and drop extractions/setup-just

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -41,7 +41,12 @@ jobs:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env['ACTIONS_CACHE_URL'] || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN'] || '');
-      - uses: extractions/setup-just@v4
+      - uses: DeterminateSystems/determinate-nix-action@v3
+      - uses: cachix/cachix-action@v17
+        with:
+          name: dasch-swiss
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix profile install nixpkgs#just
       - run: just docker-test-build-amd64 # two stage build, where test is run in the first stage
       - uses: dasch-swiss/sipi/.github/actions/setup-python@main
       - run: pip3 install pytest requests testcontainers
@@ -101,7 +106,12 @@ jobs:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env['ACTIONS_CACHE_URL'] || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN'] || '');
-      - uses: extractions/setup-just@v4
+      - uses: DeterminateSystems/determinate-nix-action@v3
+      - uses: cachix/cachix-action@v17
+        with:
+          name: dasch-swiss
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix profile install nixpkgs#just
       - run: just docker-test-build-arm64 # two stage build, where test is run in the first stage
       - uses: dasch-swiss/sipi/.github/actions/setup-python@main
       - run: pip3 install pytest requests testcontainers
@@ -133,6 +143,11 @@ jobs:
           git lfs fetch --all
           git lfs checkout
       - uses: dasch-swiss/sipi/.github/actions/setup-python@main
-      - uses: extractions/setup-just@v4
+      - uses: DeterminateSystems/determinate-nix-action@v3
+      - uses: cachix/cachix-action@v17
+        with:
+          name: dasch-swiss
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix profile install nixpkgs#just
       - run: just docs-install-requirements
       - run: just docs-build

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           name: dasch-swiss
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - uses: extractions/setup-just@v4
+      - run: nix profile install nixpkgs#just
 
       - name: Find last successful fuzz run
         id: last-run

--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           name: dasch-swiss
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - uses: extractions/setup-just@v4
+      - run: nix profile install nixpkgs#just
 
       - name: Install wrk
         run: sudo apt-get update && sudo apt-get install -y wrk

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,12 @@ jobs:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env['ACTIONS_CACHE_URL'] || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN'] || '');
-      - uses: extractions/setup-just@v4
+      - uses: DeterminateSystems/determinate-nix-action@v3
+      - uses: cachix/cachix-action@v17
+        with:
+          name: dasch-swiss
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix profile install nixpkgs#just
       - run: just ${{ matrix.build_target }}
       - run: just test-smoke-ci
 
@@ -97,7 +102,12 @@ jobs:
             core.exportVariable('ACTIONS_CACHE_URL', process.env['ACTIONS_CACHE_URL'] || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN'] || '');
 
-      - uses: extractions/setup-just@v4
+      - uses: DeterminateSystems/determinate-nix-action@v3
+      - uses: cachix/cachix-action@v17
+        with:
+          name: dasch-swiss
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix profile install nixpkgs#just
       - run: just ${{ matrix.build_target }}
       - run: just test-smoke-ci
       - name: Push image to Docker Hub
@@ -155,7 +165,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-      - uses: extractions/setup-just@v4
+      - uses: DeterminateSystems/determinate-nix-action@v3
+      - uses: cachix/cachix-action@v17
+        with:
+          name: dasch-swiss
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix profile install nixpkgs#just
       - run: just docker-publish-manifest
 
   # Build the static release archive (sipi + config/scripts/server +
@@ -188,7 +203,7 @@ jobs:
           name: dasch-swiss
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
-      - uses: extractions/setup-just@v4
+      - run: nix profile install nixpkgs#just
       - name: Build release archive
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           name: dasch-swiss
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - uses: extractions/setup-just@v4
+      - run: nix profile install nixpkgs#just
 
       - name: Build with sanitizers (ASan + UBSan) — unit tests run in sandbox
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           name: dasch-swiss
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - uses: extractions/setup-just@v4
+      - run: nix profile install nixpkgs#just
       - name: Build and test (unit tests run in the Nix sandbox)
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
@@ -125,7 +125,7 @@ jobs:
         with:
           name: dasch-swiss
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - uses: extractions/setup-just@v4
+      - run: nix profile install nixpkgs#just
       - name: Build static binary
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
@@ -160,7 +160,7 @@ jobs:
         with:
           name: dasch-swiss
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - uses: extractions/setup-just@v4
+      - run: nix profile install nixpkgs#just
       - name: Build native Darwin binary
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}


### PR DESCRIPTION
Fixes DEV-6313

## Motivation

On 2026-04-27, GitHub's `GET /repos/casey/just/releases` API returned
empty arrays for several hours. `extractions/setup-just@v4` (Dependabot
bump #568, merged that morning) wraps `extractions/setup-crate`, which
queries that endpoint to resolve a version — every PR's CI broke until
the API recovered.

`just` is a one-liner from nixpkgs. Removing the third-party action
removes the upstream failure mode entirely.

## Summary

- 13 occurrences of `extractions/setup-just@v4` removed across 6
  workflow files.
- Replaced with `nix profile install nixpkgs#just`.
- Six jobs without prior Nix gain `DeterminateSystems` +
  `cachix-action` bootstrap, matching the canonical block in
  `test.yml`.

## Key Changes

### `test.yml`, `sanitizer.yml`, `fuzz.yml`, `loadtest.yml`

Single-line swap: `- uses: extractions/setup-just@v4` →
`- run: nix profile install nixpkgs#just`. Nix is already installed in
all 7 affected jobs.

### `docker-build.yml` and `publish.yml`

Six jobs (`build_amd64`, `build_arm64`, `build_docs`,
`validate-docker`, `publish-docker`, `manifest`) gain the
`DeterminateSystems/determinate-nix-action@v3` +
`cachix/cachix-action@v17` block before the `nix profile install`. The
`extra-conf: configurable-impure-env` setting is omitted — these jobs
do not run `nix-build` recipes that need GH_TOKEN passthrough.

`publish-static-release` already had Nix installed and gets the simple
swap (Pattern A).

## Challenges and Decisions

### Scope: full elimination vs leaving setup-just in non-Nix jobs

**Problem:** Six of the 13 invocations live in jobs that don't
otherwise install Nix (all of `docker-build.yml`, plus
`validate-docker` / `publish-docker` / `manifest` in `publish.yml`).
The original ticket flagged only the `docs` job as a possible
exception.

**Decision:** Add Nix to all six. Keeping `setup-just` in any job
leaves the failure mode in half the workflows, defeating the point of
the cleanup. The bootstrap adds ~30s per job on cold cache; Cachix
amortises this on warm cache.

### No composite action

The same three-line Nix + Cachix block now repeats in each Pattern B
job. A composite action would deduplicate this but adds indirection;
project convention prefers KISS / inline repetition over an
abstraction with one real caller.

## Gotchas

- `nixpkgs#just` resolves from the ambient flake registry baked into
  the Determinate installer image. This matches existing
  `nix develop` / `nix build` invocations elsewhere in the workflows.
- `dependabot.yml` does not need editing: there is no explicit
  `extractions/setup-just` entry; the blanket `github-actions`
  ecosystem rule auto-discovered it. Removing all references is
  sufficient.

## Test Plan

- [ ] PR CI green: `test`, `docker-build`, `sanitizer`, `fuzz`,
      `loadtest` all pass.
- [ ] Spot-check Pattern A logs: `nix profile install nixpkgs#just`
      succeeds and downstream `just <recipe>` finds the binary.
- [ ] Spot-check Pattern B logs (e.g. `docker / amd64`):
      `DeterminateSystems` + `cachix-action` + `nix profile install`
      all succeed before the first `just` invocation.
- [ ] `rg 'extractions/setup-just' .github/` returns no matches on
      the merged commit.