### PR TITLE
fix(http): treat any OUTPUT_WRITE_FAIL as client abort

### DIFF
--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -81,6 +81,7 @@ The seven valid permission-type strings a preflight script may return:
 | **Decode memory budget** | A process-wide, lock-free accounting of memory currently committed to in-flight image decodes, with an RAII guard. Rejects requests that would push concurrent decode memory over a configured ceiling. | memory budget, decode budget |
 | **Rate limiter** | The per-client request-rate ceiling enforced before decode admission. | throttle |
 | **Cache** | A file-based LRU of generated representations, keyed by *cache key*, with dual-limit eviction (total size **and** file count) and crash recovery. | response cache, output cache |
+| **Client abort** | An HTTP response write that fails because the peer is gone (FIN, RST, or write timeout). Surfaces in code as `Sipi::SipiImageClientAbortError`, raised when `shttps::OUTPUT_WRITE_FAIL` is thrown from a socket write. Logged at info, **not** captured to Sentry — these are peer-side events, not server faults. | broken pipe error, peer disconnect error |
 
 ## Platform context
 

--- a/src/SipiImageError.hpp
+++ b/src/SipiImageError.hpp
@@ -110,10 +110,14 @@ private:
 };
 
 /*!
- * Signals that a write to an HTTP response failed because the client closed
- * the connection before we finished sending. Detected at the write site via
- * shttps::Connection::peerConnected(). The HTTP handler uses the distinct
- * type to skip Sentry capture — these are not server-side errors.
+ * Signals that a write to an HTTP response failed because the peer is gone
+ * (FIN, RST, or write timeout). Detected at the write site by catching
+ * `shttps::OUTPUT_WRITE_FAIL` — the only thing `shttps::Connection`'s
+ * `sendAndFlush` / `flush` raises on a socket-write failure. Every such
+ * throw is a definitive abort, so no further `peerConnected()` check is
+ * needed (POLLRDHUP misses RST and write-timeout aborts). The HTTP handler
+ * uses the distinct type to skip Sentry capture — these are not
+ * server-side errors.
  */
 class SipiImageClientAbortError final : public SipiImageError
 {

--- a/src/formats/SipiIOJ2k.cpp
+++ b/src/formats/SipiIOJ2k.cpp
@@ -102,7 +102,10 @@ bool J2kHttpStream::write(const kdu_byte *buf, int num_bytes)
   try {
     conobj->sendAndFlush(buf, num_bytes);
   } catch (int) {
-    if (!conobj->peerConnected()) client_aborted = true;
+    // Catches shttps::OUTPUT_WRITE_FAIL — by definition a socket-write
+    // failure (peer FIN, RST, or write timeout). peerConnected()'s POLLRDHUP
+    // poll misses RST/timeout, so the throw itself is the abort signal.
+    client_aborted = true;
     return false;
   }
   return true;
@@ -114,7 +117,7 @@ bool J2kHttpStream::close()
   try {
     conobj->flush();
   } catch (int) {
-    if (!conobj->peerConnected()) client_aborted = true;
+    client_aborted = true;
     return false;
   }
   return true;

--- a/src/formats/SipiIOJpeg.cpp
+++ b/src/formats/SipiIOJpeg.cpp
@@ -334,13 +334,17 @@ static boolean empty_html_buffer(j_compress_ptr cinfo)
     cinfo->dest->next_output_byte = html_buffer->buffer.get();
     return static_cast<boolean>(true);
   } catch (const std::exception &e) {
+    // shttps::Error and other std::exception subclasses → genuine error path.
     err_msg = e.what();
   } catch (...) {
     // sendAndFlush throws the bare shttps::OUTPUT_WRITE_FAIL enum — not derived
-    // from std::exception, so it reaches this branch.
-    err_msg = "unknown error";
+    // from std::exception, so it reaches this branch. The throw itself is the
+    // abort signal: every OUTPUT_WRITE_FAIL means the underlying socket write
+    // failed (peer FIN, RST, write timeout). peerConnected() polls POLLRDHUP
+    // and misses RST/timeout, so we don't consult it.
+    err_msg = "shttps::OUTPUT_WRITE_FAIL";
+    html_buffer->client_aborted = true;
   }
-  if (!html_buffer->conobj->peerConnected()) html_buffer->client_aborted = true;
   log_err("JPEG HTTP write failed: %s", err_msg.c_str());
   ERREXIT(cinfo, JERR_FILE_WRITE);  // triggers jpegErrorExit → longjmp
   return FALSE;  // unreachable
