### PR TITLE
docs: ADR-0003 module-co-located source, headers, and unit tests

### DIFF
--- a/docs/adr/0003-module-co-located-source-and-tests.md
+++ b/docs/adr/0003-module-co-located-source-and-tests.md
@@ -1,0 +1,23 @@
+---
+status: proposed
+---
+
+# Module-co-located source, headers, and unit tests with flat-style includes
+
+A SIPI module's `.cpp`, `.h`, and `*_test.cpp` files live in the same directory (e.g. `src/metadata/{SipiIcc.cpp, SipiIcc.h, sipiicc_test.cpp}`) — not in the historical `src/<mod>/` + `include/<mod>/` shadow + `test/unit/<mod>/` split. Cross-module includes use the flat path-prefixed form `#include "metadata/Foo.h"`; siblings within a module use `#include "Foo.h"`. The `include/<mod>/` shadow directories are deleted; `include/` retains only the generated headers (`SipiVersion.h.in`, `ICC-Profiles/`).
+
+We accept this because Bazel's per-module `cc_library` plus `--strict_deps` and `features = ["layering_check", "parse_headers"]` turns module boundaries from a markdown convention (`CONTEXT-MAP.md`, `scripts/shttps-context-check.sh`) into a build-graph invariant: a forbidden `#include` fails analysis, not code review. The flat-style include already matches what `shttps/` and `src/handlers/` use today, so cross-codebase consistency improves while diff churn stays minimal. SIPI ships a single binary with no public C++ API to gate, so the `include/` shadow exists only to mirror `src/` — pure ceremony. The pattern aligns with Abseil, Bloomberg BDE (Lakos's "physical hierarchy" doctrine), Chromium, and WG21 P1204R0 (Kolpackov's "Canonical Project Structure").
+
+This decision is also a response to agentic coding. AI now writes the bulk of application-level code in this codebase; the human's role has shifted from writing code to defining and policing architecture. AI is excellent at local correctness — making a test pass, fixing a bug — and unreliable at architectural correctness — respecting module boundaries, refusing the convenient shortcut. Markdown rules and shell-script gates are advisory and do not scale with AI throughput. Module co-location lets Bazel's per-package `cc_library` + `package_group` + `layering_check` convert architectural intent into build invariants: the AI cannot accidentally violate the rule, and the human reviews high-leverage `BUILD.bazel` and visibility diffs instead of every implementation line. Review surface area shrinks to the leverage points; the build graph polices everything below.
+
+## Considered Options
+
+- **Keep the split layout** — rejected. The `include/<mod>/` directories exist only to mirror `src/<mod>/`; the three coexisting include styles (`"Foo.h"`, `"mod/Foo.h"`, `"../Foo.h"`) are accidental complexity; and `libsipi_testable` (the CMake static lib that compiles every production `.cpp` for the test binaries) hides intra-module coupling that per-module `cc_library` targets would expose.
+- **Abseil-style fully path-prefixed includes** (`#include "sipi/metadata/Foo.h"`) — rejected. Verbose without semantic benefit on a single-binary project; would require touching every `#include` line in the codebase. Flat-style covers the same disambiguation needs at lower churn.
+
+## Consequences
+
+- The CMake `libsipi_testable` God-library is replaced by per-module `cc_library` targets. Each module's unit test depends only on the module's own library, surfacing implicit cross-module coupling as build errors.
+- `scripts/shttps-context-check.sh` is deleted — `package_group()` + `visibility` on `//shttps:shttps` enforces the SIPI → shttps direction at analysis time. The known violation (`shttps/Server.cpp` calling `SipiMetrics::instance()`) becomes a build error, forcing a real fix.
+- `src/formats/` (today: zero unit tests, only approval coverage) gains a per-format unit-test target as part of the same flip.
+- Migration is staged as five mechanical PRs (Y+8a..Y+8e in the Bazel migration plan), gated on the Bazel build-tool migration (Y+6) being merged. Each PR is one module and is revertable.


### PR DESCRIPTION
## Motivation

Sipi's current layout has accumulated three coexisting `#include` styles (flat `"Foo.h"`, path-prefixed `"mod/Foo.h"`, relative-up `"../Foo.h"`), an `include/<mod>/` shadow that mirrors `src/<mod>/` for no semantic gain, and a `libsipi_testable` CMake God-library that hides intra-module coupling. The Bazel migration (dasch-specs PR #96) is the natural point to fix this: per-module `cc_library` + `--strict_deps` + `layering_check` lifts module boundaries from a markdown convention (`CONTEXT-MAP.md`, `scripts/shttps-context-check.sh`) to a build-graph invariant.

This ADR records the direction so the eventual post-Y+6 layout flip (Y+8a..Y+8e in the migration plan) starts from an agreed baseline rather than re-litigating the design under PR pressure.

## Summary

- New ADR `docs/adr/0003-module-co-located-source-and-tests.md` (status: proposed).
- Decision: a module's `.cpp`, `.h`, and `*_test.cpp` sit in the same directory; cross-module includes use flat path-prefixed form (`#include \"metadata/Foo.h\"`); `include/<mod>/` shadow directories are deleted.
- Aligns with Abseil, Bloomberg BDE (Lakos's physical hierarchy), Chromium, and WG21 P1204R0 (Kolpackov).

## Key Changes

### `docs/adr/0003-module-co-located-source-and-tests.md`

- Decision body: Bazel turns CONTEXT-MAP rules into build invariants; flat-style matches what `shttps/` and `src/handlers/` already do.
- Considered Options: keep the split layout (rejected — `include/` shadow is ceremony, three include styles are accidental complexity); Abseil-style fully prefixed includes `\"sipi/metadata/Foo.h\"` (rejected — verbose without benefit on a single-binary project).
- Consequences: `libsipi_testable` decomposes into per-module `cc_library` targets; `scripts/shttps-context-check.sh` deletable once `package_group()` enforces SIPI → shttps; `src/formats/` gains its first per-format unit tests; flip is staged as five mechanical PRs gated on Y+6.

## Challenges and Decisions

### Why an ADR now, before any code moves?

**Problem:** The layout flip is multi-PR (Y+8a..Y+8e in the bazel migration plan). Without a recorded decision, each PR re-relitigates the include-style and shadow-directory questions.

**Solution:** Record the direction once. Future PRs cite the ADR and stay focused on the mechanical move. The ADR is `status: proposed` because the gating Bazel cutover (Y+6) hasn't merged yet.

### Why flat-style instead of Abseil-style fully prefixed includes?

**Problem:** Abseil uses `#include \"absl/strings/str_cat.h\"`. Sipi could plausibly mirror that as `#include \"sipi/metadata/Foo.h\"`.

**Tried:** Mentally walked through the diff size of an Abseil-style flip across all `src/` `.cpp` files vs. a flat-style flip.

**Solution:** Flat-style. Sipi's existing flat-tree contexts (`shttps/`, `src/handlers/`) already use `#include \"Foo.h\"` for siblings. Cross-module references are already path-prefixed (`#include \"metadata/SipiIcc.h\"`). Picking flat-style aligns with the existing dominant pattern; Abseil-style would force a churn pass on every line that already works. Abseil's prefixing pays off when consumers pull a library into an external project — sipi is a single binary with no external C++ consumers.

### Why this matters for `shttps/Server.cpp` → `SipiMetrics::instance()`

**Problem:** `CONTEXT-MAP.md:14` records this as a known violation of the SIPI → shttps one-way rule. The current shell-script enforcement (`scripts/shttps-context-check.sh`) treats it as an exception; it never gets fixed.

**Solution:** Once `package_group()` + `layering_check` enforce the boundary at the build graph, the violation becomes a build error. That forces the rehoming work to happen rather than persist as a tracked exception. Y+8e schedules the fix.

## Gotchas

- ADR status is `proposed` — the actual move is gated on the Bazel migration's Y+6 milestone. Don't read this as a near-term refactor; read it as recording the destination so subsequent PRs are mechanical.
- The ADR keeps `include/` for *generated* headers (`SipiVersion.h.in`, `ICC-Profiles/*`) — those are codegen outputs, not source-code shadow.
- Flat-style is enforced by convention + Bazel `cc_library(strip_include_prefix, includes)` — not by a lint rule. If this becomes painful, a buildifier check is the natural escalation.

## Test Plan

- [x] ADR renders cleanly in mkdocs (`just docs-serve`).
- [x] Format complies with `docs/adr/ADR-FORMAT.md` (frontmatter status, body, optional Considered Options + Consequences).
- [x] Cross-references to `dasch-specs/specs/2026-04-29-sipi-bazel-migration/01-refactor-sipi-bazel-migration-plan.md` (Y+8 series) are present.