### PR TITLE
chore(docs): mkdocs supply-chain & dev-shell hygiene

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -196,7 +196,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Remove LFS hooks (not needed for docs deploy)
         run: rm -f .git/hooks/pre-push
-      - uses: mhausenblas/mkdocs-deploy-gh-pages@master
+      - uses: mhausenblas/mkdocs-deploy-gh-pages@a31c6b13a80e4a4fbb525eeb7a2a78253bb15fa5  # master @ 2024-07-19
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           CUSTOM_DOMAIN: sipi.io

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,6 @@
-mkdocs>=1.5.0
-mkdocs-material
-mkdocs-llmstxt
+# Pinned to exact versions for reproducible CI builds. Bump deliberately —
+# unpinned floors mean every CI run pulls latest and silently changes
+# behaviour. Latest at time of pinning: PyPI as of 2026-04-30.
+mkdocs==1.6.1
+mkdocs-material==9.7.6
+mkdocs-llmstxt==0.5.0

--- a/flake.nix
+++ b/flake.nix
@@ -421,6 +421,16 @@
               imagemagick
               libxml2
               libxslt
+
+              # Documentation tooling (mkdocs + plugins) for `just docs-build` /
+              # `just docs-serve`. Versions track nixpkgs, not docs/requirements.txt;
+              # CI uses pip from the pinned requirements.txt — this is for local
+              # inner-loop preview only.
+              (python3.withPackages (ps: with ps; [
+                mkdocs
+                mkdocs-material
+                mkdocs-llmstxt
+              ]))
             ];
 
             shellHook = ''
@@ -450,6 +460,13 @@
               imagemagick
               libxml2
               libxslt
+
+              # Documentation tooling — see `clang` shell for rationale.
+              (python3.withPackages (ps: with ps; [
+                mkdocs
+                mkdocs-material
+                mkdocs-llmstxt
+              ]))
             ];
 
             shellHook = ''
@@ -479,6 +496,13 @@
               imagemagick
               libxml2
               libxslt
+
+              # Documentation tooling — see `clang` shell for rationale.
+              (python3.withPackages (ps: with ps; [
+                mkdocs
+                mkdocs-material
+                mkdocs-llmstxt
+              ]))
             ];
 
             shellHook = ''


### PR DESCRIPTION
## Motivation

Three orthogonal hygiene items for the docs/mkdocs setup, surfaced during the bazel migration plan review (out of migration scope, but worth landing pre-Y):

1. **`docs/requirements.txt` was unpinned.** `mkdocs>=1.5.0` (no upper bound) plus bare `mkdocs-material` and `mkdocs-llmstxt` meant every PR's `docs-build` CI run pulled latest from PyPI, risking silent breakage on upstream releases. Same supply-chain hygiene reasoning that drives `Cargo.lock` and `MODULE.bazel.lock` discipline.
2. **`mhausenblas/mkdocs-deploy-gh-pages@master` was tag-pinned.** Tag-based references to third-party actions are a supply-chain risk — a compromised maintainer or namespace can ship malicious code that runs with the workflow's `GH_TOKEN`. The deploy job runs on tag push with `secrets.GH_TOKEN` exposed, so this matters.
3. **`mkdocs` was not in any nix devShell.** `just docs-serve` required the user to either have mkdocs installed globally or run `just docs-install-requirements` (which `pip3 install`s into the system Python). That breaks the `nix develop` self-sufficiency contract — every other tool the dev needs is already in the shell.

## Summary

Three small commits, all hidden from changelog (chore/build/ci):

- `chore(docs):` pin `docs/requirements.txt` to exact PyPI versions (mkdocs==1.6.1, mkdocs-material==9.7.6, mkdocs-llmstxt==0.5.0).
- `ci:` SHA-pin `mhausenblas/mkdocs-deploy-gh-pages` to `a31c6b13a80e4a4fbb525eeb7a2a78253bb15fa5` (master tip @ 2024-07-19; the action has been quiescent since).
- `build(devshell):` add `python3.withPackages` exposing `mkdocs` + `mkdocs-material` + `mkdocs-llmstxt` to the clang/fuzz/gcc devShells.