@@ -362,9 +366,11 @@ static void term_html_destination(j_compress_ptr cinfo)
   } catch (const std::exception &e) {
     err_msg = e.what();
   } catch (...) {
-    err_msg = "unknown error";
+    // See empty_html_buffer for the rationale: OUTPUT_WRITE_FAIL is itself
+    // the abort signal; no peerConnected() check needed.
+    err_msg = "shttps::OUTPUT_WRITE_FAIL";
+    html_buffer->client_aborted = true;
   }
-  if (!html_buffer->conobj->peerConnected()) html_buffer->client_aborted = true;
   log_err("JPEG HTTP write (term) failed: %s", err_msg.c_str());
   ERREXIT(cinfo, JERR_FILE_WRITE);
   // unreachable

--- a/src/formats/SipiIOPng.cpp
+++ b/src/formats/SipiIOPng.cpp
@@ -431,7 +431,12 @@ static void conn_write_data(png_structp png_ptr, png_bytep data, png_size_t leng
   try {
     ctx->conn->sendAndFlush(data, length);
   } catch (...) {
-    if (!ctx->conn->peerConnected()) ctx->client_aborted = true;
+    // Any throw out of sendAndFlush — bare shttps::OUTPUT_WRITE_FAIL or
+    // shttps::Error — means the response stream is no longer usable. We mark
+    // the abort here unconditionally because peerConnected()'s POLLRDHUP poll
+    // misses RST/timeout aborts. We can't narrow the catch (e.g. to `int`)
+    // without re-introducing C++-exception-through-libpng-C-frame UB.
+    ctx->client_aborted = true;
     // Signal error via libpng's error mechanism → sipi_error_fn → longjmp
     png_error(png_ptr, "HTTP write failed");
   }
@@ -446,7 +451,7 @@ static void conn_flush_data(png_structp png_ptr)
   try {
     ctx->conn->flush();
   } catch (...) {
-    if (!ctx->conn->peerConnected()) ctx->client_aborted = true;
+    ctx->client_aborted = true;
     png_error(png_ptr, "HTTP flush failed");
   }
 }

