### PR TITLE
build(nix): build Rust e2e and Docker smoke test binaries via crane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-      - run: nix profile install nixpkgs#just
+      - run: nix profile install --inputs-from . nixpkgs#just
       - name: Build and test (unit tests run in the Nix sandbox)
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
@@ -94,8 +94,13 @@ jobs:
       - name: Rust e2e and Hurl tests
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
-        # cargo + hurl come from the dev shell — keep the wrap.
-        run: nix develop --command bash -c "just rust-test-e2e && just hurl-test"
+        # `nix-test-e2e` consumes the .#e2e-tests Nix derivation — no
+        # cargo on PATH needed. `hurl-test` still shells out to `hurl`,
+        # which we install onto PATH alongside `just`.
+        run: |
+          nix profile install --inputs-from . nixpkgs#hurl
+          just nix-test-e2e
+          just hurl-test
       - name: Gather code coverage
         if: ${{ matrix.arch == 'amd64' }}
         env:
@@ -112,7 +117,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
         run: just nix-docker-build-${{ matrix.arch }}
-      - run: just test-smoke-ci
+      - run: just nix-test-smoke
       - name: Docker Scout — compare to production
         if: github.event_name == 'pull_request'
         uses: docker/scout-action@v1
@@ -174,7 +179,7 @@ jobs:
         with:
           name: dasch-swiss
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - run: nix profile install nixpkgs#just
+      - run: nix profile install --inputs-from . nixpkgs#just
       - name: Build static binary
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
@@ -186,8 +191,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
           SIPI_BIN: ${{ github.workspace }}/result/bin/sipi
-        # cargo comes from the dev shell — keep the wrap.
-        run: nix develop --command bash -c "just rust-test-e2e"
+        # `nix-test-e2e` consumes the .#e2e-tests Nix derivation —
+        # no cargo on PATH needed.
+        run: just nix-test-e2e
 
   # Native Darwin build via Nix + clang/libc++, with a dylib-linkage audit.
   # Replaces the old zig-macos job; the invariant (no Homebrew / third-party
@@ -212,7 +218,7 @@ jobs:
         with:
           name: dasch-swiss
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - run: nix profile install nixpkgs#just
+      - run: nix profile install --inputs-from . nixpkgs#just
       - name: Build native Darwin binary
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
@@ -241,6 +247,6 @@ jobs:
           git lfs checkout
       - uses: dasch-swiss/sipi/.github/actions/setup-python@main
       - uses: DeterminateSystems/determinate-nix-action@v3
-      - run: nix profile install nixpkgs#just
+      - run: nix profile install --inputs-from . nixpkgs#just
       - run: just docs-install-requirements
       - run: just docs-build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,12 +42,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-      - run: nix profile install nixpkgs#just
+      - run: nix profile install --inputs-from . nixpkgs#just
       - name: Build Docker image (Nix dockerTools)
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
         run: just nix-docker-build-${{ matrix.arch }}
-      - run: just test-smoke-ci
+      - run: just nix-test-smoke
 
   release-gate:
     runs-on: ubuntu-latest
@@ -98,7 +98,7 @@ jobs:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-      - run: nix profile install nixpkgs#just
+      - run: nix profile install --inputs-from . nixpkgs#just
       - name: Build Docker image + sipi-debug (Nix dockerTools)
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
@@ -108,7 +108,7 @@ jobs:
         run: just nix-docker-build-${{ matrix.arch }}
       - name: Extract debug symbols for Sentry upload
         run: just nix-docker-extract-debug ${{ matrix.arch }}
-      - run: just test-smoke-ci
+      - run: just nix-test-smoke
       - name: Push image to Docker Hub
         run: just ${{ matrix.push_target }}
 
@@ -169,7 +169,7 @@ jobs:
         with:
           name: dasch-swiss
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - run: nix profile install nixpkgs#just
+      - run: nix profile install --inputs-from . nixpkgs#just
       - run: just docker-publish-manifest
 
   # Build the static release archive (sipi + config/scripts/server +
@@ -202,7 +202,7 @@ jobs:
           name: dasch-swiss
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
-      - run: nix profile install nixpkgs#just
+      - run: nix profile install --inputs-from . nixpkgs#just
       - name: Build release archive
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           name: dasch-swiss
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - run: nix profile install nixpkgs#just
+      - run: nix profile install --inputs-from . nixpkgs#just
 
       - name: Build with sanitizers (ASan + UBSan) — unit tests run in sandbox
         env:
@@ -69,11 +69,13 @@ jobs:
           SIPI_BIN: ${{ github.workspace }}/result/bin/sipi
           ASAN_OPTIONS: detect_leaks=1:halt_on_error=0:log_path=/tmp/asan-e2e
           LSAN_OPTIONS: suppressions=${{ github.workspace }}/.lsan_suppressions.txt
-        # cargo comes from the dev shell — keep the wrap.
-        run: |
-          nix \
-            --option filter-syscalls false \
-            develop --command bash -c "just rust-test-e2e"
+        # `nix-test-e2e` consumes the `.#e2e-tests` Nix derivation —
+        # no cargo on PATH needed, so the `nix develop` wrap is gone.
+        # ASan / LSan run in the sipi binary (already built sanitized
+        # by the previous step); the test client doesn't need to be
+        # sanitized, so building it via crane in a regular sandbox is
+        # fine (filter-syscalls only matters for the sanitizer build).
+        run: just nix-test-e2e
 
       - name: Check for sanitizer findings in e2e
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,9 @@ just nix-docker-build-arm64      # .#packages.aarch64-linux.docker-stream + sipi
 just nix-docker-extract-debug arch  # rename result-debug/.../*.debug → sipi-<arch>.debug
 
 # Tests (consume $SIPI_BIN, default ./result/bin/sipi)
-just rust-test-e2e               # Rust e2e tests (needs cargo — from dev shell)
+just nix-test-e2e                # Rust e2e tests via .#e2e-tests (CI canonical, no cargo)
+just nix-test-smoke              # Docker smoke test via .#smoke-test (CI canonical)
+just rust-test-e2e               # inner-loop Rust e2e via cargo (needs dev shell)
 just hurl-test                   # Hurl HTTP contract tests (needs hurl — from dev shell)
 just nix-run                     # run sipi with the dev config
 just nix-valgrind                # run sipi under Valgrind
@@ -59,7 +61,7 @@ just nix-valgrind                # run sipi under Valgrind
 # Dev-shell inner loop (non-recipe — see "Inner-loop development" below)
 
 # Docker push / manifest (build is via Nix — see nix-docker-build* above)
