### PR TITLE
test(e2e): de-flake ASan by avoiding SIGKILL of draining sipi

### DIFF
--- a/test/e2e-rust/src/lib.rs
+++ b/test/e2e-rust/src/lib.rs
@@ -53,8 +53,10 @@ impl SipiServer {
 
         let (http_port, ssl_port) = allocate_ports();
 
-        // If a stale sipi from a previous test run is still holding these ports,
-        // kill it. Otherwise the new server can't bind and tests get IncompleteMessage.
+        // If a stale sipi from a previous test run is still holding these
+        // ports, terminate it gracefully (SIGTERM, then SIGKILL on timeout).
+        // Forced SIGKILL bypasses C++ destructors and orphans static-singleton
+        // heap, which ASan reports as a leak — see the asan-flake fix.
         kill_process_on_port(http_port);
         kill_process_on_port(ssl_port);
 
@@ -68,6 +70,11 @@ impl SipiServer {
             extra_args
         );
 
+        // `--drain-timeout 2` keeps every test's sipi shutdown bounded to ~2s
+        // (default is 30s). With `stop()`'s 5s deadline, this leaves a 2.5×
+        // margin even under ASan's runtime overhead, so SIGKILL never fires
+        // on a still-draining server. Placed before `extra_args` so an
+        // individual test can still override it (CLI11 last-wins).
         let mut cmd = Command::new(&sipi_bin);
         cmd.arg("--config")
             .arg(config)
@@ -75,6 +82,8 @@ impl SipiServer {
             .arg(http_port.to_string())
             .arg("--sslport")
             .arg(ssl_port.to_string())
+            .arg("--drain-timeout")
+            .arg("2")
             .args(extra_args)
             .current_dir(working_dir)
             .stdout(Stdio::piped())
@@ -365,23 +374,53 @@ pub fn test_data_dir() -> PathBuf {
     repo_root().join("test").join("_test_data")
 }
 
-/// Kill any process listening on the given port (cleanup from previous test runs).
+/// Terminate any process listening on the given port (cleanup from previous
+/// test runs). Sends SIGTERM first and polls for exit; falls back to SIGKILL
+/// only if the process is still alive after the deadline. Forced SIGKILL
+/// bypasses destructors and leaks singleton-owned heap that ASan flags.
 fn kill_process_on_port(port: u16) {
-    // Use lsof to find the PID, then SIGKILL it
-    if let Ok(output) = Command::new("lsof")
+    let Ok(output) = Command::new("lsof")
         .args(["-ti", &format!(":{}", port)])
         .output()
-    {
-        let pids = String::from_utf8_lossy(&output.stdout);
-        for pid_str in pids.split_whitespace() {
-            if let Ok(pid) = pid_str.parse::<i32>() {
-                signal::kill(Pid::from_raw(pid), Signal::SIGKILL).ok();
+    else {
+        return;
+    };
+    let pids: Vec<Pid> = String::from_utf8_lossy(&output.stdout)
+        .split_whitespace()
+        .filter_map(|s| s.parse::<i32>().ok())
+        .map(Pid::from_raw)
+        .collect();
+    if pids.is_empty() {
+        return;
+    }
+
+    // SIGTERM all candidates at once, then poll each.
+    for pid in &pids {
+        signal::kill(*pid, Signal::SIGTERM).ok();
+    }
+
+    let deadline = Instant::now() + Duration::from_millis(1500);
+    let mut had_to_escalate = false;
+    for pid in &pids {
+        // Poll for exit via `kill -0` (signal None). Returns Err(ESRCH)
+        // once the process is gone; Err(EPERM) means the PID is still
+        // alive but owned by another user — treat as still-alive.
+        loop {
+            match signal::kill(*pid, None) {
+                Err(nix::errno::Errno::ESRCH) => break, // gone
+                _ if Instant::now() >= deadline => {
+                    signal::kill(*pid, Signal::SIGKILL).ok();
+                    had_to_escalate = true;
+                    break;
+                }
+                _ => std::thread::sleep(Duration::from_millis(50)),
             }
         }
-        if !pids.trim().is_empty() {
-            // Give the OS time to release the port
-            std::thread::sleep(Duration::from_millis(500));
-        }
+    }
+
+    if had_to_escalate {
+        // SIGKILL'd a process — give the OS a beat to release the port.
+        std::thread::sleep(Duration::from_millis(200));
     }
 }
 


### PR DESCRIPTION
[DEV-6337](https://linear.app/dasch/issue/DEV-6337-sipi-de-flake-asan-e2e-graceful-kill-in-test-harness-fast-drain-via)

## Motivation

`sanitizer.yml` intermittently fails with ~24KB of indirect leaks at process exit. Most recently observed on PR #586, commit `3acc163`, run [25110080699](https://github.com/dasch-swiss/sipi/actions/runs/25110080699): 23525 bytes / 295 allocations / 117 indirect-leak entries. Rerun on the identical commit passed cleanly.

Memory leaks are deterministic given the same code. A flake means there's a code path that *sometimes* skips global destructors. Treating ASan as advisory erodes the merge gate; this PR closes the gap.

## Summary

Two layered changes, both in `test/e2e-rust/src/lib.rs`. The fix lives entirely in the Rust test harness — sipi's C++ shutdown path runs all destructors when allowed to complete, so no C++ changes were needed.

- **`kill_process_on_port` is now graceful.** Sends SIGTERM first, polls for exit via `kill(pid, 0)` up to a 1.5 s deadline, falls back to SIGKILL only if the process is genuinely stuck. The unconditional 500 ms `sleep` is now conditional on actually having to escalate. Mirrors the SIGTERM-then-SIGKILL pattern `stop()` already uses.
- **Every test's sipi gets `--drain-timeout 2`.** Sipi's default drain timeout is 30 s (`shttps/Server.h:196`); when the harness's `stop()` only waits 5 s before falling back to SIGKILL, that's a structural mismatch under ASan's ~30 % overhead. Bounding sipi's drain to 2 s gives `stop()`'s 5 s deadline a 2.5× safety margin. Production sipi behavior is unchanged (default 30 s preserved when the flag is absent). Placed before `extra_args` so individual tests can still override (CLI11 last-wins).

## Key Changes

### `test/e2e-rust/src/lib.rs`

- `kill_process_on_port` (was `:369-386`): SIGTERM all candidates, poll each via `kill(pid, None)`, escalate to SIGKILL only after a 1.5 s deadline. `nix::errno::Errno::ESRCH` confirms the process is gone; any other error (including `EPERM`) is treated as still-alive — `.ok()` already swallows the unprivileged-PID case correctly.
- `start_with_args` (`:71-82`): inject `--drain-timeout 2` into every sipi spawn.
- Comment refresh at the kill-on-port call sites — replaces the stale "otherwise the new server can't bind" line with a note about destructors and the asan-flake link.

## Challenges and Decisions

### Why the harness, not sipi?

**Problem:** ASan reports `SipiMetrics` Prometheus registry singleton contents as indirect leaks at process exit. Tempting fix: add explicit `clear()` in sipi's shutdown path or annotate the singleton with a teardown handler.

**Tried:** read `SipiMetrics::instance()` (`src/SipiMetrics.cpp:9-12`), trace the SIGTERM → `_exit()` path through `shttps/Server.cpp` (sigwait thread → `Server::stop()` → drain → main loop returns → `main()` returns → static destructors run).

**Solution:** sipi's normal-exit path is correct. All destructors run cleanly when `main()` returns. The leaks only appear when the process is killed mid-flight by SIGKILL — which the harness, not sipi, is responsible for. Fixing sipi would be defense-in-depth against a self-inflicted harness bug. Per CLAUDE.md scope discipline ("no defense-in-depth, no enterprise abstractions"), the fix belongs in the harness.

### Why `--drain-timeout 2` rather than extending the harness's 5 s deadline?

**Problem:** under ASan, sipi's drain can plausibly take longer than 5 s on a contended runner. Two ways to widen the margin: lengthen the harness's deadline (e.g. to 15 s under sanitizers) or shorten sipi's drain.

**Tried:** sniffing `$ASAN_OPTIONS` in the harness to conditionally extend `stop()`'s deadline.

**Solution:** shortening sipi's drain via `--drain-timeout 2` dominates. It works for native builds too (slow-runner flake risk on cargo test isn't zero today). It needs no env-var detection. Tests fail fast on a hung server instead of waiting 15 s × N tests. Production sipi behavior is unchanged. CLI11 last-wins precedence preserves test-level override capability.

### Why `nix::sys::signal::kill(pid, None)` for the alive probe?

**Problem:** the harness needs to tell whether a SIGTERM'd process has actually exited. Polling via `lsof` in a tight loop spawns a process per iteration; `child.try_wait()` only works for processes we own (the lsof'd PIDs aren't ours).

**Solution:** `kill(pid, None)` is `kill(pid, 0)` — the standard POSIX "is this PID alive" probe. Returns `Err(ESRCH)` once the process is gone; other errors (including `EPERM` for cross-user PIDs) are treated as still-alive. Cheap, correct, no subprocess.

## Gotchas

- **Whoever lands a slow-shutdown test in the future:** with `--drain-timeout=2`, sipi force-closes in-flight requests after 2 s. The existing `tests/shutdown.rs` fires a single JP2 decode (`lena512.jp2/full/max`, ~50–200 ms) — comfortably under the budget. If a future test exercises a > 2 s in-flight request during drain, override the flag at the test call site (it's appended last, CLI11 wins).
- **The new `kill_process_on_port` graceful path is not exercised by any test.** A small unit test (spawn a `sleep 5` child, call the function, assert termination within 2 s with SIGTERM-preferred semantics) would close that gap. Out of scope here; tracked as a follow-up.
- **`kill(pid, 0)` returning `EPERM`:** treated as "still alive, escalate to SIGKILL after the deadline." Acceptable; in CI runners every PID we'd kill is in our own UID so EPERM should never fire.

## Test Plan

- [ ] Trigger 10 sanitizer.yml runs on this branch via `gh workflow run sanitizer.yml`. Expect 10/10 success.
- [ ] Local: `just nix-build-sanitized` then `just nix-test-e2e` 5×. Expect zero failures.
- [x] `cargo check --tests` in `test/e2e-rust/` clean (only pre-existing warnings).
- [ ] CI: full sanitizer.yml + test/amd64 + test/arm64 + nix-macos build all green on this PR.
- [x] Spot-check `tests/shutdown.rs` still passes — it asserts in-flight request completion during drain, which is still true with the 2 s timeout.

## Rollback

Single revert. The fix is one commit affecting only `test/e2e-rust/src/lib.rs`. Reverting restores SIGKILL-first behaviour and the 30 s drain default.