--- a/src/formats/SipiIOTiff.cpp
+++ b/src/formats/SipiIOTiff.cpp
@@ -1739,12 +1739,11 @@ void SipiIOTiff::write(SipiImage *img, const std::string &filepath, const SipiCo
       try {
         img->connection()->sendAndFlush(memtif->data, memtif->flen);
       } catch (int i) {
-        const bool client_aborted = !img->connection()->peerConnected();
+        // Catches shttps::OUTPUT_WRITE_FAIL — by definition a socket-write
+        // failure. peerConnected()'s POLLRDHUP poll misses RST/timeout, so the
+        // throw itself is the abort signal.
         memTiffFree(memtif);
-        if (client_aborted) {
-          throw Sipi::SipiImageClientAbortError("Client aborted HTTP response during TIFF write");
-        }
-        throw Sipi::SipiImageError("Sending data failed! Broken pipe?: " + filepath + " !");
+        throw Sipi::SipiImageClientAbortError("Client aborted HTTP response during TIFF write");
       }
     } else {
       memTiffFree(memtif);


### PR DESCRIPTION
## Summary

- Closes the residual ~3% gap left by [PR #562](https://github.com/dasch-swiss/sipi/pull/562) for [SIPI-J](https://dasch.sentry.io/issues/SIPI-J) / [DEV-6274](https://linear.app/dasch/issue/DEV-6274).
- In all four HTTP writers (JPEG, PNG, TIFF, JPEG2000), drop the `if (!peerConnected()) client_aborted = true;` qualifier from the `sendAndFlush` catch block — flag the abort unconditionally inside the catch.
- Update `SipiImageClientAbortError` doc comment and add a **Client abort** entry to `UBIQUITOUS_LANGUAGE.md`.

## Why

PR #562 added a `peerConnected()` check after `sendAndFlush` throws, then routed client aborts to `SipiImageClientAbortError` and skipped Sentry capture. It silenced ~97% of SIPI-J events: on `dsp-prod-01`, *Client disconnected before response write, aborting* fires ~3 000/day.

But ~96 events/day still leak as `JPEG HTTP write failed: unknown error` on the same pod, 1:1 with ~85 new SIPI-J Sentry events/day (1110 events over 13 days, status **regressed** on v4.1.1).

Two facts cause the gap:

1. `shttps::sendAndFlush` throws the bare `shttps::OUTPUT_WRITE_FAIL` enum (`shttps/Connection.h:26`), which is an `int`. It matches `catch (...)` (or `catch (int)`) but **never** `catch (const std::exception &)`. The JPEG writer's `catch (...)` branch already documents this in a source comment; *every* event in the residual flood logs the literal string `"unknown error"`, confirming 100% of these go through that branch.
2. `Connection::peerConnected()` polls `POLLRDHUP`, which only fires on a *clean* half-close (FIN). Aborts via TCP RST, write timeout, or kernel-side teardown leave the next poll reading "still connected" at the moment of the catch — so `client_aborted` stays false and we fall through to the generic `SipiImageError("JPEG write failed: Output file write error --- out of disk space?")`, which is captured to Sentry.

`OUTPUT_WRITE_FAIL` is itself the abort signal: it's only thrown when the underlying `os->eof() || os->fail()` fires (`Connection.cpp:1287` and 25 sibling call sites — all the same predicate). The catch type *is* the diagnosis; the extra `peerConnected()` check is redundant *and* unreliable.

## Design

```diff
   } catch (const std::exception &e) {
+    // shttps::Error and other std::exception subclasses → genuine error path.
     err_msg = e.what();
   } catch (...) {
-    // sendAndFlush throws the bare shttps::OUTPUT_WRITE_FAIL enum — not derived
-    // from std::exception, so it reaches this branch.
-    err_msg = "unknown error";
+    // OUTPUT_WRITE_FAIL is by definition a socket-write failure. The throw
+    // itself is the abort signal — peerConnected() (POLLRDHUP) misses
+    // RST/timeout aborts, so we don't consult it.
+    err_msg = "shttps::OUTPUT_WRITE_FAIL";
+    html_buffer->client_aborted = true;
   }
-  if (!html_buffer->conobj->peerConnected()) html_buffer->client_aborted = true;
   log_err("JPEG HTTP write failed: %s", err_msg.c_str());
   ERREXIT(cinfo, JERR_FILE_WRITE);
```

JPEG keeps its existing two-arm structure (`catch (const std::exception &)` for `shttps::Error` state errors → genuine error path, `catch (...)` for `OUTPUT_WRITE_FAIL` → abort path). PNG widens slightly: a single `catch (...)` flags abort unconditionally — narrowing to `catch (int)` would re-introduce the C++-exception-through-libpng-C-frame UB that 94f45a2 fixed. J2K and TIFF already use `catch (int)`; just drop the qualifier.

## Files

- `src/formats/SipiIOJpeg.cpp` — `empty_html_buffer`, `term_html_destination`
- `src/formats/SipiIOPng.cpp` — `conn_write_data`, `conn_flush_data`
- `src/formats/SipiIOJ2k.cpp` — `J2kHttpStream::write`, `J2kHttpStream::close`
- `src/formats/SipiIOTiff.cpp` — TIFF HTTP send catch site
- `src/SipiImageError.hpp` — refresh `SipiImageClientAbortError` doc comment
- `UBIQUITOUS_LANGUAGE.md` — add **Client abort** glossary entry

## Out of scope

- Plumbing `errno` through `shttps::sendAndFlush` so we could log the *real* socket error (EPIPE/ECONNRESET/ETIMEDOUT) instead of the bare enum name. Larger surgery.
- Demoting `log_err` → `log_info` on the JPEG abort path.
- Replacing `OUTPUT_WRITE_FAIL` with a real `std::system_error`.

## Test plan

- [x] `just nix-build` (`.#dev`) — green; unit + approval tests in checkPhase.
- [x] `just hurl-test` — 9/9 files, 16/16 requests, 100% success.
- [x] `just nix-test-e2e` — 23/23 e2e binaries pass.
- [ ] **Manual stage repro** after deploy to `dsp-stage-01`:
  - `curl --max-time 0.2 -o /dev/null 'https://iiif.dasch-staging.org/<large-jpx>/full/max/0/default.jpg'` (FIN abort) — expect `Client aborted HTTP response during JPEG write` in logs, no Sentry event.
  - `kill -9` of `curl` mid-stream (RST abort) — same expectation. **This is the path the current fix misses.**
  - Repeat for `.png`, `.tif`, `.jp2` to cover all four writers.
- [ ] **Production watch:** SIPI-J event rate on `dsp-prod-01` should drop to ≈0 within 24 h after release.

Refs DEV-6274
Refs PR #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)