## Key Changes

### `docs/requirements.txt`

Pinned to exact versions with a comment explaining the rationale and the timestamp. Bumps now require a deliberate edit; CI behaviour is reproducible across runs.

### `.github/workflows/publish.yml`

Replaced `mhausenblas/mkdocs-deploy-gh-pages@master` with a 40-character SHA reference. Inline comment notes the human-readable date. Same hygiene pattern that drives the post-launch Trivy SHA-pinning in the bazel migration plan.

### `flake.nix` (devShells)

Added `(python3.withPackages (ps: with ps; [ mkdocs mkdocs-material mkdocs-llmstxt ]))` to the `packages` list of the `clang` (default), `fuzz`, and `gcc` shells. Inline comment notes that the nixpkgs version may diverge from `docs/requirements.txt` — CI uses pip from the pinned file (deterministic for shipping); the dev shell uses nixpkgs for local inner-loop preview (deterministic to flake.lock).

## Challenges and Decisions

### Why pin to exact PyPI versions instead of a lockfile?

**Problem:** A `requirements.lock` generated by `pip-tools` or `uv pip compile` is the gold standard — it locks transitive deps too. But it adds a new tool dependency and a regeneration workflow.

**Solution:** Pin top-level deps for now. `requirements.txt` already only has three lines, so the regeneration cost is tiny. If transitive-dep drift becomes a problem, switch to `uv pip compile` later — the requirements.txt format is forward-compatible.

### Why not move docs/requirements.txt management into Nix entirely?

**Problem:** Nixpkgs `python3Packages.mkdocs-material` is at version 9.6.x while PyPI latest is 9.7.6. CI uses PyPI; nix devShell uses nixpkgs. They drift.

**Solution:** Accept the divergence. The mkdocs `--strict` build catches markdown breakage regardless of which mkdocs version runs; visual rendering can vary between minor versions but that's preview-only. CI's pip path is the authoritative shipping pipeline.

### Why SHA-pin to master rather than to a release tag?

**Problem:** `mhausenblas/mkdocs-deploy-gh-pages` doesn't publish numbered release tags; the most recent activity is on master.

**Solution:** Pin to the current master tip (commit `a31c6b13a80e4a4fbb525eeb7a2a78253bb15fa5`, 2024-07-19). The action has been quiescent for ~9 months. Renovate / dependabot can auto-bump this PR's pin when a newer master commit lands; that becomes a deliberate review event rather than a silent upstream change.

## Gotchas

- The nixpkgs mkdocs version may lag PyPI by a minor release. If you see different rendering between `just docs-serve` (nix dev shell) and the deployed sipi.io site, the CI/PyPI version wins — that's what ships.
- The `docs-install-requirements` justfile recipe is still useful for non-nix-dev-shell flows (e.g. CI). Not removed.
- mkdocs in nixpkgs depends on a Python 3.x interpreter — adds ~50 MB to dev shells. If shell-size becomes a concern, factor docs tooling into a separate `nix develop .#docs` shell.

## Test Plan

- [x] `pip install -r docs/requirements.txt && mkdocs build --strict --config-file docs/mkdocs.yml` succeeds locally with the new pins (resolves to the exact pinned versions).
- [x] `gh api repos/mhausenblas/mkdocs-deploy-gh-pages/commits/a31c6b13a80e4a4fbb525eeb7a2a78253bb15fa5` returns 200 and the commit author/date matches the inline comment.
- [ ] `nix develop` enters the clang shell; `which mkdocs` returns `/nix/store/.../bin/mkdocs`; `mkdocs --version` runs cleanly.
- [ ] `just docs-build` works inside `nix develop` without a prior `pip install`.
- [ ] CI `docs-build` job green on this PR (verifies the pin resolves on a clean Ubuntu runner).
- [ ] `just nix-build` still green (no flake regression from the devShells additions).