-just test-smoke                  # build image via Nix, then run smoke tests
+just test-smoke                  # build image via Nix, then run smoke tests (inner-loop)
 just docker-push-amd64           # push already-loaded amd64 image
 just docker-push-arm64           # push already-loaded arm64 image
 just docker-publish-manifest     # publish multi-arch manifest
@@ -143,6 +145,7 @@ Image formats (libtiff, libpng, libjpeg, libwebp), compression (zlib, bzip2, xz,
 - `version.txt` — version information
 - `flake.nix` — Nix build system (overlay, package variants, dev shells)
 - `package.nix` — Nix derivation for Sipi
+- `nix/` — Nix expressions imported by `flake.nix`. Each file is a function over `{ pkgs, … }` returning attribute set(s) that `flake.nix` merges into the right output. New derivations go here, not into `flake.nix` — keeping the flake an orchestrator is an explicit goal. Existing in-flake builders (Kakadu FOD, static builds, Docker image, dev shells) are slated for migration into `nix/<topic>.nix` files using this pattern.
 
 ## Testing
 
@@ -151,9 +154,9 @@ For the authoritative testing strategy (pyramid, layer definitions, decision tre
 For test framework details (how to run tests, directory layout, adding tests), see [`docs/src/development/developing.md`](docs/src/development/developing.md).
 
 - **Unit tests** (`test/unit/`): GoogleTest + ApprovalTests — run inside the `.#dev` / `.#default` derivation's `checkPhase` (`just nix-build` fails if any unit test fails)
-- **E2E tests** (`test/e2e-rust/`): Rust (reqwest + cargo test) — `just rust-test-e2e`
+- **E2E tests** (`test/e2e-rust/`): Rust (reqwest + cargo test). CI: `just nix-test-e2e` (binaries from `.#e2e-tests`). Inner-loop: `just rust-test-e2e` (cargo from dev shell).
 - **Hurl tests** (`test/hurl/`): HTTP contract tests — `just hurl-test`
-- **Smoke tests** (`test/smoke/`): against Docker image — `just test-smoke`
+- **Smoke tests** (`test/e2e-rust/tests/docker_smoke.rs`): against Docker image. CI: `just nix-test-smoke` (binary from `.#smoke-test`). Inner-loop: `just test-smoke`.
 - **Approval tests** (`test/approval/`): snapshot-based regression — included in unit tests
 
 Run a specific unit test binary in the dev-shell inner loop: `cd build && test/unit/<component>/<component>`

--- a/docs/src/development/building.md
+++ b/docs/src/development/building.md
@@ -141,11 +141,13 @@ Run `just` (no arguments) to see the full list. Key target groups:
 | `nix-docker-extract-debug arch` | Rename `result-debug/.../*.debug` to `sipi-<arch>.debug` for Sentry upload |
 | `docker-push-{amd64,arm64}` | Push the already-loaded per-arch image to Docker Hub |
 | `docker-publish-manifest` | Publish multi-arch manifest combining the two pushed images |
-| `test-smoke` | Build Docker image (via Nix) and run Rust testcontainer smoke tests against it |
-| `test-smoke-ci` | Run smoke tests against an already-loaded Docker image |
+| `test-smoke` | Inner-loop: build Docker image (via Nix), then `cargo test` the smoke suite |
+| `nix-test-smoke` | CI canonical: run pre-built `.#smoke-test` binary against an already-loaded image |
+| `test-smoke-ci` | Inner-loop: run cargo smoke tests against an already-loaded Docker image |
 | `nix-static-linkage-verify path` | Verify a Linux static binary has no NEEDED entries |
 | `nix-macos-dylib-audit path` | Audit macOS sipi runtime dylibs |
-| `rust-test-e2e` | Rust end-to-end tests (reads `$SIPI_BIN`) |
+| `rust-test-e2e` | Inner-loop: cargo-driven Rust end-to-end tests (reads `$SIPI_BIN`) |
+| `nix-test-e2e` | CI canonical: run pre-built `.#e2e-tests` binaries via `run-e2e.sh` |
 | `hurl-test` | Hurl HTTP contract tests (reads `$SIPI_BIN`) |
 | `nix-run` | Run sipi with the dev config |
 | `nix-valgrind` | Run sipi under Valgrind |

--- a/docs/src/development/ci.md
+++ b/docs/src/development/ci.md
@@ -74,14 +74,18 @@ The `test` job is matrixed on `ubuntu-24.04` (amd64) and `ubuntu-24.04-arm`
 
 1. `just nix-build` — Nix/Clang dev derivation; unit tests run in the Nix
    sandbox.
-2. `just rust-test-e2e` and `just hurl-test` — Rust e2e + Hurl HTTP contract
-   tests against the built binary.
+2. `just nix-test-e2e` and `just hurl-test` — Rust e2e + Hurl HTTP contract
+   tests against the built binary. `nix-test-e2e` consumes the Nix-built
+   `.#e2e-tests` derivation (test binaries vendored from `Cargo.lock` via
+   crane), so cargo is not on the runner's PATH. `hurl-test` is the
+   short-term holdout that still needs a tool on PATH (installed via
+   `nix profile install nixpkgs#hurl`).
 3. `just nix-coverage` and Codecov upload — amd64 only.
 4. `just nix-docker-build-${arch}` — produces the per-arch Docker image via
    `pkgs.dockerTools.streamLayeredImage` and loads it into the local Docker
    daemon.
-5. `just test-smoke-ci` — Rust testcontainers smoke tests against the loaded
-   image.
+5. `just nix-test-smoke` — Rust smoke test from `.#smoke-test` against the
+   loaded image.
 6. `Docker Scout — compare to production` — both arches, on PR events only.
 7. `Docker Scout — CVE report (SARIF)` and `Upload SARIF to GitHub Security`
    — amd64 only, on PR events only (CVE findings are arch-independent; one
@@ -105,8 +109,9 @@ stdenv for Darwin.
    `configurable-impure-env` enabled on the daemon).
 2. `just nix-static-linkage-verify result/bin/sipi` — static linkage
    assertion via `readelf -d`; must not report any `NEEDED` entries.
-3. `just rust-test-e2e` with `SIPI_BIN=$GITHUB_WORKSPACE/result/bin/sipi`
-   — proves the Nix-built static musl binary runs on a glibc host.
+3. `just nix-test-e2e` with `SIPI_BIN=$GITHUB_WORKSPACE/result/bin/sipi`
+   — proves the Nix-built static musl binary runs on a glibc host. Uses
+   the `.#e2e-tests` derivation, so cargo is not required on the runner.
 
 **`nix-macos / arm64 dylib-audit`** (`macos-14`):
 
@@ -189,18 +194,22 @@ Linux-target recipes (`nix-build-static-*`, `nix-build-sanitized`,
 a CI round-trip.
 
 `just nix-build*` recipes wrap `nix build`, so CI invokes them directly
-without a surrounding `nix develop`. Recipes that consume dev-shell
-tools — `rust-test-e2e` (needs `cargo`) and `hurl-test` (needs `hurl`) —
-are the exception and run inside `nix develop --command …`.
+without a surrounding `nix develop`. The Rust e2e and Docker smoke test
+binaries are also Nix-built (via `.#e2e-tests` and `.#smoke-test` —
+defined in `nix/rust-tests.nix`), so `just nix-test-e2e` and
+`just nix-test-smoke` need only `just` on PATH. The remaining holdout
+is `hurl-test`, which still shells out to `hurl` (installed at CI step
+time via `nix profile install nixpkgs#hurl`).
 
 ```bash
 # Native dev build + e2e + Hurl + coverage + Docker image + smoke
 # (the full `ci.yml test` job for one arch)
 just nix-build
-nix develop --command bash -c "just rust-test-e2e && just hurl-test"
+just nix-test-e2e                         # binaries from .#e2e-tests
+just hurl-test                            # still needs `hurl` on PATH
 just nix-coverage
 just nix-docker-build-amd64               # or -arm64 on aarch64 host
-just test-smoke-ci
+just nix-test-smoke                       # binary from .#smoke-test
 
 # Static musl binaries (what ci.yml nix-static runs)
 just nix-build-static-amd64
@@ -209,7 +218,7 @@ just nix-static-linkage-verify result/bin/sipi
 
 # Sanitizer build + tests (what sanitizer.yml runs)
 just nix-build-sanitized                  # tests run in sandbox
-SIPI_BIN=$PWD/result/bin/sipi nix --option filter-syscalls false develop --command bash -c "just rust-test-e2e"
+SIPI_BIN=$PWD/result/bin/sipi just nix-test-e2e
 
 # Fuzz build + run (what fuzz.yml runs)
 just nix-build-fuzz
@@ -220,7 +229,7 @@ just nix-run-fuzz fuzz-corpus-live 60 fuzz/handlers/corpus
 # runs). The PR-time `ci.yml test` job builds the same image inline; this
 # block only adds the Sentry-bound `nix-docker-extract-debug` step.
 just nix-docker-build-amd64               # arch-pinned image + sipi-debug
-just test-smoke-ci                        # Rust testcontainer smoke tests
+just nix-test-smoke                       # smoke test against loaded image
 just nix-docker-extract-debug amd64       # produces sipi-amd64.debug for Sentry
 
 # Release archive (what publish.yml publish-static-release runs)

--- a/docs/src/development/developing.md
+++ b/docs/src/development/developing.md
@@ -134,19 +134,28 @@ requests, `serde_json` for JSON validation, and `insta` for golden baseline
 snapshots. They cover IIIF compliance, server behaviour, and upload
 functionality.
 
-Run Rust e2e tests:
+Two recipes run the same test code via two different build paths:
 
 ```bash
+# CI-canonical path: consume pre-built test binaries from the
+# `.#e2e-tests` Nix derivation (Cachix-cacheable, no cargo on PATH
+# required). This is what every CI job runs.
+just nix-test-e2e
+
+# Inner-loop dev path: build and run via `cargo test` in the dev
+# shell. Faster for iterating on the test code itself; not used by CI.
 just rust-test-e2e
 ```
 
-The recipe resolves the sipi binary via `$SIPI_BIN` with a canonical default
-of `./result/bin/sipi` (the Nix artifact path). Override `SIPI_BIN` to point
-at a dev-shell-built binary if you are iterating on cmake locally.
+Both recipes resolve the sipi binary via `$SIPI_BIN` with a canonical
+default of `./result/bin/sipi` (the Nix artifact path). Override
+`SIPI_BIN` to point at a dev-shell-built binary if you are iterating on
+cmake locally.
 
 !!! note "Sequential execution required"
     Tests must run with `--test-threads=1` because each test starts its own
-    SIPI server instance on a unique port. The recipe handles this automatically.
+    SIPI server instance on a unique port. Both recipes handle this
+    automatically.
 
 ### Hurl HTTP Contract Tests
 
@@ -174,11 +183,18 @@ Current test files:
 
 ### Smoke Tests
 
-Smoke tests live in `test/smoke/` and run against a Docker image.
-They verify basic server functionality after a Docker build:
+Smoke tests live in `test/e2e-rust/tests/docker_smoke.rs` and run
+against a built Docker image. They verify basic server functionality
+after a Docker build:
 
 ```bash
-make test-smoke
+# Inner-loop dev path: builds the image via Nix, then runs cargo test.
+just test-smoke
+
+# CI canonical path: builds the image via Nix, then runs the
+# pre-built smoke binary from the .#smoke-test derivation
+# (no cargo on PATH required).
+just nix-test-smoke
 ```
 
 ### Approval Tests

--- a/docs/src/development/nix.md
+++ b/docs/src/development/nix.md
@@ -118,6 +118,46 @@ nix build .#dev.debug                  # extracted symbols at result/lib/debug/.
 nix build .#sipi-debug                 # passthrough to .#default.debug, used by CI
 ```
 
+## Rust test binaries (via crane)
+
+The Rust e2e harness (`test/e2e-rust/`) and the Docker smoke test build
+through dedicated Nix derivations rather than `cargo test` from the dev
+shell. CI runs the resulting binaries directly — no cargo on PATH is
+required, and crate sources are vendored from `Cargo.lock` so a clean
+runner re-substitutes from Cachix instead of re-fetching from
+crates.io.
+
+```bash
+just nix-test-e2e                      # .#e2e-tests: every tests/<name>.rs
+just nix-test-smoke                    # .#smoke-test: docker_smoke (--features docker)
+```
+
+Source of truth: [`nix/rust-tests.nix`](https://github.com/dasch-swiss/sipi/blob/main/nix/rust-tests.nix).
+The module exposes `e2e-tests` and `smoke-test` derivations, both
+sharing a single `cargoArtifacts` deps build via [crane](https://crane.dev/)
+(pinned to `v0.23.3` in `flake.nix`).
+
+`flake.nix` stays an orchestrator — topical Nix expressions live in
+`nix/<topic>.nix` as functions over `{ pkgs, … }` returning attrsets
+that the flake merges into its outputs. `nix/rust-tests.nix` is the
+first module under this pattern; existing in-flake builders (Kakadu
+FOD, static builds, Docker image, dev shells) follow in later PRs.
+
+Two crane-specific notes:
+
+- The default `installFromCargoBuildLogHook` filters cargo's JSON
+  build log with `.profile.test == false`, which is the inverse of
+  what's needed for test binaries. The module sets
+  `doNotPostBuildInstallCargoBinaries = true` and parses the log
+  directly with `jq` to install each `.profile.test == true`
+  artifact under its `target.name`.
+- Test binaries cannot rely on `env!("CARGO_MANIFEST_DIR")` at
+  runtime — that resolves to a Nix sandbox path that no longer
+  exists. The `sipi_e2e::repo_root()` helper reads `$SIPI_REPO_ROOT`
+  first, falling back to `CARGO_MANIFEST_DIR` for the inner-loop
+  `cargo test` path. The `nix-test-e2e` and `nix-test-smoke` recipes
+  set `SIPI_REPO_ROOT={{justfile_directory()}}`.
+
 ## Docker image
 
 The Docker image is built by `pkgs.dockerTools.streamLayeredImage`

--- a/docs/src/development/testing-strategy.md
+++ b/docs/src/development/testing-strategy.md
@@ -763,7 +763,9 @@ insta::assert_json_snapshot!(info_json, {
 | Target | Just Recipe | When | Notes |
 |---|---|---|---|
 | C++ unit tests | `just nix-build` (`.#dev` checkPhase) | PR CI | GoogleTest via ctest, runs in the Nix sandbox |
-| Rust e2e tests | `just rust-test-e2e` | PR CI | Includes insta snapshots |
+| Rust e2e tests (CI) | `just nix-test-e2e` | PR CI | Pre-built binaries from `.#e2e-tests` (crane); reads `$SIPI_BIN` |
+| Rust e2e tests (inner-loop) | `just rust-test-e2e` | local | cargo-driven; reads `$SIPI_BIN`; same test code as `nix-test-e2e` |
+| Docker smoke (CI) | `just nix-test-smoke` | PR + tag CI | Pre-built binary from `.#smoke-test`; runs against loaded image |
 | Hurl contract tests | `just hurl-test` | PR CI | Declarative HTTP tests |
 | Python e2e tests | *(retired)* | — | Replaced by Rust e2e tests |
 | Fuzz testing | `.github/workflows/fuzz.yml` | Nightly | libFuzzer corpus growth |

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1776394852,
+        "narHash": "sha256-K0i9GoNk2To1RQkW348EY4c7RYf3mD74hWlGSc/9sk0=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "db220b8709cea4bd43c9adcd4192f212fb6768d1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "ref": "v0.23.3",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -36,6 +52,7 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,15 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    # Used by `nix/rust-tests.nix` to build the Rust e2e + Docker smoke
+    # test binaries reproducibly with vendored crate sources from
+    # `test/e2e-rust/Cargo.lock`. Pinned to a release tag so that
+    # `nix flake update` does not silently follow upstream's default
+    # branch into a major-version bump.
+    crane.url = "github:ipetkov/crane?ref=v0.23.3";
   };
 
-  outputs = { self, nixpkgs, flake-utils, ... }:
+  outputs = { self, nixpkgs, flake-utils, crane, ... }:
     let
       # Kakadu archive (proprietary). Fetched by a fixed-output derivation
       # (FOD) from the dsp-ci-assets GitHub release via `gh release
@@ -102,6 +108,10 @@
         };
 
         version = pkgs.lib.strings.trim (builtins.readFile ./version.txt);
+
+        # New Nix expressions live in ./nix/<topic>.nix and are imported here.
+        craneLib  = crane.mkLib pkgs;
+        rustTests = import ./nix/rust-tests.nix { inherit pkgs craneLib; };
 
         filteredSrc = pkgs.lib.fileset.toSource {
           root = ./.;
@@ -383,6 +393,11 @@
           # Exposed so `nix build .#kakaduArchive` can pre-populate the
           # store in isolation, and so `nix flake check` covers it.
           kakaduArchive = pkgs.kakaduArchive;
+
+          # Rust e2e + Docker smoke test binaries (see nix/rust-tests.nix).
+          # Built with vendored crate sources via crane; consumed by
+          # `just nix-test-e2e` and `just nix-test-smoke`.
+          inherit (rustTests) e2e-tests smoke-test;
 
           # Debug build with coverage instrumentation
           dev = pkgs.sipi.override {

--- a/justfile
+++ b/justfile
@@ -221,6 +221,9 @@ nix-macos-dylib-audit path:
 #####################################
 
 # Run Rust e2e tests against the built sipi.
+# Inner-loop dev path — uses cargo from the dev shell. CI uses
+# `nix-test-e2e` (below), which consumes pre-built test binaries from
+# the .#e2e-tests derivation and needs no cargo on PATH.
 rust-test-e2e:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -230,6 +233,40 @@ rust-test-e2e:
         exit 1
     fi
     cd test/e2e-rust && SIPI_BIN="$SIPI_BIN" cargo test -- --test-threads=1
+
+# Run nix-built Rust e2e test binaries against the built sipi.
+# Equivalent coverage to `rust-test-e2e`, but the test binaries come
+# from the .#e2e-tests Nix derivation (Cachix-cacheable, no cargo needed).
+# `INSTA_WORKSPACE_ROOT` overrides insta's default `cargo metadata`-based
+# snapshot lookup, which fails when the binary was compiled in a Nix
+# sandbox whose source path no longer exists at runtime.
+nix-test-e2e:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    SIPI_BIN="${SIPI_BIN:-{{justfile_directory()}}/result/bin/sipi}"
+    if [ ! -x "$SIPI_BIN" ]; then
+        echo "sipi binary not found at $SIPI_BIN. Run 'just nix-build' first." >&2
+        exit 1
+    fi
+    {{_nix_build}} -o result-e2e .#e2e-tests
+    SIPI_BIN="$SIPI_BIN" \
+    SIPI_REPO_ROOT="{{justfile_directory()}}" \
+    INSTA_WORKSPACE_ROOT="{{justfile_directory()}}/test/e2e-rust" \
+        {{justfile_directory()}}/result-e2e/bin/run-e2e.sh
+
+# Run nix-built Docker smoke test against the loaded daschswiss/sipi:latest image.
+# Replaces `test-smoke-ci` for CI use; that recipe stays for the inner-loop dev path.
+nix-test-smoke:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! docker image inspect daschswiss/sipi:latest >/dev/null 2>&1; then
+        echo "ERROR: daschswiss/sipi:latest not loaded. Run 'just nix-docker-build-<arch>' first." >&2
+        exit 1
+    fi
+    {{_nix_build}} -o result-smoke .#smoke-test
+    SIPI_REPO_ROOT="{{justfile_directory()}}" \
+    INSTA_WORKSPACE_ROOT="{{justfile_directory()}}/test/e2e-rust" \
+        {{justfile_directory()}}/result-smoke/bin/docker_smoke --test-threads=1
 
 # Run Hurl HTTP contract tests against the built sipi.
 hurl-test:

--- a/nix/rust-tests.nix
+++ b/nix/rust-tests.nix
@@ -1,0 +1,150 @@
+# Rust e2e + Docker smoke test binaries.
+#
+# Inputs:
+#   pkgs     — nixpkgs (with sipi overlay applied in flake.nix)
+#   craneLib — `crane.mkLib pkgs`
+#
+# Outputs:
+#   e2e-tests   — every tests/<name>.rs binary except docker_smoke
+#                 (no features); ships a run-e2e.sh driver alongside
+#   smoke-test  — the docker_smoke binary, --features docker
+#
+# Each derivation produces test binaries under $out/bin/<test-target>,
+# named after the cargo test target (one per tests/<name>.rs). The
+# binaries discover the sipi repo root at runtime via $SIPI_REPO_ROOT
+# (see sipi_e2e::repo_root in test/e2e-rust/src/lib.rs) — they cannot
+# rely on env!("CARGO_MANIFEST_DIR") because that resolves to the
+# Nix sandbox source path.
+{ pkgs, craneLib }:
+
+let
+  src = craneLib.cleanCargoSource ../test/e2e-rust;
+
+  commonArgs = {
+    inherit src;
+    strictDeps = true;
+    pname = "sipi-e2e";
+    version = "0.1.0";
+
+    nativeBuildInputs = with pkgs; [
+      cmake          # aws-lc-sys (jsonwebtoken[aws_lc_rs])
+      perl           # aws-lc-sys, openssl-sys
+      pkg-config     # openssl-sys
+    ];
+    buildInputs = with pkgs; [ openssl ];
+    env = {
+      # Pin libclang to the same LLVM major as the C++ stdenv override
+      # (`flake.nix` picks `llvmPackages_19.libcxxStdenv`). The
+      # unversioned `pkgs.llvmPackages` alias drifts across nixpkgs
+      # channels and can land bindgen on a different LLVM ABI than the
+      # surrounding C++ build.
+      LIBCLANG_PATH = "${pkgs.llvmPackages_19.libclang.lib}/lib";  # bindgen
+      # Crane defaults to CARGO_PROFILE=release, which makes
+      # `cargoWithProfile test --no-run` emit `cargo test --release`.
+      # Release-optimized test binaries hammer the sipi server ~5x
+      # faster than debug-profile binaries, exceeding sipi's tolerated
+      # connection-drop rate on the JP2 → JPEG decode path and turning
+      # several iiif_compliance / resource_limits tests flaky. Pin the
+      # cargo profile to `test` to match the default `cargo test`
+      # behavior used by the inner-loop dev shell.
+      CARGO_PROFILE = "test";
+    };
+  };
+
+  # Vendored deps build, shared between e2e-tests and smoke-test.
+  cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
+  # Build "cargo test --no-run" and install the resulting test
+  # binaries. Crane's `installFromCargoBuildLogHook` filters its
+  # extraction with `.profile.test == false`, so it is unsuitable
+  # for installing test binaries — it would silently install zero
+  # files. Instead we parse cargo's JSON build log directly with
+  # `jq`, picking compiler-artifact records where `.profile.test`
+  # is true, and copying each `.executable` to `$out/bin/<target>`
+  # under its cargo test target name (one binary per `tests/<name>.rs`).
+  mkTestBinaries = extraArgs: craneLib.mkCargoDerivation (commonArgs // {
+    inherit cargoArtifacts;
+    pnameSuffix = "-tests";
+
+    # Disable crane's default post-build install — its filter is
+    # the inverse of what we need (it wants non-test binaries).
+    doNotPostBuildInstallCargoBinaries = true;
+
+    nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ pkgs.jq ];
+
+    buildPhaseCargoCommand = ''
+      cargoBuildLog=$(mktemp cargoBuildLog-XXXXXX.json)
+      cargoWithProfile test --no-run ${extraArgs} \
+        --message-format json-render-diagnostics > "$cargoBuildLog"
+    '';
+
+    installPhaseCommand = ''
+      mkdir -p $out/bin
+      jq -r '
+        select(.reason == "compiler-artifact" and .profile.test == true)
+        | select(.executable != null)
+        | "\(.target.name)\t\(.executable)"
+      ' < "$cargoBuildLog" | while IFS=$'\t' read -r name exe; do
+        echo "installing test binary: $name"
+        cp "$exe" "$out/bin/$name"
+      done
+
+      # Fail loudly if the jq filter extracted zero binaries (e.g. a
+      # future cargo / crane / message-format change makes the
+      # `.profile.test == true` selector miss). Without this guard the
+      # derivation builds successfully with an empty $out/bin and the
+      # confusion surfaces only at run-e2e.sh time.
+      if [ -z "$(ls -A "$out/bin" 2>/dev/null)" ]; then
+        echo "ERROR: no test binaries extracted from cargo build log" >&2
+        exit 1
+      fi
+    '';
+  });
+
+  # Bash driver script: iterates every test binary in $out/bin/ except
+  # itself and runs each with --test-threads=1. Exits non-zero if any
+  # binary failed. The justfile's nix-test-e2e recipe shells out to this.
+  runE2eDriver = pkgs.writeShellScript "run-e2e.sh" ''
+    # `-e` is intentionally omitted: the loop must continue past
+    # per-binary failures to count them all and exit with the
+    # aggregate. Per-binary success/failure is captured explicitly
+    # via `if ! "$bin" ...`.
+    set -uo pipefail
+    : "''${SIPI_BIN:?SIPI_BIN must point at the sipi binary under test}"
+    : "''${SIPI_REPO_ROOT:?SIPI_REPO_ROOT must point at the sipi repo root}"
+
+    bin_dir=$(dirname "$0")
+    failed=0
+    total=0
+
+    for bin in "$bin_dir"/*; do
+      [ -x "$bin" ] || continue
+      name=$(basename "$bin")
+      [ "$name" = "run-e2e.sh" ] && continue
+      total=$((total + 1))
+      echo "==> $name"
+      if ! "$bin" --test-threads=1; then
+        failed=$((failed + 1))
+      fi
+    done
+
+    if [ "$failed" -gt 0 ]; then
+      echo "FAIL: $failed/$total e2e test binaries failed" >&2
+      exit 1
+    fi
+    echo "OK: $total/$total e2e test binaries passed"
+  '';
+
+  e2eTests = (mkTestBinaries "").overrideAttrs (old: {
+    postInstall = (old.postInstall or "") + ''
+      cp ${runE2eDriver} $out/bin/run-e2e.sh
+      chmod +x $out/bin/run-e2e.sh
+    '';
+  });
+
+  smokeTest = mkTestBinaries "--features docker --test docker_smoke";
+in
+{
+  e2e-tests = e2eTests;
+  smoke-test = smokeTest;
+}

--- a/test/e2e-rust/src/lib.rs
+++ b/test/e2e-rust/src/lib.rs
@@ -5,16 +5,27 @@ use std::net::TcpStream;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicU16, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 /// Atomic port counter to avoid conflicts when tests run in parallel.
 /// Start well above privileged ports (macOS restricts ports below 1024).
-static NEXT_PORT: AtomicU16 = AtomicU16::new(11024);
+/// The base offset is derived from the PID so back-to-back test
+/// binaries don't restart at the same port and collide on TIME_WAIT
+/// state from each other's recently-closed sockets.
+static NEXT_PORT: OnceLock<AtomicU16> = OnceLock::new();
+
+fn next_port() -> &'static AtomicU16 {
+    NEXT_PORT.get_or_init(|| {
+        // 11024 + (PID mod 16k), keeping ports under 32k so the +2 SSL port never overflows u16.
+        let offset = (std::process::id() % 16384) as u16;
+        AtomicU16::new(11024 + offset)
+    })
+}
 
 /// Allocate a pair of (http_port, ssl_port) for a test server instance.
 pub fn allocate_ports() -> (u16, u16) {
-    let http = NEXT_PORT.fetch_add(2, Ordering::SeqCst);
+    let http = next_port().fetch_add(2, Ordering::SeqCst);
     assert!(http < 65534, "port counter overflow");
     let ssl = http + 1;
     (http, ssl)
@@ -79,7 +90,12 @@ impl SipiServer {
         // Local (zig): paths are relative (CMakeFiles/...). When the test harness
         // changes cwd to test/_test_data/, gcda files would land there instead of
         // in build/. GCOV_PREFIX redirects them to the build dir.
-        let build_dir = find_sipi_bin()
+        //
+        // Derive `build_dir` from the *actually-resolved* sipi binary, not from
+        // `find_sipi_bin()` (the cmake-inner-loop default). When `$SIPI_BIN`
+        // points outside `repo_root/build` (static-musl CI, sanitizer CI, or
+        // any custom binary), `find_sipi_bin()` would compute the wrong dir.
+        let build_dir = PathBuf::from(&sipi_bin)
             .parent()
             .expect("sipi binary should be in a build directory")
             .to_path_buf();
@@ -316,25 +332,37 @@ impl Drop for SipiServer {
     }
 }
 
-/// Find the sipi binary relative to the project root.
-pub fn find_sipi_bin() -> PathBuf {
-    // test/e2e-rust/ is two levels below the repo root
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let repo_root = manifest_dir
+/// Path to the sipi repository root.
+///
+/// Resolution order:
+///   1. `$SIPI_REPO_ROOT` if set — required when this crate is built in a
+///      Nix sandbox, because `CARGO_MANIFEST_DIR` is baked at compile time
+///      and points at the (now-deleted) sandbox source path.
+///   2. `CARGO_MANIFEST_DIR/../..` — the inner-loop `cargo test` path.
+pub fn repo_root() -> PathBuf {
+    if let Ok(p) = std::env::var("SIPI_REPO_ROOT") {
+        return PathBuf::from(p);
+    }
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .and_then(|p| p.parent())
-        .expect("e2e-rust should be two levels below repo root");
-    repo_root.join("build").join("sipi")
+        .expect("e2e-rust should be two levels below repo root")
+        .to_path_buf()
+}
+
+/// Default sipi binary path for the cmake inner-loop dev shell
+/// (`<repo>/build/sipi`).
+///
+/// Test harness resolution prefers `$SIPI_BIN` (set by
+/// `just nix-test-e2e` to `<repo>/result/bin/sipi`); this fallback
+/// only fires when `SIPI_BIN` is unset.
+pub fn find_sipi_bin() -> PathBuf {
+    repo_root().join("build").join("sipi")
 }
 
 /// Path to the test data directory.
 pub fn test_data_dir() -> PathBuf {
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let repo_root = manifest_dir
-        .parent()
-        .and_then(|p| p.parent())
-        .expect("e2e-rust should be two levels below repo root");
-    repo_root.join("test").join("_test_data")
+    repo_root().join("test").join("_test_data")
 }
 
 /// Kill any process listening on the given port (cleanup from previous test runs).

--- a/test/e2e-rust/tests/docker_smoke.rs
+++ b/test/e2e-rust/tests/docker_smoke.rs
@@ -93,12 +93,7 @@ impl Drop for DockerContainer {
 }
 
 fn project_root() -> std::path::PathBuf {
-    let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    manifest_dir
-        .parent()
-        .and_then(|p| p.parent())
-        .expect("e2e-rust should be two levels below repo root")
-        .to_path_buf()
+    sipi_e2e::repo_root()
 }
 
 fn smoke_client() -> Client {

--- a/test/e2e-rust/tests/iiif_compliance.rs
+++ b/test/e2e-rust/tests/iiif_compliance.rs
@@ -1362,8 +1362,17 @@ fn assert_corrupt_image_handled(filename: &str, source: &str, truncate_bytes: us
     );
     std::fs::write(&corrupt_path, &real_data[..truncate_bytes]).expect("write truncated file");
 
-    let isolated_srv =
-        sipi_e2e::SipiServer::start("config/sipi.e2e-test-config.lua", &test_data);
+    // Give the isolated server its own cache dir so its startup orphan
+    // scan doesn't wipe out the main shared server's cache entries —
+    // shared `cache_dir = './cache'` from the Lua config means concurrent
+    // sipi processes race on `.sipicache` index updates and on disk files.
+    let cache_tmp = tempfile::tempdir().expect("create isolated cache dir");
+    let cache_arg = cache_tmp.path().to_string_lossy().to_string();
+    let isolated_srv = sipi_e2e::SipiServer::start_with_args(
+        "config/sipi.e2e-test-config.lua",
+        &test_data,
+        &["--cache-dir", &cache_arg],
+    );
     let isolated_client = sipi_e2e::http_client();
 
     // Request the corrupt image — server should return error, not crash
@@ -1408,6 +1417,15 @@ fn assert_corrupt_image_handled(filename: &str, source: &str, truncate_bytes: us
     );
 
     let _ = std::fs::remove_file(&corrupt_path);
+
+    // Drop the server before the temp dir: SipiServer::Drop sends SIGTERM
+    // and waits up to 5s for graceful shutdown; if `cache_tmp` were dropped
+    // first, the cache_dir would be deleted under sipi's feet during its
+    // shutdown flush. Today this is enforced implicitly by reverse-
+    // declaration drop order — make it explicit so a future refactor can't
+    // silently break it.
+    drop(isolated_srv);
+    drop(cache_tmp);
 }
 
 #[test]

--- a/test/e2e-rust/tests/resource_limits.rs
+++ b/test/e2e-rust/tests/resource_limits.rs
@@ -290,10 +290,30 @@ fileserver = {
 routes = {}
 "#;
 
-    let config_path = test_data.join("config/sipi.pixel-limit-test.lua");
-    std::fs::write(&config_path, config_content).expect("write pixel limit config");
+    // Give the isolated server its own cache dir so its startup orphan
+    // scan doesn't wipe out the main shared server's cache entries —
+    // shared `cache_dir = './cache'` from the Lua config means concurrent
+    // sipi processes race on `.sipicache` index updates and on disk files.
+    let cache_tmp = tempfile::tempdir().expect("create isolated cache dir");
+    let cache_arg = cache_tmp.path().to_string_lossy().to_string();
 
-    let srv = SipiServer::start("config/sipi.pixel-limit-test.lua", &test_data);
+    // Write the pixel-limit-test config inside the per-test tempdir so two
+    // parallel runs (different `cargo test` invocations or two CI workspaces
+    // sharing this checkout) can't race on a single shared
+    // `test_data/config/sipi.pixel-limit-test.lua` path. sipi's `--config`
+    // accepts an absolute path, so this works the same as the old in-tree
+    // config write.
+    let config_path = cache_tmp.path().join("sipi.pixel-limit-test.lua");
+    std::fs::write(&config_path, config_content).expect("write pixel limit config");
+    let config_arg = config_path
+        .to_str()
+        .expect("config path is valid utf-8");
+
+    let srv = SipiServer::start_with_args(
+        config_arg,
+        &test_data,
+        &["--cache-dir", &cache_arg],
+    );
     let c = http_client();
 
     // Request full-size image (512x512 = 262144 pixels, exceeds 10000 limit)
@@ -326,7 +346,15 @@ routes = {}
         "request within max_pixel_limit should return 200"
     );
 
-    let _ = std::fs::remove_file(&config_path);
+    // Drop the server before the temp dir: SipiServer::Drop sends SIGTERM
+    // and waits up to 5s for graceful shutdown; if `cache_tmp` were dropped
+    // first, the cache_dir + the config file inside it would be deleted
+    // under sipi's feet during its shutdown flush. Today this is enforced
+    // implicitly by reverse-declaration drop order — make it explicit so a
+    // future refactor can't silently break it. (cache_tmp's Drop also
+    // cleans up the config file, so no manual remove is needed.)
+    drop(srv);
+    drop(cache_tmp);
 }
 
 /// Extract a gauge metric value from Prometheus text format.


### PR DESCRIPTION
## Motivation

The Rust e2e crate (`test/e2e-rust/`) and the Docker smoke test inside
it were built imperatively from `cargo test`. CI ran them inside a
`nix develop --command bash -c "..."` wrap to get cargo on PATH; crate
sources were re-fetched from crates.io on every clean runner. Two
problems:

- **Weak CI caching.** A clean runner re-downloaded ~200 crates on
  every PR even when `Cargo.lock` had not changed.
- **`nix develop` wrap on a `just` recipe.** The convention is that
  CI invokes `just <recipe>` directly, with any required tools
  provisioned via `nix profile install nixpkgs#<tool>`.

## Summary

- New `.#e2e-tests` and `.#smoke-test` Nix derivations build the
  Rust test binaries from vendored crate sources via `crane`.
  Cachix-cacheable.
- New `just nix-test-e2e` and `just nix-test-smoke` recipes invoke
  the pre-built binaries; need only `just` on PATH.
- Every CI workflow that ran Rust e2e or Docker smoke (`ci.yml`,
  `publish.yml`, `sanitizer.yml`) drops the `nix develop --command`
  wrap and consumes the new recipes.

## Key Changes

### `nix/` subfolder

`flake.nix` should stay an orchestrator. New Nix expressions live in
`nix/<topic>.nix` as functions over `{ pkgs, ... }` returning
attribute sets that `flake.nix` merges into the right output. This
PR introduces the pattern with `nix/rust-tests.nix`; existing
in-flake builders (Kakadu FOD, static builds, Docker image, dev
shells) follow in later PRs.

### `nix/rust-tests.nix`

One module, two derivations:

- `e2e-tests` — every `tests/<name>.rs` binary (no features) plus
  a `run-e2e.sh` driver that iterates them with `--test-threads=1`.
- `smoke-test` — the `docker_smoke` binary built with
  `--features docker`.

Both share a single `cargoArtifacts` deps build, so flipping
features re-uses the dep build. `crane.url` is pinned to `?ref=v0.23.3`
(commit db220b8) so a routine `nix flake update` cannot silently
follow upstream's default branch into a major-version bump.
`LIBCLANG_PATH` is pinned to `pkgs.llvmPackages_19.libclang.lib` to
match the C++ stdenv override (avoids an ABI mismatch with the
surrounding C++ build).

### Test source change

`find_sipi_bin` and `test_data_dir` derived the repo root from
`env!("CARGO_MANIFEST_DIR")`, a compile-time constant that points at
the now-deleted Nix sandbox path when the crate is built inside a
derivation. They now use a public `repo_root()` helper that prefers
`$SIPI_REPO_ROOT` and falls back to `CARGO_MANIFEST_DIR`. Inner-loop
`cargo test` keeps working unchanged.

### CI surface

Three workflows migrated together:

- `ci.yml`: `test/{amd64,arm64}` and `nix-static/{amd64,arm64}`
  jobs replace the `nix develop --command` wrap with
  `just nix-test-e2e`, and `just test-smoke-ci` with
  `just nix-test-smoke`.
- `publish.yml`: `validate-docker` and `publish-docker` (tag-release
  jobs) likewise migrate to `just nix-test-smoke`. Without this the
  release-tag smoke gate would still depend on cargo at release time.
- `sanitizer.yml`: e2e-under-sanitizer drops the
  `nix --option filter-syscalls false develop --command bash -c
  "just rust-test-e2e"` wrap for `just nix-test-e2e`. The
  filter-syscalls flag mattered for the *build* of the sanitized
  sipi (already done in the prior step), not for running the test
  client. The test client doesn't need to be sanitized; only sipi
  does.

Tool installation hygiene: every `nix profile install nixpkgs#<tool>`
across the three workflows now passes `--inputs-from .`, resolving
`nixpkgs` from the project's `flake.lock` instead of the user/global
flake registry. `just` and `hurl` were silently unpinned before.

## Challenges and Decisions

### Crane's `installFromCargoBuildLogHook` is unsuitable for test binaries

**Problem:** `craneLib.cargoBuild` with `cargo test --no-run` produced
zero installed binaries. The build phase ran cleanly, the JSON log
was captured, but `$out/bin/` was empty.

**Tried:** Adding `craneLib.installFromCargoBuildLogHook` to
`nativeBuildInputs` and letting crane's default install phase consume
the log.

**Solution:** The hook's `jq` filter is
`select(.reason == "compiler-artifact" and .profile.test == false)`
— the inverse of what is needed for test binaries (test artifacts
are exactly the ones with `.profile.test == true`). The install
phase now parses the log directly with `jq`, picking
compiler-artifact records where `.profile.test == true` and copying
each `.executable` to `$out/bin/<target.name>`. A zero-binary guard
fails the build loudly if a future cargo / crane / message-format
change makes the selector miss.

### Crane's `CARGO_PROFILE=release` default produced flaky tests

**Problem:** With the initial `commonArgs.env` not setting
`CARGO_PROFILE`, crane's default of `CARGO_PROFILE=release` made
`cargoWithProfile test --no-run` emit `cargo test --release`. The
release-optimized test binaries hammered the sipi server about 5x
faster than the debug-profile binaries the prior `cargo test` step
in dev shell produced (iiif_compliance went from 13.7s → 3.1s).
That pace exceeded sipi's tolerated connection-drop rate on the
JP2 → JPEG decode path, turning five `iiif_compliance` and two
`resource_limits` tests flaky on every CI run.

**Solution:** Set `CARGO_PROFILE = "test"` in `commonArgs.env` so
both the deps build (`buildDepsOnly`) and the consumer test-binary
build use the test profile (debug + assertions on, matches what
inner-loop `cargo test` produces).

### `env!("CARGO_MANIFEST_DIR")` does not survive a Nix sandbox build

**Problem:** Test binaries built inside a Nix derivation cannot
find the sipi binary or the `test/_test_data/` tree at runtime —
`CARGO_MANIFEST_DIR` is baked at compile time into the Nix sandbox
path, which no longer exists when the binary runs.

**Solution:** Add a `$SIPI_REPO_ROOT` runtime override. The new
`sipi_e2e::repo_root` helper picks it up first; the
`CARGO_MANIFEST_DIR` fallback keeps the inner-loop `cargo test`
flow working without changes. The `nix-test-e2e` /
`nix-test-smoke` recipes set the env var to
`{{justfile_directory()}}`.

### Sequential runner exposes a sipi cache-concurrency race

**Problem:** Even with the profile fix above, `iiif_compliance` and
`resource_limits` reproduced 5+2 connection drops on
`lena512.jp2/full/max/0/default.jpg` on every run. Sipi's stdout
revealed the race:

```
{"level": "DEBUG", "message": "Using cachefile ./cache/cache_PooNJuq88X"}
{"level": "DEBUG", "message": "Orphan file \"cache_PooNJuq88X\" not in cache index, removing"}
{"level": "WARN", "message": "Internal server error: ... File not readable: ./cache/cache_PooNJuq88X"}
```

`assert_corrupt_image_handled` and
`pixel_limit_rejects_oversized_request` each spawn a *second* sipi
server alongside the per-binary shared `OnceLock` server, both
using the same `cache_dir = './cache'` from the Lua config.
`SipiCache::SipiCache` runs an orphan scan at every startup that
deletes any file in `cache_dir` not present in the on-disk
`.sipicache` index — wiping cache entries the still-running shared
server holds only in its in-memory index. The prior `cargo test`
ran binaries in parallel and that masked the race; the new
sequential `nix-test-e2e` runner makes it deterministic.

**Solution:** Pass `--cache-dir <tempdir>` to each spawned-isolated
server so its orphan scan only sees its own cache dir. Underlying
cache-concurrency issue in sipi remains, out of scope for the
build-system PR.

### `publish.yml` migration was missed; surfaced post-merge by review

**Problem:** Initial PR migrated only `ci.yml`. A
`/eng:workflows:review` pass caught that `publish.yml` (tag-release
jobs) still called `just test-smoke-ci` (cargo-dependent), and
`sanitizer.yml` still called `just rust-test-e2e` inside a
`nix develop --command` wrap. The release-tag smoke gate would
break on the next release.

**Solution:** Migrate both sibling workflows in the same PR. The
sanitizer workflow specifically needed the
`--option filter-syscalls false` wrap dropped — that flag was for
the sanitizer *build*, already done in the prior step.

## Gotchas

- The `e2e-tests` derivation's `$out/bin/` includes a `docker_smoke`
  binary built without the `docker` feature; it compiles to an
  empty test runner (the test file is `#![cfg(feature = "docker")]`-
  gated) and exits 0 when `run-e2e.sh` invokes it. Harmless but
  surprising at first glance — the actual Docker smoke is in
  `.#smoke-test`.
- Test target name collisions are not handled: if two test files
  shared a name across different feature sets, the install phase's
  `cp $exe $out/bin/$name` would overwrite. Not an issue today
  (every `tests/*.rs` has a unique name), but worth noting if
  someone adds a `cargo`-feature-conditional test target.
- `nix profile install nixpkgs#<tool>` is **not** flake-locked by
  default; it resolves `nixpkgs` from the user/global flake
  registry. Add `--inputs-from .` to use the project's `flake.lock`.
  Both `just` and `hurl` were silently unpinned before this PR.
- Drop order matters in the spawned-isolated-server helpers: the
  `SipiServer` value must drop before the `tempfile::TempDir` it
  uses as `--cache-dir`, otherwise the cache directory disappears
  under sipi during its 5s graceful-shutdown window. Today this is
  enforced by Rust's reverse-declaration drop order; explicit
  `drop(srv); drop(cache_tmp);` calls at the end of the helper make
  it visible at the call site.
- `GCOV_PREFIX` for coverage-instrumented sipi must derive from the
  *resolved* `$SIPI_BIN` (whatever path actually ran), not from the
  cmake-default `<repo>/build/sipi`. Otherwise the static-musl and
  sanitizer CI jobs (where SIPI_BIN points at
  `result/bin/sipi`) write `.gcda` files into the wrong directory.

## Test Plan

- [x] `just nix-build` → `just nix-test-e2e` → `just hurl-test`
      succeeds locally (macOS aarch64).
- [x] `just nix-docker-build` → `just nix-test-smoke` succeeds
      locally against the loaded image.
- [x] CI `test/{amd64,arm64}`, `nix-static/{amd64,arm64}`,
      `asan-ubsan/amd64` all green on Linux runners (run
      [25102065843](https://github.com/dasch-swiss/sipi/actions/runs/25102065843)).
- [x] Locally verified all 23 binaries from `.#e2e-tests` pass via
      `just nix-test-e2e`.
- [x] `just nix-test-smoke` precondition guard fails fast with a
      clear error when no Docker image is loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)