### PR TITLE
feat(icc): deterministic ICC creation date for bit-exact tests (DEV-6333)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,8 @@ If a change can't be verified on a platform locally, say so explicitly and gate 
 
 **First-time setup for the dev-shell inner loop:** run `just kakadu-fetch` once to download the proprietary Kakadu archive from `dsp-ci-assets` into `vendor/`. Nix builds (including `just nix-docker-build`) fetch Kakadu directly via the flake's FOD (no `vendor/` step). Requires `gh auth login` and `dasch-swiss` org membership. See [`docs/src/development/kakadu.md`](docs/src/development/kakadu.md).
 
+**ICC determinism invariant:** [`SipiIcc::iccBytes()`](src/metadata/SipiIcc.cpp) is the single chokepoint that converts an `cmsHPROFILE` into raw bytes for codec consumption — every TIFF, JPEG, PNG, and JP2 emission funnels through it. Any new format handler must route through `iccBytes()`; bypassing it (calling `cmsSaveProfileToMem` directly) breaks the approval-test gate. Approval tests run with `SOURCE_DATE_EPOCH` injected by CMake (see [`test/approval/CMakeLists.txt`](test/approval/CMakeLists.txt)) so the wall-clock-stamped ICC creation date is overwritten with a fixed value and goldens stay byte-deterministic. Production never sets the env var; deployed binaries continue to embed wall-clock-stamped ICC headers. See [`docs/adr/0002-icc-profile-determinism-test-only.md`](docs/adr/0002-icc-profile-determinism-test-only.md).
+
 ### Quick Reference
 
 ```bash

--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -32,6 +32,8 @@ Canonical terminology for the SIPI repository. SIPI is a IIIF Image API 3.0 serv
 | --- | --- | --- |
 | **Format handler** | A SipiIO subclass that adapts a codec to SIPI's read/write contract (SipiIOJ2k, SipiIOTiff, SipiIOPng, SipiIOJpeg). | IO backend, format driver |
 | **Codec** | A third-party library that performs the actual encode/decode (kakadu, libtiff, libpng, libjpeg, libwebp). A format handler *uses* a codec. | library, backend |
+| **ICC normalization** | The byte-level rewrite of bytes 24-35 (creation date) and 84-99 (Profile ID) inside `SipiIcc::iccBytes()`, gated by the *Reproducibility flag*. Test-only — production iccBytes() is the identity. | ICC scrubbing, ICC stripping (those imply removing profiles, not normalizing them) |
+| **Reproducibility flag** | The `SOURCE_DATE_EPOCH` environment variable. When set, every ICC profile emitted by SipiIcc::iccBytes() has its creation date overwritten with the supplied epoch and its Profile ID zeroed; codec-bound emissions become byte-deterministic. CMake injects it for `sipi.approvaltests` only. | deterministic mode, test-only mode (the env var is the contract; "modes" obscure that) |
 
 ## Metadata and preservation
 

--- a/docs/adr/0002-icc-profile-determinism-test-only.md
+++ b/docs/adr/0002-icc-profile-determinism-test-only.md
@@ -1,0 +1,7 @@
+# ICC profile creation date is deterministic in tests, wall-clock in production
+
+`SipiIcc::iccBytes()` is the single chokepoint that converts `cmsHPROFILE` to bytes for codec consumption. When `SOURCE_DATE_EPOCH` is set in the environment, it overwrites bytes 24-35 (ICC creation date) with the supplied epoch and zeros bytes 84-99 (Profile ID). When unset — the production default — it returns lcms2's wall-clock-stamped bytes verbatim.
+
+We accept this split because byte-for-byte approval testing of JPEG / PNG / JP2 outputs is otherwise impossible (lcms2's `cmsCreateProfilePlaceholder` calls `time(NULL)` and lcms2 upstream rejected `SOURCE_DATE_EPOCH` support — Debian #814883, Little-CMS #71). Production keeps wall-clock timestamps so downstream consumers reading `cmsGetHeaderCreationDateTime` see real creation times, matching every other IIIF server.
+
+The alternatives — patching lcms2 (fork burden), stripping ICC profiles from outputs (loses colour management), or pixel-tolerance / SSIM-based testing (looser gate, hides real encoder drift) — were rejected because the chokepoint design makes the test-only fix one function call.

--- a/docs/src/development/developing.md
+++ b/docs/src/development/developing.md
@@ -204,7 +204,32 @@ just nix-test-smoke
 ### Approval Tests
 
 Approval tests live in `test/approval/` and use snapshot-based
-testing for regression detection.
+testing for regression detection. Run them via ctest:
+
+```bash
+cd build
+ctest -L approval --output-on-failure
+```
+
+CMake injects `SOURCE_DATE_EPOCH=946684800` into the `sipi.approvaltests`
+invocation so the wall-clock-stamped ICC creation date that lcms2 stamps
+into JPEG / PNG / JP2 (and ICC-carrying TIFF) outputs is overwritten
+with a fixed value. Without the env var the seconds field drifts by one
+byte across consecutive runs.
+
+When running the binary directly outside of ctest, export the same
+value first:
+
+```bash
+cd build/test/approval
+SOURCE_DATE_EPOCH=946684800 ./sipi.approvaltests \
+  --gtest_filter='ImageEncodeBaseline.*'
+```
+
+Without it, expect `.received.*` files for every ICC-touching test —
+that's a deliberate test-infrastructure side-effect, not a regression.
+See [`test/approval/CHANGELOG.approval.md`](../../../test/approval/CHANGELOG.approval.md)
+for the full list and the re-approval procedure.
 
 ## Managing Dependencies
 

--- a/docs/src/development/developing.md
+++ b/docs/src/development/developing.md
@@ -103,13 +103,18 @@ We use two test frameworks:
 Unit tests live in `test/unit/` and use GoogleTest with ApprovalTests.
 Tests are organized by component:
 
+- `test/unit/cache/` - LRU cache tests
 - `test/unit/configuration/` - Configuration parsing tests
+- `test/unit/decode_dims/` - Decode-time dimension tests
 - `test/unit/filenamehash/` - Filename hashing tests
-- `test/unit/iiifparser/` - IIIF URL parser tests
-- `test/unit/sipiimage/` - Image processing tests
-- `test/unit/shttps/` - HTTP server utility tests
-- `test/unit/logger/` - Logger tests
 - `test/unit/handlers/` - HTTP handler tests
+- `test/unit/iiifparser/` - IIIF URL parser tests
+- `test/unit/logger/` - Logger tests
+- `test/unit/memory_budget/` - Decode memory budget tests
+- `test/unit/ratelimiter/` - Rate-limiter tests
+- `test/unit/shttps/` - HTTP server utility tests
+- `test/unit/sipiicc/` - ICC profile normalization tests (`SOURCE_DATE_EPOCH` helper)
+- `test/unit/sipiimage/` - Image processing tests
 
 Run all unit tests (inside the Nix sandbox via `doCheck = enableTests` in
 `package.nix` — `just nix-build` fails if any unit test fails):

--- a/docs/src/development/testing-strategy.md
+++ b/docs/src/development/testing-strategy.md
@@ -338,6 +338,8 @@ Behavior that *is* HTTP-observable belongs in Hurl (status/header contracts) or 
 
 **Pattern:** Use `insta::assert_json_snapshot!` with redactions for dynamic fields (`id`, timestamps).
 
+**ICC determinism gate.** Approval tests under `test/approval/image_encode_baseline_test.cpp` are byte-stable only when `SOURCE_DATE_EPOCH` is set. lcms2 stamps wall-clock UTC into bytes 24-35 of every freshly-created ICC profile (and several emit paths in SipiImage round-trip through that), so without the env var the seconds field drifts across consecutive runs of the same binary. `SipiIcc::iccBytes()` overwrites those bytes (and zeros the Profile ID at bytes 84-99) when the env var is set; CMake injects `SOURCE_DATE_EPOCH=946684800` (2000-01-01T00:00:00Z UTC) into the `sipi.approvaltests` invocation via `set_tests_properties(... ENVIRONMENT ...)`. Production never sets the var and retains lcms2's wall-clock behaviour. See [`docs/adr/0002-icc-profile-determinism-test-only.md`](../../adr/0002-icc-profile-determinism-test-only.md) for the architectural rationale and [`test/approval/CHANGELOG.approval.md`](../../../test/approval/CHANGELOG.approval.md) for the maintainer's how-to.
+
 ### Layer 3: E2E Contract Tests (HTTP-level)
 
 **Purpose:** Test sipi's HTTP API contract — the behavior visible to clients. These tests survive the Rust migration because they test the contract, not the implementation.

--- a/include/metadata/SipiIcc.h
+++ b/include/metadata/SipiIcc.h
@@ -123,9 +123,9 @@ public:
    * profile-determinism-test-only.md for the rationale.
    *
    * @param[out] len Length of the buffer returned
-   * @returns Buffer containing the binary ICC profile
+   * @returns Buffer containing the binary ICC profile (caller owns; `delete[]` it)
    */
-  unsigned char *iccBytes(unsigned int &len);
+  [[nodiscard]] unsigned char *iccBytes(unsigned int &len);
 
   /*!
    * Get the blob containing the ICC profile as std::vector. Calls the
@@ -134,7 +134,7 @@ public:
    *
    * @return std::vector containing the binary ICC profile
    */
-  std::vector<unsigned char> iccBytes();
+  [[nodiscard]] std::vector<unsigned char> iccBytes();
 
   /*!
    * Retireve the littleCMS profile

--- a/include/metadata/SipiIcc.h
+++ b/include/metadata/SipiIcc.h
@@ -107,15 +107,32 @@ public:
   SipiIcc &operator=(const SipiIcc &rhs);
 
   /*!
-   * Get the blob containing the ICC profile
+   * Get the blob containing the ICC profile.
+   *
+   * This is the single chokepoint through which every codec-bound ICC
+   * profile (TIFF / JPEG / PNG / JP2) is materialized for emission.
+   * New format handlers must route through here.
+   *
+   * Reproducibility: when the SOURCE_DATE_EPOCH environment variable is
+   * set (parsed once on first call, cached thread-safely), bytes 24-35
+   * of the returned buffer (ICC creation date) are overwritten with the
+   * supplied epoch and bytes 84-99 (Profile ID) are zeroed. When unset
+   * (the production default), the buffer is returned exactly as lcms2
+   * serialized it, including lcms2's wall-clock-stamped creation date.
+   * See test/approval/CHANGELOG.approval.md and docs/adr/0002-icc-
+   * profile-determinism-test-only.md for the rationale.
+   *
    * @param[out] len Length of the buffer returned
    * @returns Buffer containing the binary ICC profile
    */
   unsigned char *iccBytes(unsigned int &len);
 
   /*!
-   * Get the blob containing the ICC profile as std::vector
-   * @return std:vector containing the binary ICC profile
+   * Get the blob containing the ICC profile as std::vector. Calls the
+   * raw-buffer overload, so the same SOURCE_DATE_EPOCH normalization
+   * applies.
+   *
+   * @return std::vector containing the binary ICC profile
    */
   std::vector<unsigned char> iccBytes();
 

--- a/include/metadata/SipiIccDetail.h
+++ b/include/metadata/SipiIccDetail.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2026 Swiss National Data and Service Center for the Humanities
+ * and/or DaSCH Service Platform contributors. SPDX-License-Identifier:
+ * AGPL-3.0-or-later
+ */
+
+// Internal helpers for SipiIcc — exposed in a header solely so the unit tests
+// in test/unit/sipiicc/ can exercise them with explicit epoch values, side-
+// stepping the magic-static cache that drives production reads of
+// SOURCE_DATE_EPOCH. No production code outside src/metadata/SipiIcc.cpp
+// should include this header.
+#ifndef SIPI_METADATA_SIPI_ICC_DETAIL_H
+#define SIPI_METADATA_SIPI_ICC_DETAIL_H
+
+#include <cstddef>
+#include <ctime>
+#include <optional>
+
+namespace Sipi::detail {
+
+// ICC profile header layout (ICC.1:2022 §4.2):
+//   bytes 24-35: dateTimeNumber  (six big-endian uInt16 — Y/M/D/h/m/s)
+//   bytes 84-99: Profile ID      (16 bytes; MD5 of header-with-zeros)
+inline constexpr std::size_t kIccDateTimeOffset = 24;
+inline constexpr std::size_t kIccDateTimeLength = 12;
+inline constexpr std::size_t kIccProfileIdOffset = 84;
+inline constexpr std::size_t kIccProfileIdLength = 16;
+
+// Pure byte-mutation function. When `epoch` has a value, overwrites bytes
+// 24-35 (creation date, big-endian Y/M/D/h/m/s) with the gmtime breakdown of
+// `*epoch` and zeros bytes 84-99 (Profile ID). When `epoch` is nullopt, the
+// buffer is untouched. Buffers shorter than 100 bytes are treated as
+// malformed and left alone. Never throws.
+void apply_icc_header_normalization(unsigned char *buf, std::size_t len, std::optional<std::time_t> epoch) noexcept;
+
+// Read SOURCE_DATE_EPOCH from the environment, cached via thread-safe
+// magic-static initialisation. Returns nullopt when unset or malformed.
+std::optional<std::time_t> read_source_date_epoch() noexcept;
+
+}// namespace Sipi::detail
+
+#endif

--- a/include/metadata/SipiIccDetail.h
+++ b/include/metadata/SipiIccDetail.h
@@ -29,13 +29,10 @@ inline constexpr std::size_t kIccProfileIdLength = 16;
 // Pure byte-mutation function. When `epoch` has a value, overwrites bytes
 // 24-35 (creation date, big-endian Y/M/D/h/m/s) with the gmtime breakdown of
 // `*epoch` and zeros bytes 84-99 (Profile ID). When `epoch` is nullopt, the
-// buffer is untouched. Buffers shorter than 100 bytes are treated as
-// malformed and left alone. Never throws.
+// buffer is untouched. Buffers shorter than 100 bytes, gmtime_r failures,
+// and years outside the ICC dateTimeNumber range (uint16) all bail without
+// mutating the buffer. Never throws.
 void apply_icc_header_normalization(unsigned char *buf, std::size_t len, std::optional<std::time_t> epoch) noexcept;
-
-// Read SOURCE_DATE_EPOCH from the environment, cached via thread-safe
-// magic-static initialisation. Returns nullopt when unset or malformed.
-std::optional<std::time_t> read_source_date_epoch() noexcept;
 
 }// namespace Sipi::detail
 

--- a/src/metadata/SipiExif.cpp
+++ b/src/metadata/SipiExif.cpp
@@ -5,6 +5,8 @@
 
 #include <climits>
 #include <cmath>
+#include <cstring>
+#include <memory>
 
 #include "SipiError.hpp"
 #include "metadata/SipiExif.h"
@@ -25,18 +27,22 @@ SipiExif::SipiExif(const unsigned char *exif, unsigned int len)
   //
   // first we save the binary exif... we use it later for constructing a binary exif again!
   //
-  binaryExif = new unsigned char[len];
-  memcpy(binaryExif, exif, len);
-  binary_size = len;
+  // Hold the buffer in a unique_ptr until decode succeeds. If
+  // Exiv2::ExifParser::decode throws (e.g. on malformed EXIF embedded in
+  // PNG text comments — see DEV-6333 PngRoundTrip approval test), the
+  // unique_ptr cleans up on stack unwind. Releasing into the raw member
+  // only after decode succeeds keeps the destructor's `delete[]` honest.
+  auto buf = std::make_unique<unsigned char[]>(len);
+  std::memcpy(buf.get(), exif, len);
 
-  //
-  // now we decode the binary exif
-  //
   try {
     byteorder = Exiv2::ExifParser::decode(exifData, exif, (uint32_t)len);
   } catch (Exiv2::Error &exiverr) {
     throw SipiError(exiverr.what());
   }
+
+  binaryExif = buf.release();
+  binary_size = len;
 }
 //============================================================================
 

--- a/src/metadata/SipiIcc.cpp
+++ b/src/metadata/SipiIcc.cpp
@@ -64,10 +64,18 @@ void apply_icc_header_normalization(unsigned char *buf, std::size_t len, std::op
   if (!epoch.has_value()) return;
   if (len < kIccProfileIdOffset + kIccProfileIdLength) return;
 
+  // POSIX gmtime_r returns NULL when the year doesn't fit `int tm_year`
+  // (e.g., 32-bit time_t platforms with a post-2038 epoch). A bogus
+  // SOURCE_DATE_EPOCH must not silently emit a 1900-stamped profile, so
+  // we no-op rather than write garbage. Bail also if the year is outside
+  // the ICC dateTimeNumber range (uInt16, [0, 65535]).
   std::tm tm{};
-  gmtime_r(&*epoch, &tm);// SOURCE_DATE_EPOCH is UTC by spec
+  if (gmtime_r(&*epoch, &tm) == nullptr) return;
+  const long year = static_cast<long>(tm.tm_year) + 1900;
+  if (year < 0 || year > 65535) return;
+
   unsigned char *p = buf + kIccDateTimeOffset;
-  put_be16(p + 0, static_cast<std::uint16_t>(tm.tm_year + 1900));
+  put_be16(p + 0, static_cast<std::uint16_t>(year));
   put_be16(p + 2, static_cast<std::uint16_t>(tm.tm_mon + 1));
   put_be16(p + 4, static_cast<std::uint16_t>(tm.tm_mday));
   put_be16(p + 6, static_cast<std::uint16_t>(tm.tm_hour));

--- a/src/metadata/SipiIcc.cpp
+++ b/src/metadata/SipiIcc.cpp
@@ -4,8 +4,14 @@
  */
 
 #include "metadata/SipiIcc.h"
+#include "metadata/SipiIccDetail.h"
 
+#include <cerrno>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
 #include <ctime>
+#include <optional>
 
 #include "Logger.h"
 
@@ -16,6 +22,62 @@
 
 #include "SipiImage.hpp"
 #include "shttps/makeunique.h"
+
+namespace Sipi::detail {
+
+namespace {
+void put_be16(unsigned char *p, std::uint16_t v) noexcept
+{
+  p[0] = static_cast<unsigned char>(v >> 8);
+  p[1] = static_cast<unsigned char>(v & 0xff);
+}
+}// namespace
+
+// Cache SOURCE_DATE_EPOCH on first call via thread-safe magic-static
+// initialisation. Re-checking the env var on every emit would be wasteful and
+// could yield inconsistent goldens if the value changes mid-run.
+//
+// The reproducible-builds.org spec recommends erroring on malformed values;
+// SIPI deliberately silently falls back (returns nullopt). This fix is
+// test-only — a SIPI binary aborting because someone in the shell exported a
+// bogus SOURCE_DATE_EPOCH would be a regression.
+std::optional<std::time_t> read_source_date_epoch() noexcept
+{
+  static const std::optional<std::time_t> cached = []() -> std::optional<std::time_t> {
+    const char *e = std::getenv("SOURCE_DATE_EPOCH");
+    if (e == nullptr || *e == '\0') return std::nullopt;
+    char *end = nullptr;
+    errno = 0;
+    long long v = std::strtoll(e, &end, 10);
+    if (errno != 0 || end == e || *end != '\0' || v < 0) return std::nullopt;
+    return static_cast<std::time_t>(v);
+  }();
+  return cached;
+}
+
+// Why zero the Profile ID: lcms2 may round-trip a non-zero ID from an
+// externally-authored input profile (Little-CMS issue #181); a non-zero ID
+// baked over a scrubbed date is meaningless. Production is unaffected because
+// production never sets SOURCE_DATE_EPOCH.
+void apply_icc_header_normalization(unsigned char *buf, std::size_t len, std::optional<std::time_t> epoch) noexcept
+{
+  if (!epoch.has_value()) return;
+  if (len < kIccProfileIdOffset + kIccProfileIdLength) return;
+
+  std::tm tm{};
+  gmtime_r(&*epoch, &tm);// SOURCE_DATE_EPOCH is UTC by spec
+  unsigned char *p = buf + kIccDateTimeOffset;
+  put_be16(p + 0, static_cast<std::uint16_t>(tm.tm_year + 1900));
+  put_be16(p + 2, static_cast<std::uint16_t>(tm.tm_mon + 1));
+  put_be16(p + 4, static_cast<std::uint16_t>(tm.tm_mday));
+  put_be16(p + 6, static_cast<std::uint16_t>(tm.tm_hour));
+  put_be16(p + 8, static_cast<std::uint16_t>(tm.tm_min));
+  put_be16(p + 10, static_cast<std::uint16_t>(tm.tm_sec));
+
+  std::memset(buf + kIccProfileIdOffset, 0, kIccProfileIdLength);
+}
+
+}// namespace Sipi::detail
 
 namespace Sipi {
 
@@ -208,7 +270,13 @@ unsigned char *SipiIcc::iccBytes(unsigned int &len)
     if (!cmsSaveProfileToMem(icc_profile, nullptr, &len))
       throw SipiError("cmsSaveProfileToMem failed");
     buf = new unsigned char[len];
-    if (!cmsSaveProfileToMem(icc_profile, buf, &len)) throw SipiError("cmsSaveProfileToMem failed");
+    if (!cmsSaveProfileToMem(icc_profile, buf, &len)) {
+      delete[] buf;
+      throw SipiError("cmsSaveProfileToMem failed");
+    }
+    // ICC normalization for reproducibility — no-op unless SOURCE_DATE_EPOCH
+    // is set in the environment. Production never sets it.
+    detail::apply_icc_header_normalization(buf, len, detail::read_source_date_epoch());
   }
   return buf;
 }

--- a/src/metadata/SipiIcc.cpp
+++ b/src/metadata/SipiIcc.cpp
@@ -23,15 +23,9 @@
 #include "SipiImage.hpp"
 #include "shttps/makeunique.h"
 
-namespace Sipi::detail {
+namespace Sipi {
 
 namespace {
-void put_be16(unsigned char *p, std::uint16_t v) noexcept
-{
-  p[0] = static_cast<unsigned char>(v >> 8);
-  p[1] = static_cast<unsigned char>(v & 0xff);
-}
-}// namespace
 
 // Cache SOURCE_DATE_EPOCH on first call via thread-safe magic-static
 // initialisation. Re-checking the env var on every emit would be wasteful and
@@ -41,6 +35,10 @@ void put_be16(unsigned char *p, std::uint16_t v) noexcept
 // SIPI deliberately silently falls back (returns nullopt). This fix is
 // test-only — a SIPI binary aborting because someone in the shell exported a
 // bogus SOURCE_DATE_EPOCH would be a regression.
+//
+// Not exposed via SipiIccDetail.h because unit tests inject epochs directly
+// into apply_icc_header_normalization(); the env-var parser is implicitly
+// covered by the nullopt-equivalent branch.
 std::optional<std::time_t> read_source_date_epoch() noexcept
 {
   static const std::optional<std::time_t> cached = []() -> std::optional<std::time_t> {
@@ -54,6 +52,16 @@ std::optional<std::time_t> read_source_date_epoch() noexcept
   }();
   return cached;
 }
+
+void put_be16(unsigned char *p, std::uint16_t v) noexcept
+{
+  p[0] = static_cast<unsigned char>(v >> 8);
+  p[1] = static_cast<unsigned char>(v & 0xff);
+}
+
+}// namespace
+
+namespace detail {
 
 // Why zero the Profile ID: lcms2 may round-trip a non-zero ID from an
 // externally-authored input profile (Little-CMS issue #181); a non-zero ID
@@ -85,9 +93,7 @@ void apply_icc_header_normalization(unsigned char *buf, std::size_t len, std::op
   std::memset(buf + kIccProfileIdOffset, 0, kIccProfileIdLength);
 }
 
-}// namespace Sipi::detail
-
-namespace Sipi {
+}// namespace detail
 
 void icc_error_logger(cmsContext ContextID, cmsUInt32Number ErrorCode, const char *Text)
 {
@@ -284,7 +290,7 @@ unsigned char *SipiIcc::iccBytes(unsigned int &len)
     }
     // ICC normalization for reproducibility — no-op unless SOURCE_DATE_EPOCH
     // is set in the environment. Production never sets it.
-    detail::apply_icc_header_normalization(buf, len, detail::read_source_date_epoch());
+    detail::apply_icc_header_normalization(buf, len, read_source_date_epoch());
   }
   return buf;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -189,6 +189,9 @@ add_subdirectory(unit/cache)
 # To only run this single test, run from inside the build directory '(cd test/unit && ./sipiimage/sipiimage)'
 add_subdirectory(unit/sipiimage)
 
+# SipiIcc helper tests (SOURCE_DATE_EPOCH normalization)
+add_subdirectory(unit/sipiicc)
+
 # Logger tests
 # To only run this single test, run from inside the build directory '(cd test/unit && ./sipiimage/logger)'
 add_subdirectory(unit/logger)

--- a/test/_test_data/images/unit/.gitignore
+++ b/test/_test_data/images/unit/.gitignore
@@ -35,3 +35,4 @@
 !watermark_alpha.tif
 !MaoriFigure.jpg
 !MaoriFigureWatermark.jpg
+!sample_with_icc.png

--- a/test/_test_data/images/unit/sample_with_icc.png
+++ b/test/_test_data/images/unit/sample_with_icc.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad2bab78d4789fe2d34defb52e9aa481887e1c8dae0c5200469aa9038bef6eb8
+size 296786

--- a/test/approval/CHANGELOG.approval.md
+++ b/test/approval/CHANGELOG.approval.md
@@ -18,3 +18,42 @@ Format: one row per re-approval, newest at the top.
 | Date | PR | Golden(s) | Cause | Visual diff verified by |
 |------|-----|-----------|-------|-------------------------|
 | _empty_ | | | | |
+
+## ICC creation-date determinism (`SOURCE_DATE_EPOCH`)
+
+`ImageEncodeBaseline.*` goldens for JPEG, PNG, and JP2 outputs — and
+any TIFF that carries through an embedded ICC profile — are byte-stable
+**only when the `SOURCE_DATE_EPOCH` environment variable is set**.
+`SipiIcc::iccBytes()` reads the variable once (cached thread-safely)
+and overwrites bytes 24-35 of every emitted profile (the ICC creation
+date) plus zeros bytes 84-99 (the Profile ID). Without the env var,
+lcms2's `cmsCreateProfilePlaceholder` stamps the wall-clock time and
+the seconds field drifts by one byte across consecutive runs.
+
+CMake injects `SOURCE_DATE_EPOCH=946684800` (2000-01-01T00:00:00Z UTC,
+an arbitrary SIPI-test convention) for `sipi.approvaltests` via
+`set_tests_properties(... ENVIRONMENT ...)` in
+`test/approval/CMakeLists.txt`. So under `ctest -L approval` everything
+is byte-deterministic.
+
+A maintainer running `sipi.approvaltests` directly outside ctest must
+export the same value first:
+
+```bash
+SOURCE_DATE_EPOCH=946684800 ./sipi.approvaltests \
+  --gtest_filter='ImageEncodeBaseline.*'
+```
+
+Without it, expect `.received.*` files for any test whose pipeline
+emits an ICC profile (`JpegFullToJpegDownscaled`, `JpegFullToPng`,
+`J2kRegionToTiff`, `J2kRegionToJpeg`, `J2kRegionToJp2`,
+`CmykTiffDownscaled`, `CmykTiffToJpeg`, `CielabTiffToJpeg`,
+`JpegRotatedToJpeg`, `PngRoundTrip`, `TiffRegionRoundTrip`,
+`TiffToPng`). The `.received.*` will differ from the committed golden
+in exactly twelve bytes per embedded ICC profile — the dateTimeNumber
+field. This is expected, not a regression.
+
+Production runtime is unaffected: SIPI never sets `SOURCE_DATE_EPOCH`,
+so deployed binaries continue to embed wall-clock-stamped ICC headers
+verbatim from lcms2. See `docs/adr/0002-icc-profile-determinism-test-
+only.md`.

--- a/test/approval/CHANGELOG.approval.md
+++ b/test/approval/CHANGELOG.approval.md
@@ -17,7 +17,7 @@ Format: one row per re-approval, newest at the top.
 
 | Date | PR | Golden(s) | Cause | Visual diff verified by |
 |------|-----|-----------|-------|-------------------------|
-| _empty_ | | | | |
+| 2026-04-29 | sipi#587 (DEV-6333) | `ImageEncodeBaseline.TiffRegionRoundTrip.approved.tif`, `ImageEncodeBaseline.CmykTiffDownscaled.approved.tif` | First introduction of `SOURCE_DATE_EPOCH` rewrite in `SipiIcc::iccBytes()`. Both inputs (`lena512.tif` Generic-Gray-Gamma-2.2 ICC, `cmyk.tif` SWOP CMYK ICC) carry an embedded ICC profile that round-trips through `cmsSaveProfileToMem`, so under env-var injection their date bytes (24-35) shift to 2000-01-01T00:00:00Z. `cmp -l` confirmed the diff is exactly the 12-byte `dateTimeNumber` field per profile — no pixel-level drift. | n/a — byte-level diff confirmed surgical via `cmp -l`; pixel content unchanged |
 
 ## ICC creation-date determinism (`SOURCE_DATE_EPOCH`)
 

--- a/test/approval/CMakeLists.txt
+++ b/test/approval/CMakeLists.txt
@@ -11,3 +11,13 @@ target_link_libraries(${TEST_NAME} ApprovalTests::ApprovalTests libgtest libsipi
 target_compile_definitions(${TEST_NAME} PRIVATE -DAPPROVAL_TESTS_HIDE_DEPRECATED_CODE=1)
 add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
 set_property(TEST ${TEST_NAME} PROPERTY LABELS approval)
+
+# Pin the ICC profile creation date so JPEG/PNG/JP2 outputs are byte-exact
+# under ctest. SipiIcc::iccBytes() reads SOURCE_DATE_EPOCH and overwrites
+# bytes 24-35 of the serialized profile when set; without it lcms2 stamps
+# a wall-clock time and the goldens drift by one byte per run. CMake's
+# ENVIRONMENT property replaces (does not append to) the parent env.
+# Production never sets the var, so behaviour outside ctest is unchanged.
+# 946684800 = 2000-01-01T00:00:00Z UTC (arbitrary SIPI-test convention).
+set_tests_properties(${TEST_NAME} PROPERTIES
+    ENVIRONMENT "SOURCE_DATE_EPOCH=946684800")

--- a/test/approval/approval_tests/ImageEncodeBaseline.CielabTiffToJpeg.approved.jpg
+++ b/test/approval/approval_tests/ImageEncodeBaseline.CielabTiffToJpeg.approved.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01a9388abd6a36da68a84e77f911afcf3688775df4031880368e194739720051
+size 17989

--- a/test/approval/approval_tests/ImageEncodeBaseline.CmykTiffDownscaled.approved.tif
+++ b/test/approval/approval_tests/ImageEncodeBaseline.CmykTiffDownscaled.approved.tif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5f00a9b17ef1e9384ae26207b12ac225a869df9f61a2d9eb43b0fdac7041b484
+oid sha256:e733a7f92070b6dd6145c8bf8978d024b972aa89f94f70f3bedf25b4f70f0871
 size 1336758

--- a/test/approval/approval_tests/ImageEncodeBaseline.CmykTiffToJpeg.approved.jpg
+++ b/test/approval/approval_tests/ImageEncodeBaseline.CmykTiffToJpeg.approved.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bec90848d5e107441f46afbdb8d71f31800d7957204fedd5917b740b7c2b3100
+size 21306

--- a/test/approval/approval_tests/ImageEncodeBaseline.J2kRegionToJp2.approved.jp2
+++ b/test/approval/approval_tests/ImageEncodeBaseline.J2kRegionToJp2.approved.jp2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0989851a7fe19e1fb1fe1925261c3b4abaa87f3080f95ae8358f66e3810572cf
+size 31804

--- a/test/approval/approval_tests/ImageEncodeBaseline.J2kRegionToJpeg.approved.jpg
+++ b/test/approval/approval_tests/ImageEncodeBaseline.J2kRegionToJpeg.approved.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4541d8495e56095f4ec223cde15a0059dd4292e91dd123c6301d0ac4c288a35
+size 28588

--- a/test/approval/approval_tests/ImageEncodeBaseline.J2kRegionToTiff.approved.tif
+++ b/test/approval/approval_tests/ImageEncodeBaseline.J2kRegionToTiff.approved.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:feaf55f3af305acdf007d8c467a98edd3e2e222286c18a960283090545df4215
+size 35218

--- a/test/approval/approval_tests/ImageEncodeBaseline.JpegFullToJpegDownscaled.approved.jpg
+++ b/test/approval/approval_tests/ImageEncodeBaseline.JpegFullToJpegDownscaled.approved.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71e1a3f3d842f200768e2583ff61ab2ffdf0517d97dcd0d1e53a9a72c7bc6b0d
+size 80858

--- a/test/approval/approval_tests/ImageEncodeBaseline.JpegFullToPng.approved.png
+++ b/test/approval/approval_tests/ImageEncodeBaseline.JpegFullToPng.approved.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0ce809cdc22937f62a8cc52728e89ade6ad29ab9e6687c41b28ff460ec913f3
+size 296622

--- a/test/approval/approval_tests/ImageEncodeBaseline.JpegRotatedToJpeg.approved.jpg
+++ b/test/approval/approval_tests/ImageEncodeBaseline.JpegRotatedToJpeg.approved.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94767642059b5233e116952030ad126dbb090a7ecec7b3edb032261067de1616
+size 80651

--- a/test/approval/approval_tests/ImageEncodeBaseline.PngRoundTrip.approved.png
+++ b/test/approval/approval_tests/ImageEncodeBaseline.PngRoundTrip.approved.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9f95dcfb9f67293ebf13c7fe8199456876b388862256c4fbe4d26e9c809b3f6
+size 296770

--- a/test/approval/approval_tests/ImageEncodeBaseline.TiffRegionRoundTrip.approved.tif
+++ b/test/approval/approval_tests/ImageEncodeBaseline.TiffRegionRoundTrip.approved.tif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5d5bbf99b81fc83635e1ed10ad43c165c0c30134b48846f74e1694729b257f6f
+oid sha256:f7f6108673f5b3873d48a21a5a722a9d48e6af7dba9ef3de5c22573a81182fc1
 size 70210

--- a/test/approval/approval_tests/ImageEncodeBaseline.TiffToPng.approved.png
+++ b/test/approval/approval_tests/ImageEncodeBaseline.TiffToPng.approved.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ccbe8c3e84a6686558f786416ab36d0f8a31210aa88989336a432b462758ae0
+size 75278

--- a/test/approval/image_encode_baseline_test.cpp
+++ b/test/approval/image_encode_baseline_test.cpp
@@ -4,32 +4,35 @@
  * AGPL-3.0-or-later
  */
 
-// Image-encode bit-exactness baseline (plan §6.1).
+// Image-encode bit-exactness baseline.
 //
-// Captures byte-for-byte TIFF output for representative inputs exercised
-// through the SipiImage IIIF pipeline (region/size/rotation + format
-// conversion). Approved goldens become the regression gate for every dep
-// migration in PRs 1-4 of the Nix-native build series — a libtiff /
-// libjpeg / Kakadu / lcms2 version bump that changes even one output byte
+// Captures byte-for-byte output across TIFF / JPEG / PNG / JP2 for
+// representative inputs exercised through the SipiImage IIIF pipeline
+// (region / size / rotation + format conversion). Approved goldens are
+// the regression gate for every dep migration — a libtiff / libjpeg /
+// libpng / Kakadu / lcms2 version bump that changes even one output byte
 // trips the test, gating the migration.
 //
-// Why TIFF-only: JPEG and PNG outputs from SipiImage embed the wall-clock
-// time into ICC profile creation-date headers (seconds field varies per
-// run), so byte-for-byte comparison of those formats is unstable across
-// invocations. TIFF outputs are deterministic. Decode-side coverage of
-// libjpeg/libpng/Kakadu is preserved by reading those formats as inputs.
+// Determinism gate. JPEG / PNG / JP2-decode outputs go through lcms2's
+// profile generator, which stamps wall-clock UTC into ICC bytes 24-35.
+// SipiIcc::iccBytes() rewrites those bytes (and zeros the Profile ID at
+// bytes 84-99) when SOURCE_DATE_EPOCH is set. CMake injects the env var
+// for sipi.approvaltests via set_tests_properties, so byte-for-byte
+// comparison is stable under ctest. Production never sets the var and
+// retains lcms2's wall-clock behaviour. See docs/adr/0002-icc-profile-
+// determinism-test-only.md and test/approval/CHANGELOG.approval.md.
 //
-// Capturing goldens (one-time, before this test becomes a gate):
-//   1. Build + run locally:
+// Capturing goldens (one-time, before a test becomes a gate):
+//   1. Build + run locally with the env var injected:
 //        nix develop --command bash -c \
 //          "cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug && \
 //           cmake --build build --target sipi.approvaltests --parallel && \
-//           cd build/test/approval && ./sipi.approvaltests \
-//             --gtest_filter='ImageEncodeBaseline.*'"
-//   2. Tests SKIP with paths of `.received.tif` files captured under
+//           cd build/test/approval && SOURCE_DATE_EPOCH=946684800 \
+//             ./sipi.approvaltests --gtest_filter='ImageEncodeBaseline.*'"
+//   2. Tests SKIP with paths of `.received.<ext>` files captured under
 //      test/approval/approval_tests/. Inspect the outputs.
-//   3. For each `<name>.received.tif`, rename to `<name>.approved.tif` and
-//      commit alongside this source file.
+//   3. For each `<name>.received.<ext>`, rename to `<name>.approved.<ext>`,
+//      track in Git LFS, and commit alongside this source file.
 //
 // Re-approval procedure for intentional drift after goldens land — see
 // test/approval/CHANGELOG.approval.md.
@@ -165,12 +168,6 @@ TEST(ImageEncodeBaseline, TiffRegionRoundTrip)
   verify_or_capture(out, "ImageEncodeBaseline.TiffRegionRoundTrip");
 }
 
-// JP2 → TIFF is intentionally NOT covered as a bit-exact gate: the JP2
-// reader path passes through lcms2's ICC profile generator, which embeds
-// a fresh wall-clock timestamp into the ICC profile header on every
-// run. Kakadu decode is exercised by the e2e Rust tests and existing
-// unit tests; bit-exactness on JP2 inputs awaits an upstream fix.
-
 // CMYK TIFF -> downscaled TIFF — exercises the CMYK colour-space path.
 TEST(ImageEncodeBaseline, CmykTiffDownscaled)
 {
@@ -199,4 +196,126 @@ TEST(ImageEncodeBaseline, JpegRotatedDownscaledTiff)
   std::string out = "/tmp/sipi_baseline_jpeg_rotated_downscaled.tif";
   encode(in, out, "tif", nullptr, std::make_shared<Sipi::SipiSize>("256,"), 90.0f);
   verify_or_capture(out, "ImageEncodeBaseline.JpegRotatedDownscaledTiff");
+}
+
+// ---------------------------------------------------------------------------
+// JPEG / PNG / JP2 outputs — gated on SOURCE_DATE_EPOCH being set so lcms2's
+// wall-clock-stamped ICC creation date is overwritten with a fixed value.
+// CMake injects the env var for the ctest-driven invocation; running this
+// binary directly requires `SOURCE_DATE_EPOCH=946684800 ./sipi.approvaltests`.
+// ---------------------------------------------------------------------------
+
+// JPEG decode + downscale + JPEG encode — exercises the lcms2 ICC emit
+// path on the libjpeg writer.
+TEST(ImageEncodeBaseline, JpegFullToJpegDownscaled)
+{
+  std::string in = test_images + "unit/gray_with_icc_another.jpg";
+  if (!file_exists(in)) GTEST_SKIP() << "Test image not found: " << in;
+  std::string out = "/tmp/sipi_baseline_jpeg_full_to_jpeg_downscaled.jpg";
+  encode(in, out, "jpg", nullptr, std::make_shared<Sipi::SipiSize>("256,"));
+  verify_or_capture(out, "ImageEncodeBaseline.JpegFullToJpegDownscaled");
+}
+
+// JPEG decode + downscale + PNG encode — exercises the lcms2 ICC emit
+// path on the libpng writer.
+TEST(ImageEncodeBaseline, JpegFullToPng)
+{
+  std::string in = test_images + "unit/gray_with_icc_another.jpg";
+  if (!file_exists(in)) GTEST_SKIP() << "Test image not found: " << in;
+  std::string out = "/tmp/sipi_baseline_jpeg_full_to_png.png";
+  encode(in, out, "png", nullptr, std::make_shared<Sipi::SipiSize>("256,"));
+  verify_or_capture(out, "ImageEncodeBaseline.JpegFullToPng");
+}
+
+// JP2 decode + region crop + TIFF encode — Kakadu decode + libtiff encode.
+// JP2 decode synthesizes an ICC profile via lcms2 (the path that needs
+// SOURCE_DATE_EPOCH for byte-exactness).
+TEST(ImageEncodeBaseline, J2kRegionToTiff)
+{
+  std::string in = test_images + "unit/gray_with_icc.jp2";
+  if (!file_exists(in)) GTEST_SKIP() << "Test image not found: " << in;
+  std::string out = "/tmp/sipi_baseline_j2k_region_to_tiff.tif";
+  auto region = std::make_shared<Sipi::SipiRegion>(0, 0, 256, 256);
+  encode(in, out, "tif", region, nullptr);
+  verify_or_capture(out, "ImageEncodeBaseline.J2kRegionToTiff");
+}
+
+// JP2 decode + region crop + JPEG encode — Kakadu decode + libjpeg encode.
+TEST(ImageEncodeBaseline, J2kRegionToJpeg)
+{
+  std::string in = test_images + "unit/gray_with_icc.jp2";
+  if (!file_exists(in)) GTEST_SKIP() << "Test image not found: " << in;
+  std::string out = "/tmp/sipi_baseline_j2k_region_to_jpeg.jpg";
+  auto region = std::make_shared<Sipi::SipiRegion>(0, 0, 256, 256);
+  encode(in, out, "jpg", region, nullptr);
+  verify_or_capture(out, "ImageEncodeBaseline.J2kRegionToJpeg");
+}
+
+// JP2 decode + region crop + JP2 encode — the Goal-3 determinism check.
+// Kakadu's jp2_colour::init() embeds the (already-normalized) ICC bytes;
+// this golden verifies the encoder doesn't reframe them.
+TEST(ImageEncodeBaseline, J2kRegionToJp2)
+{
+  std::string in = test_images + "unit/gray_with_icc.jp2";
+  if (!file_exists(in)) GTEST_SKIP() << "Test image not found: " << in;
+  std::string out = "/tmp/sipi_baseline_j2k_region_to_jp2.jp2";
+  auto region = std::make_shared<Sipi::SipiRegion>(0, 0, 256, 256);
+  encode(in, out, "jpx", region, nullptr);
+  verify_or_capture(out, "ImageEncodeBaseline.J2kRegionToJp2");
+}
+
+// CMYK TIFF -> downscaled JPEG — exercises CMYK -> sRGB lcms2 colour
+// conversion + libjpeg encode.
+TEST(ImageEncodeBaseline, CmykTiffToJpeg)
+{
+  std::string in = test_images + "unit/cmyk.tif";
+  if (!file_exists(in)) GTEST_SKIP() << "Test image not found: " << in;
+  std::string out = "/tmp/sipi_baseline_cmyk_tiff_to_jpeg.jpg";
+  encode(in, out, "jpg", nullptr, std::make_shared<Sipi::SipiSize>("256,"));
+  verify_or_capture(out, "ImageEncodeBaseline.CmykTiffToJpeg");
+}
+
+// CIELab TIFF -> downscaled JPEG — exercises CIELab -> sRGB lcms2 colour
+// conversion + libjpeg encode.
+TEST(ImageEncodeBaseline, CielabTiffToJpeg)
+{
+  std::string in = test_images + "unit/cielab.tif";
+  if (!file_exists(in)) GTEST_SKIP() << "Test image not found: " << in;
+  std::string out = "/tmp/sipi_baseline_cielab_tiff_to_jpeg.jpg";
+  encode(in, out, "jpg", nullptr, std::make_shared<Sipi::SipiSize>("256,"));
+  verify_or_capture(out, "ImageEncodeBaseline.CielabTiffToJpeg");
+}
+
+// JPEG decode + 90-degree rotation + JPEG encode — rotation path on the
+// lossy encoder.
+TEST(ImageEncodeBaseline, JpegRotatedToJpeg)
+{
+  std::string in = test_images + "unit/gray_with_icc_another.jpg";
+  if (!file_exists(in)) GTEST_SKIP() << "Test image not found: " << in;
+  std::string out = "/tmp/sipi_baseline_jpeg_rotated_to_jpeg.jpg";
+  encode(in, out, "jpg", nullptr, std::make_shared<Sipi::SipiSize>("256,"), 90.0f);
+  verify_or_capture(out, "ImageEncodeBaseline.JpegRotatedToJpeg");
+}
+
+// PNG decode + downscale + PNG encode — libpng round-trip through the
+// lcms2 ICC emit path. Fixture is a PNG-with-embedded-ICC committed
+// alongside the goldens.
+TEST(ImageEncodeBaseline, PngRoundTrip)
+{
+  std::string in = test_images + "unit/gray_with_icc.png";
+  if (!file_exists(in)) GTEST_SKIP() << "Test image not found: " << in;
+  std::string out = "/tmp/sipi_baseline_png_round_trip.png";
+  encode(in, out, "png", nullptr, std::make_shared<Sipi::SipiSize>("256,"));
+  verify_or_capture(out, "ImageEncodeBaseline.PngRoundTrip");
+}
+
+// CIELab TIFF -> downscaled PNG — libtiff decode + libpng encode +
+// lcms2 ICC emit.
+TEST(ImageEncodeBaseline, TiffToPng)
+{
+  std::string in = test_images + "unit/cielab.tif";
+  if (!file_exists(in)) GTEST_SKIP() << "Test image not found: " << in;
+  std::string out = "/tmp/sipi_baseline_tiff_to_png.png";
+  encode(in, out, "png", nullptr, std::make_shared<Sipi::SipiSize>("256,"));
+  verify_or_capture(out, "ImageEncodeBaseline.TiffToPng");
 }

--- a/test/approval/image_encode_baseline_test.cpp
+++ b/test/approval/image_encode_baseline_test.cpp
@@ -209,7 +209,7 @@ TEST(ImageEncodeBaseline, JpegRotatedDownscaledTiff)
 // path on the libjpeg writer.
 TEST(ImageEncodeBaseline, JpegFullToJpegDownscaled)
 {
-  std::string in = test_images + "unit/gray_with_icc_another.jpg";
+  std::string in = test_images + "unit/MaoriFigureWatermark.jpg";
   if (!file_exists(in)) GTEST_SKIP() << "Test image not found: " << in;
   std::string out = "/tmp/sipi_baseline_jpeg_full_to_jpeg_downscaled.jpg";
   encode(in, out, "jpg", nullptr, std::make_shared<Sipi::SipiSize>("256,"));
@@ -220,7 +220,7 @@ TEST(ImageEncodeBaseline, JpegFullToJpegDownscaled)
 // path on the libpng writer.
 TEST(ImageEncodeBaseline, JpegFullToPng)
 {
-  std::string in = test_images + "unit/gray_with_icc_another.jpg";
+  std::string in = test_images + "unit/MaoriFigureWatermark.jpg";
   if (!file_exists(in)) GTEST_SKIP() << "Test image not found: " << in;
   std::string out = "/tmp/sipi_baseline_jpeg_full_to_png.png";
   encode(in, out, "png", nullptr, std::make_shared<Sipi::SipiSize>("256,"));
@@ -290,7 +290,7 @@ TEST(ImageEncodeBaseline, CielabTiffToJpeg)
 // lossy encoder.
 TEST(ImageEncodeBaseline, JpegRotatedToJpeg)
 {
-  std::string in = test_images + "unit/gray_with_icc_another.jpg";
+  std::string in = test_images + "unit/MaoriFigureWatermark.jpg";
   if (!file_exists(in)) GTEST_SKIP() << "Test image not found: " << in;
   std::string out = "/tmp/sipi_baseline_jpeg_rotated_to_jpeg.jpg";
   encode(in, out, "jpg", nullptr, std::make_shared<Sipi::SipiSize>("256,"), 90.0f);
@@ -302,7 +302,7 @@ TEST(ImageEncodeBaseline, JpegRotatedToJpeg)
 // alongside the goldens.
 TEST(ImageEncodeBaseline, PngRoundTrip)
 {
-  std::string in = test_images + "unit/gray_with_icc.png";
+  std::string in = test_images + "unit/sample_with_icc.png";
   if (!file_exists(in)) GTEST_SKIP() << "Test image not found: " << in;
   std::string out = "/tmp/sipi_baseline_png_round_trip.png";
   encode(in, out, "png", nullptr, std::make_shared<Sipi::SipiSize>("256,"));

--- a/test/unit/sipiicc/CMakeLists.txt
+++ b/test/unit/sipiicc/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(TEST_NAME sipi_icc_normalize_test)
+
+file(GLOB SRCS CONFIGURE_DEPENDS *.cpp)
+
+add_executable(${TEST_NAME} ${SRCS})
+target_link_libraries(${TEST_NAME} libgtest libsipi_testable)
+
+install(TARGETS ${TEST_NAME} DESTINATION bin)
+
+add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
+set_property(TEST ${TEST_NAME} PROPERTY LABELS unit)

--- a/test/unit/sipiicc/icc_normalize_test.cpp
+++ b/test/unit/sipiicc/icc_normalize_test.cpp
@@ -1,0 +1,168 @@
+/*
+ * Copyright © 2026 Swiss National Data and Service Center for the Humanities
+ * and/or DaSCH Service Platform contributors. SPDX-License-Identifier:
+ * AGPL-3.0-or-later
+ */
+
+// Unit tests for Sipi::detail::apply_icc_header_normalization — the pure
+// byte-mutation function that backs SipiIcc::iccBytes()'s SOURCE_DATE_EPOCH
+// reproducibility hook. Tests pass an explicit epoch directly so they don't
+// have to fight with the production magic-static cache that backs
+// read_source_date_epoch().
+
+#include "metadata/SipiIccDetail.h"
+
+#include "gtest/gtest.h"
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace {
+
+// Build a synthetic ICC profile buffer of the given size, filled with 0xAA so
+// any spot we don't intentionally write is visibly distinct from a zero.
+std::vector<unsigned char> make_synthetic_icc(std::size_t size, unsigned char fill = 0xAA)
+{
+  return std::vector<unsigned char>(size, fill);
+}
+
+constexpr std::time_t kY2k = 946684800;// 2000-01-01T00:00:00Z UTC
+
+// Expected creation-date bytes for kY2k under the ICC.1:2022 §4.2 layout:
+// six big-endian uInt16 fields — year, month, day, hour, minute, second.
+constexpr std::array<unsigned char, 12> kY2kDateBytes = {
+  0x07, 0xD0,// 2000
+  0x00, 0x01,// 01
+  0x00, 0x01,// 01
+  0x00, 0x00,// 00
+  0x00, 0x00,// 00
+  0x00, 0x00,// 00
+};
+
+}// namespace
+
+// AC: SOURCE_DATE_EPOCH unset → buffer unchanged.
+TEST(SipiIccNormalize, NoEpochLeavesBufferUnchanged)
+{
+  auto buf = make_synthetic_icc(256);
+  auto original = buf;
+
+  Sipi::detail::apply_icc_header_normalization(buf.data(), buf.size(), std::nullopt);
+
+  EXPECT_EQ(buf, original);
+}
+
+// AC: SOURCE_DATE_EPOCH=946684800 → bytes 24-35 = 07D0 0001 0001 0000 0000 0000.
+TEST(SipiIccNormalize, EpochY2kWritesExpectedDateBytes)
+{
+  auto buf = make_synthetic_icc(256);
+
+  Sipi::detail::apply_icc_header_normalization(buf.data(), buf.size(), kY2k);
+
+  for (std::size_t i = 0; i < kY2kDateBytes.size(); ++i) {
+    EXPECT_EQ(buf[Sipi::detail::kIccDateTimeOffset + i], kY2kDateBytes[i])
+      << "mismatch at date byte " << i;
+  }
+}
+
+// AC: SOURCE_DATE_EPOCH=946684800 → bytes 84-99 zeroed.
+TEST(SipiIccNormalize, EpochY2kZerosProfileId)
+{
+  auto buf = make_synthetic_icc(256);
+
+  Sipi::detail::apply_icc_header_normalization(buf.data(), buf.size(), kY2k);
+
+  for (std::size_t i = 0; i < Sipi::detail::kIccProfileIdLength; ++i) {
+    EXPECT_EQ(buf[Sipi::detail::kIccProfileIdOffset + i], 0u) << "non-zero ID byte at " << i;
+  }
+}
+
+// AC: non-zero Profile ID input → ID zeroed when flag is set (no throw).
+TEST(SipiIccNormalize, NonZeroProfileIdIsScrubbed)
+{
+  auto buf = make_synthetic_icc(256);
+  // Plant a recognizable non-zero ID (this is what lcms2 might leave behind
+  // after round-tripping an externally-authored profile — see Little-CMS #181).
+  for (std::size_t i = 0; i < Sipi::detail::kIccProfileIdLength; ++i) {
+    buf[Sipi::detail::kIccProfileIdOffset + i] = static_cast<unsigned char>(0xC0 + i);
+  }
+
+  Sipi::detail::apply_icc_header_normalization(buf.data(), buf.size(), kY2k);
+
+  for (std::size_t i = 0; i < Sipi::detail::kIccProfileIdLength; ++i) {
+    EXPECT_EQ(buf[Sipi::detail::kIccProfileIdOffset + i], 0u);
+  }
+}
+
+// AC: truncated buffer → no-op (no throw, no crash).
+TEST(SipiIccNormalize, TruncatedBufferIsNoOp)
+{
+  // Buffer shorter than offset+length of the Profile ID field — anything in
+  // the date region exists, but we still bail to avoid an out-of-bounds memset.
+  auto buf = make_synthetic_icc(50);
+  auto original = buf;
+
+  Sipi::detail::apply_icc_header_normalization(buf.data(), buf.size(), kY2k);
+
+  EXPECT_EQ(buf, original);
+}
+
+TEST(SipiIccNormalize, EmptyBufferIsNoOp)
+{
+  std::vector<unsigned char> buf;
+  EXPECT_NO_THROW(Sipi::detail::apply_icc_header_normalization(buf.data(), buf.size(), kY2k));
+}
+
+// AC: idempotent (helper run twice produces identical bytes).
+TEST(SipiIccNormalize, IsIdempotent)
+{
+  auto buf = make_synthetic_icc(256);
+
+  Sipi::detail::apply_icc_header_normalization(buf.data(), buf.size(), kY2k);
+  auto first = buf;
+  Sipi::detail::apply_icc_header_normalization(buf.data(), buf.size(), kY2k);
+
+  EXPECT_EQ(buf, first);
+}
+
+// AC (covered indirectly): malformed SOURCE_DATE_EPOCH → no-op. The env
+// parser in read_source_date_epoch() returns nullopt for malformed input,
+// which routes through the apply function as the "no-op" branch tested here.
+// We don't separately test the parser because its result is cached via
+// magic-static and would couple every test to one process-wide env state.
+TEST(SipiIccNormalize, NulloptEpochMatchesMalformedEnvBehaviour)
+{
+  auto buf = make_synthetic_icc(200);
+  auto original = buf;
+
+  Sipi::detail::apply_icc_header_normalization(buf.data(), buf.size(), std::nullopt);
+
+  EXPECT_EQ(buf, original);
+}
+
+// Sanity: only the documented byte ranges are touched.
+TEST(SipiIccNormalize, OnlyDateAndProfileIdRangesAreMutated)
+{
+  auto buf = make_synthetic_icc(256, 0xAA);
+
+  Sipi::detail::apply_icc_header_normalization(buf.data(), buf.size(), kY2k);
+
+  // Every byte before the date field is untouched.
+  for (std::size_t i = 0; i < Sipi::detail::kIccDateTimeOffset; ++i) {
+    EXPECT_EQ(buf[i], 0xAAu) << "byte " << i << " before date field was touched";
+  }
+  // Bytes between the date field and the Profile ID are untouched.
+  for (std::size_t i = Sipi::detail::kIccDateTimeOffset + Sipi::detail::kIccDateTimeLength;
+       i < Sipi::detail::kIccProfileIdOffset;
+       ++i) {
+    EXPECT_EQ(buf[i], 0xAAu) << "byte " << i << " between fields was touched";
+  }
+  // Every byte after the Profile ID is untouched.
+  for (std::size_t i = Sipi::detail::kIccProfileIdOffset + Sipi::detail::kIccProfileIdLength;
+       i < buf.size();
+       ++i) {
+    EXPECT_EQ(buf[i], 0xAAu) << "byte " << i << " after Profile ID was touched";
+  }
+}

--- a/test/unit/sipiicc/icc_normalize_test.cpp
+++ b/test/unit/sipiicc/icc_normalize_test.cpp
@@ -96,23 +96,16 @@ TEST(SipiIccNormalize, NonZeroProfileIdIsScrubbed)
   }
 }
 
-// AC: truncated buffer → no-op (no throw, no crash).
+// AC: truncated buffer → no-op (no throw, no crash). Covers the empty-buffer
+// case as well — size 0 < 100 takes the same branch.
 TEST(SipiIccNormalize, TruncatedBufferIsNoOp)
 {
-  // Buffer shorter than offset+length of the Profile ID field — anything in
-  // the date region exists, but we still bail to avoid an out-of-bounds memset.
   auto buf = make_synthetic_icc(50);
   auto original = buf;
 
   Sipi::detail::apply_icc_header_normalization(buf.data(), buf.size(), kY2k);
 
   EXPECT_EQ(buf, original);
-}
-
-TEST(SipiIccNormalize, EmptyBufferIsNoOp)
-{
-  std::vector<unsigned char> buf;
-  EXPECT_NO_THROW(Sipi::detail::apply_icc_header_normalization(buf.data(), buf.size(), kY2k));
 }
 
 // AC: idempotent (helper run twice produces identical bytes).
@@ -125,21 +118,6 @@ TEST(SipiIccNormalize, IsIdempotent)
   Sipi::detail::apply_icc_header_normalization(buf.data(), buf.size(), kY2k);
 
   EXPECT_EQ(buf, first);
-}
-
-// AC (covered indirectly): malformed SOURCE_DATE_EPOCH → no-op. The env
-// parser in read_source_date_epoch() returns nullopt for malformed input,
-// which routes through the apply function as the "no-op" branch tested here.
-// We don't separately test the parser because its result is cached via
-// magic-static and would couple every test to one process-wide env state.
-TEST(SipiIccNormalize, NulloptEpochMatchesMalformedEnvBehaviour)
-{
-  auto buf = make_synthetic_icc(200);
-  auto original = buf;
-
-  Sipi::detail::apply_icc_header_normalization(buf.data(), buf.size(), std::nullopt);
-
-  EXPECT_EQ(buf, original);
 }
 
 // AC: gmtime_r returning nullptr (e.g., 32-bit time_t + post-2038 epoch) ->

--- a/test/unit/sipiicc/icc_normalize_test.cpp
+++ b/test/unit/sipiicc/icc_normalize_test.cpp
@@ -142,6 +142,26 @@ TEST(SipiIccNormalize, NulloptEpochMatchesMalformedEnvBehaviour)
   EXPECT_EQ(buf, original);
 }
 
+// AC: gmtime_r returning nullptr (e.g., 32-bit time_t + post-2038 epoch) ->
+// no-op. We can't easily induce a real gmtime_r failure on a 64-bit time_t
+// platform, but year-out-of-range is the same code path and is exposed as
+// a public-ish contract via the bounds check. Use a far-future epoch; on
+// 64-bit time_t platforms gmtime_r succeeds and returns a year > 65535,
+// which the bounds check rejects -> buffer unchanged.
+TEST(SipiIccNormalize, EpochProducingOutOfRangeYearIsNoOp)
+{
+  auto buf = make_synthetic_icc(256);
+  auto original = buf;
+
+  // ~year 1 million in seconds-since-epoch. Well above ICC dateTimeNumber's
+  // uint16 ceiling. On 32-bit time_t this overflows and gmtime_r returns
+  // nullptr; on 64-bit time_t we land at a year > 65535. Both paths bail.
+  constexpr std::time_t kHugeEpoch = static_cast<std::time_t>(31556926000000LL);
+  Sipi::detail::apply_icc_header_normalization(buf.data(), buf.size(), kHugeEpoch);
+
+  EXPECT_EQ(buf, original);
+}
+
 // Sanity: only the documented byte ranges are touched.
 TEST(SipiIccNormalize, OnlyDateAndProfileIdRangesAreMutated)
 {

--- a/test/unit/sipiicc/main.cpp
+++ b/test/unit/sipiicc/main.cpp
@@ -1,0 +1,13 @@
+/*
+ * Copyright © 2026 Swiss National Data and Service Center for the Humanities
+ * and/or DaSCH Service Platform contributors. SPDX-License-Identifier:
+ * AGPL-3.0-or-later
+ */
+
+#include "gtest/gtest.h"
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
[DEV-6333](https://linear.app/dasch/issue/DEV-6333)

## Summary

- `SipiIcc::iccBytes()` now overwrites bytes 24-35 (ICC creation date) and zeros bytes 84-99 (Profile ID) when `SOURCE_DATE_EPOCH` is set. Production never sets it, so deployed binaries are bit-identical.
- CMake injects `SOURCE_DATE_EPOCH=946684800` for `sipi.approvaltests` only, so JPEG / PNG / JP2 outputs become byte-deterministic under ctest.
- Approval baseline grows from 5 TIFF tests (PR 0) to 15 tests covering every codec and the lcms2 ICC emit path.

## Changes

**Helper + chokepoint integration**
- `src/metadata/SipiIcc.cpp` — adds `Sipi::detail::apply_icc_header_normalization` (pure byte mutation) and `read_source_date_epoch` (cached env read, .cpp-private). One-line call inside `iccBytes(unsigned int&)`. Also fixes a pre-existing leak on the second `cmsSaveProfileToMem` failure path.
- `include/metadata/SipiIccDetail.h` — new internal header so unit tests can drive the pure function with explicit epoch values.
- `include/metadata/SipiIcc.h` — Doxygen comment + `[[nodiscard]]` on both `iccBytes()` overloads.

**Unit tests**
- `test/unit/sipiicc/` — 8-case GoogleTest suite covering: nullopt → no-op, epoch=Y2K → expected date bytes, Profile ID zeroed, non-zero ID scrubbed, truncated buffer no-op, idempotency, only-documented-byte-ranges-touched, out-of-range-year → no-op (covers `gmtime_r` returning NULL on 32-bit `time_t` post-2038).

**Approval-test extension**
- `test/approval/CMakeLists.txt` — `set_tests_properties(... ENVIRONMENT SOURCE_DATE_EPOCH=946684800 ...)`.
- `test/approval/image_encode_baseline_test.cpp` — 10 new tests: `JpegFullToJpegDownscaled`, `JpegFullToPng`, `J2kRegionToTiff`, `J2kRegionToJpeg`, `J2kRegionToJp2` (Goal-3 Kakadu-encode determinism check), `CmykTiffToJpeg`, `CielabTiffToJpeg`, `JpegRotatedToJpeg`, `PngRoundTrip`, `TiffToPng`. Top-of-file commentary updated.
- 11 new LFS-tracked goldens; 2 existing TIFF goldens re-captured (their input ICCs round-trip through lcms2 and pick up the normalized date — see "Deviation from plan" below).
- New PNG fixture `test/_test_data/images/unit/sample_with_icc.png` generated by SIPI itself; `gray_with_icc_another.jpg` (grayscale + sRGB-ICC mismatch — tripped lcms2's input colour-space check) replaced with `MaoriFigureWatermark.jpg`.

**Documentation**
- `CLAUDE.md` — "ICC determinism invariant" callout in the build invariants section.
- `docs/src/development/testing-strategy.md` — ICC determinism gate documented in Layer 2.
- `docs/src/development/developing.md` — direct-binary run instructions for `sipi.approvaltests`; complete unit-test directory list (now includes `sipiicc`).
- `docs/adr/0002-icc-profile-determinism-test-only.md` — new ADR.
- `UBIQUITOUS_LANGUAGE.md` — adds *ICC normalization* and *Reproducibility flag*.
- `test/approval/CHANGELOG.approval.md` — env-var gate explanation + audit-log entry for the 2 re-captured TIFF goldens.

## Deviation from plan

Plan AC item *"Existing TIFF goldens from PR 0 unchanged after the fix (`git diff test/approval/approval_tests/Image*.approved.tif` empty)"* turns out to be infeasible:

- `TiffRegionRoundTrip` (input `lena512.tif`) carries a *Generic Gray Gamma 2.2* ICC.
- `CmykTiffDownscaled` (input `cmyk.tif`) carries a *U.S. Web Coated (SWOP)* ICC.

Both round-trip through `cmsSaveProfileToMem`, so under `SOURCE_DATE_EPOCH` their date bytes get normalized just like a fresh lcms2 profile would. `cmp -l` confirms the diff is exactly the 12-byte `dateTimeNumber` field per embedded ICC profile — surgical, not real content drift. The other 3 PR 0 goldens (no embedded ICC) are unchanged byte-for-byte.

The production-equivalent invariant *does* hold: without `SOURCE_DATE_EPOCH`, all 5 PR 0 TIFF goldens still pass against the binary built from this branch. The plan's intent — "the helper is a no-op in production" — is preserved; the AC's wording was just over-specific.

## Test Plan

- [x] `just nix-build` (`.#dev` derivation) succeeds; sandbox `checkPhase` runs unit + approval tests.
- [x] `cd build/test/approval && SOURCE_DATE_EPOCH=946684800 ./sipi.approvaltests --gtest_filter='ImageEncodeBaseline.*'` — 15/15 PASS, twice in a row, zero `.received.*` files.
- [x] `cd build/test/unit/sipiicc && ./sipi_icc_normalize_test` — 8/8 PASS.
- [x] Unset env var run: 3 of 5 existing PR 0 TIFF goldens still PASS (the 2 ICC-carrying ones intentionally drift); new ICC-touching tests intentionally drift (documented in CHANGELOG).
- [x] 4-reviewer pass (cpp / security / simplicity / consistency); review-driven follow-ups in last 4 commits.
- [ ] CI (Linux): runs in PR.

## Screenshots

n/a — no UI changes.