### PR TITLE
refactor(shttps): invert SipiMetrics dependency via Strategy + Adapter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,6 +485,7 @@ add_executable(sipi
         ${PROJECT_SOURCE_DIR}/src/handlers/iiif_handler.hpp
         ${PROJECT_SOURCE_DIR}/src/SipiCache.cpp include/SipiCache.h
         ${PROJECT_SOURCE_DIR}/src/SipiMetrics.cpp ${PROJECT_SOURCE_DIR}/include/SipiMetrics.h
+        ${PROJECT_SOURCE_DIR}/src/SipiConnectionMetricsAdapter.cpp ${PROJECT_SOURCE_DIR}/include/SipiConnectionMetricsAdapter.h
         ${PROJECT_SOURCE_DIR}/src/SipiLua.cpp include/SipiLua.h
         ${PROJECT_SOURCE_DIR}/src/iiifparser/SipiRotation.cpp include/iiifparser/SipiRotation.h
         ${PROJECT_SOURCE_DIR}/src/iiifparser/SipiQualityFormat.cpp ${PROJECT_SOURCE_DIR}/include/iiifparser/SipiQualityFormat.h
@@ -504,6 +505,7 @@ add_executable(sipi
         ${PROJECT_SOURCE_DIR}/shttps/Parsing.cpp ${PROJECT_SOURCE_DIR}/shttps/Parsing.h
         ${PROJECT_SOURCE_DIR}/shttps/ThreadControl.cpp ${PROJECT_SOURCE_DIR}/shttps/ThreadControl.h
         ${PROJECT_SOURCE_DIR}/shttps/SocketControl.cpp ${PROJECT_SOURCE_DIR}/shttps/SocketControl.h
+        ${PROJECT_SOURCE_DIR}/shttps/ConnectionMetrics.h
         ${PROJECT_SOURCE_DIR}/shttps/Server.cpp ${PROJECT_SOURCE_DIR}/shttps/Server.h
         ${PROJECT_SOURCE_DIR}/shttps/jwt.c ${PROJECT_SOURCE_DIR}/shttps/jwt.h
         ${PROJECT_SOURCE_DIR}/shttps/makeunique.h

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -11,7 +11,7 @@ This repository has two bounded contexts. The boundary is real (separate namespa
 
 **SIPI → shttps. Strictly one-way.**
 
-SIPI is a *consumer* of shttps: it subclasses `shttps::Server`, registers route handlers (`iiif_handler`, `file_handler`), and uses shttps types (`Connection`, `LuaServer`, `Parsing`, `Hash`) inside its own code. shttps must not name any `Sipi::` symbol or include any `Sipi*.h` header. Today there is one known violation (`shttps/Server.cpp` reaches into `SipiMetrics`); it is a bug, tracked as a layering leak. The boundary is enforced by `just shttps-context-check`. See `scripts/shttps-context-check.sh` for the allowlist.
+SIPI is a *consumer* of shttps: it subclasses `shttps::Server`, registers route handlers (`iiif_handler`, `file_handler`), and uses shttps types (`Connection`, `LuaServer`, `Parsing`, `Hash`) inside its own code. shttps must not name any `Sipi::` symbol or include any `Sipi*.h` header. Telemetry crosses the boundary in the *correct* direction: shttps owns the `shttps::ConnectionMetrics` strategy interface; SIPI installs a `Sipi::SipiConnectionMetricsAdapter` on the server at startup that bridges those events to the `SipiMetrics` singleton. shttps holds no reverse dependency on any `Sipi::` symbol. The boundary is enforced by `just shttps-context-check` (see `scripts/shttps-context-check.sh`); the allowlist is empty.
 
 ## Long-term direction
 

--- a/include/SipiConnectionMetricsAdapter.h
+++ b/include/SipiConnectionMetricsAdapter.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+ * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#ifndef __defined_sipi_connection_metrics_adapter_h
+#define __defined_sipi_connection_metrics_adapter_h
+
+#include "shttps/ConnectionMetrics.h"
+
+namespace Sipi {
+
+// Adapter (GoF): bridges the shttps::ConnectionMetrics strategy interface to
+// the legacy SipiMetrics singleton. SIPI installs an instance on the shttps
+// Server at startup; from then on shttps delegates telemetry events here
+// without naming any SIPI type.
+class SipiConnectionMetricsAdapter : public shttps::ConnectionMetrics
+{
+public:
+  void onConnectionsRejected(std::size_t n) override;
+  void onWaitingConnectionsChanged(std::size_t depth) override;
+  void onRequestComplete(double duration_seconds) override;
+};
+
+}// namespace Sipi
+
+#endif

--- a/scripts/shttps-context-check.sh
+++ b/scripts/shttps-context-check.sh
@@ -8,11 +8,9 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
 # Allowlist: each entry is "file|symbol" and must carry an inline TODO comment
-# naming the follow-up that retires it.
-ALLOWLIST=(
-    # TODO: remove once metrics-hook lands
-    "shttps/Server.cpp|SipiMetrics"
-)
+# naming the follow-up that retires it. Currently empty — the boundary is
+# clean. Add new entries only with a tracked Linear issue for retirement.
+ALLOWLIST=()
 
 # grep flags shared by both passes. Vendored third-party sources are excluded.
 GREP_FLAGS=(

--- a/shttps/CMakeLists.txt
+++ b/shttps/CMakeLists.txt
@@ -111,6 +111,7 @@ add_library(
         SockStream.cpp SockStream.h
         ChunkReader.cpp ChunkReader.h
         Connection.cpp Connection.h
+        ConnectionMetrics.h
         LuaServer.cpp LuaServer.h
         Parsing.cpp Parsing.h
         Server.cpp Server.h

--- a/shttps/CONTEXT.md
+++ b/shttps/CONTEXT.md
@@ -85,7 +85,7 @@ These currently live in shttps but are not seam types. They are utilities or dom
 
 > **Dev:** "And if I want to expose request count to Prometheus?"
 
-> **Maintainer:** "Same answer at the boundary. shttps must not call `SipiMetrics`. The clean shape is: shttps exposes a metrics-callback hook on **Server**; SIPI installs a callback that drives `SipiMetrics`. Today shttps reaches into `SipiMetrics` directly — that is a tracked layering leak."
+> **Maintainer:** "Same answer at the boundary. shttps must not call `SipiMetrics`. The clean shape — and the one we have today — is: shttps owns a `ConnectionMetrics` strategy interface on **Server**; SIPI installs `SipiConnectionMetricsAdapter` at startup, which bridges those events to `SipiMetrics`. shttps holds no reverse dependency on any `Sipi::` type."
 
 > **Dev:** "Why is `LuaServer` called a server if it isn't one?"
 
@@ -96,4 +96,4 @@ These currently live in shttps but are not seam types. They are utilities or dom
 - **`LuaServer` is not a server.** It is a per-request Lua interpreter (a VM wrapper). The name predates the current model and cannot be renamed without breaking consumers; in conversation, prefer "Lua interpreter" or "Lua VM" and reserve "server" for `shttps::Server`.
 - **"Handler" is overloaded across the boundary.** In shttps, **RequestHandler** is a C++ function pointer. In SIPI's user-facing language ("Route handler" in `UBIQUITOUS_LANGUAGE.md`), it is a *Lua script* bound to a URL. They are distinct concepts: a SIPI Lua route handler is *invoked by* a shttps `RequestHandler` that loads and runs the script.
 - **"file_handler" is overloaded.** `shttps::file_handler` serves arbitrary files from the **document root** (generic static-file + Lua-in-HTML). SIPI's IIIF `/file` endpoint (`handlers::iiif_handler::FILE_DOWNLOAD`, sipi-side) serves a **Bitstream** keyed by an IIIF identifier under the **image root**. Same word, two unrelated handlers; never use "file_handler" without qualifying which side.
-- **`SipiMetrics` is referenced from `shttps/Server.cpp`.** This violates the one-way dependency direction and is a tracked layering leak, not a sanctioned pattern.
+- **Telemetry crosses the boundary via the `ConnectionMetrics` strategy.** shttps owns the `ConnectionMetrics` interface (`shttps/ConnectionMetrics.h`) and `Server::setMetrics`; SIPI installs `Sipi::SipiConnectionMetricsAdapter` at startup. shttps does not name any `Sipi::` type, and `SipiMetrics::instance()` is never called from `shttps/`.

--- a/shttps/ConnectionMetrics.h
+++ b/shttps/ConnectionMetrics.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+ * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#ifndef __defined_shttps_connection_metrics_h
+#define __defined_shttps_connection_metrics_h
+
+#include <cstddef>
+
+namespace shttps {
+
+// Strategy interface (GoF) for HTTP-layer telemetry hooks. Server holds an
+// optional std::shared_ptr<ConnectionMetrics> and delegates per-event to it;
+// embedders install a concrete implementation via Server::setMetrics().
+//
+// Method names are event-shaped because each call site is an event emission;
+// the pattern is determined by structure (1:1 delegation, single field,
+// interchangeable policy), not by naming. This is *not* the Observer pattern —
+// there is no subscriber list, no notify-all, no broadcast.
+//
+// Lives in the shttps namespace and depends only on <cstddef>; no SIPI types
+// are named here. This is the seam that lets shttps stay free of any reverse
+// dependency on the SIPI bounded context (see CONTEXT-MAP.md).
+class ConnectionMetrics
+{
+public:
+  virtual ~ConnectionMetrics() = default;
+
+  // Called when one or more queued connections are rejected (queue full or
+  // wait-time expired). `n` is the count rejected by this event.
+  virtual void onConnectionsRejected(std::size_t n) = 0;
+
+  // Called when the depth of the waiting-connections queue changes. `depth`
+  // is the new absolute size of the queue.
+  virtual void onWaitingConnectionsChanged(std::size_t depth) = 0;
+
+  // Called when a request completes (handler returned without throwing).
+  // `duration_seconds` is the wall-clock time spent inside the handler.
+  virtual void onRequestComplete(double duration_seconds) = 0;
+};
+
+}// namespace shttps
+
+#endif

--- a/shttps/Server.cpp
+++ b/shttps/Server.cpp
@@ -35,7 +35,6 @@
 #include "LuaServer.h"
 #include "Parsing.h"
 #include "Server.h"
-#include "SipiMetrics.h"
 #include "SockStream.h"
 #include "makeunique.h"
 
@@ -1017,9 +1016,7 @@ void Server::run()
         // Collect expired sockets (lock released before I/O)
         auto expired = socket_control.collect_expired_waiting();
         for (const auto &si : expired) { reject_with_503(si); }
-        if (!expired.empty()) {
-          SipiMetrics::instance().rejected_connections_total.Increment(static_cast<double>(expired.size()));
-        }
+        if (!expired.empty() && metrics_) { metrics_->onConnectionsRejected(expired.size()); }
 
         // Collect idle keep-alive sockets (lock released before I/O)
         if (_keep_alive_timeout > 0) {
@@ -1027,8 +1024,7 @@ void Server::run()
           for (const auto &si : idle) { close_socket(si); }
         }
 
-        SipiMetrics::instance().waiting_connections.Set(
-          static_cast<double>(socket_control.waiting_queue_size()));
+        if (metrics_) { metrics_->onWaitingConnectionsChanged(socket_control.waiting_queue_size()); }
       }
       continue;// No events — restart poll
     }
@@ -1204,7 +1200,7 @@ void Server::run()
                 SocketControl::SocketInfo sockid;
                 socket_control.remove(i, sockid);
                 reject_with_503(sockid);
-                SipiMetrics::instance().rejected_connections_total.Increment();
+                if (metrics_) { metrics_->onConnectionsRejected(1); }
                 log_warn("Queue full — rejected connection from %s with 503", sockid.peer_ip);
               }
             }
@@ -1337,7 +1333,7 @@ shttps::ThreadStatus Server::process_request(std::istream *ins,
       handler(conn, luaserver, _user_data, hd);
       auto request_end = std::chrono::steady_clock::now();
       double duration_seconds = std::chrono::duration<double>(request_end - request_start).count();
-      SipiMetrics::instance().request_duration_seconds.Observe(duration_seconds);
+      if (metrics_) { metrics_->onRequestComplete(duration_seconds); }
     } catch (InputFailure iofail) {
       log_debug("Possibly socket closed by peer");
       return CLOSE;// or CLOSE ??

--- a/shttps/Server.h
+++ b/shttps/Server.h
@@ -15,6 +15,7 @@
 #include <chrono>
 #include <csignal>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <queue>
 #include <vector>
@@ -36,6 +37,7 @@
 #include "openssl/ssl.h"
 
 #include "Connection.h"
+#include "ConnectionMetrics.h"
 #include "Error.h"
 #include "Global.h"
 #include "Logger.h"
@@ -203,6 +205,7 @@ private:
   std::vector<shttps::LuaRoute> _lua_routes;//!< This vector holds the routes that are served by lua scripts
   std::vector<GlobalFunc> lua_globals;
   size_t _max_post_size;
+  std::shared_ptr<ConnectionMetrics> metrics_;//!< Optional telemetry strategy; null = no-op
 
   RequestHandler get_handler(Connection &conn, void **handler_data_p);
 
@@ -471,6 +474,16 @@ public:
    * \param[in] User data
    */
   inline void user_data(void *user_data_p) { _user_data = user_data_p; }
+
+  /*!
+   * Install a telemetry strategy. Server delegates HTTP-layer events
+   * (connections rejected, queue-depth changes, request completion) to the
+   * installed strategy. Pass an empty shared_ptr to disable. Strategy must be
+   * thread-safe — events fire from worker threads and from the main poll loop.
+   *
+   * \param[in] metrics Concrete ConnectionMetrics implementation, or null
+   */
+  void setMetrics(std::shared_ptr<ConnectionMetrics> metrics) { metrics_ = std::move(metrics); }
 
   void drain_timeout(unsigned seconds) { _drain_timeout = seconds; }
   unsigned drain_timeout() const { return _drain_timeout; }

--- a/src/SipiConnectionMetricsAdapter.cpp
+++ b/src/SipiConnectionMetricsAdapter.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+ * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "SipiConnectionMetricsAdapter.h"
+#include "SipiMetrics.h"
+
+namespace Sipi {
+
+void SipiConnectionMetricsAdapter::onConnectionsRejected(std::size_t n)
+{
+  SipiMetrics::instance().rejected_connections_total.Increment(static_cast<double>(n));
+}
+
+void SipiConnectionMetricsAdapter::onWaitingConnectionsChanged(std::size_t depth)
+{
+  SipiMetrics::instance().waiting_connections.Set(static_cast<double>(depth));
+}
+
+void SipiConnectionMetricsAdapter::onRequestComplete(double duration_seconds)
+{
+  SipiMetrics::instance().request_duration_seconds.Observe(duration_seconds);
+}
+
+}// namespace Sipi

--- a/src/sipi.cpp
+++ b/src/sipi.cpp
@@ -34,6 +34,7 @@
 #include "CLI11.hpp"
 #include "Logger.h"
 #include "SipiConf.h"
+#include "SipiConnectionMetricsAdapter.h"
 #include "SipiFilenameHash.h"
 #include "SipiHttpServer.hpp"
 #include "SipiMemoryBudget.h"
@@ -1554,6 +1555,14 @@ int main(int argc, char *argv[])
       }
       Sipi::SipiHttpServer server(
         sipiConf.getPort(), nthreads, sipiConf.getUseridStr(), sipiConf.getLogfile(), sipiConf.getLoglevel());
+
+      // Install the SIPI-side telemetry adapter on the shttps server before
+      // any other configuration runs, so early-startup events (queue depth,
+      // rejections during warm-up) reach SipiMetrics. shttps owns the
+      // ConnectionMetrics strategy interface; SIPI plugs in the adapter that
+      // bridges to its singleton — this is the seam that keeps shttps free
+      // of any reverse dependency on Sipi:: types (see CONTEXT-MAP.md).
+      server.setMetrics(std::make_shared<Sipi::SipiConnectionMetricsAdapter>());
 
       log_info("BUILD_TIMESTAMP: %s", BUILD_TIMESTAMP);
       log_info("BUILD_SCM_TAG: %s", BUILD_SCM_TAG);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -97,6 +97,7 @@ set(SIPI_TESTABLE_SRCS
     ${CMAKE_SOURCE_DIR}/src/handlers/iiif_handler.cpp
     ${CMAKE_SOURCE_DIR}/src/SipiCache.cpp
     ${CMAKE_SOURCE_DIR}/src/SipiMetrics.cpp
+    ${CMAKE_SOURCE_DIR}/src/SipiConnectionMetricsAdapter.cpp
     ${CMAKE_SOURCE_DIR}/src/SipiLua.cpp
     ${CMAKE_SOURCE_DIR}/src/iiifparser/SipiIdentifier.cpp
     ${CMAKE_SOURCE_DIR}/src/iiifparser/SipiRotation.cpp
@@ -191,6 +192,9 @@ add_subdirectory(unit/sipiimage)
 
 # SipiIcc helper tests (SOURCE_DATE_EPOCH normalization)
 add_subdirectory(unit/sipiicc)
+
+# SipiConnectionMetricsAdapter tests (Adapter forwarding to SipiMetrics)
+add_subdirectory(unit/sipiconnectionmetrics)
 
 # Logger tests
 # To only run this single test, run from inside the build directory '(cd test/unit && ./sipiimage/logger)'

--- a/test/unit/sipiconnectionmetrics/CMakeLists.txt
+++ b/test/unit/sipiconnectionmetrics/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(TEST_NAME sipi_connection_metrics_adapter_test)
+
+file(GLOB SRCS CONFIGURE_DEPENDS *.cpp)
+
+add_executable(${TEST_NAME} ${SRCS})
+target_link_libraries(${TEST_NAME} libgtest libsipi_testable)
+
+install(TARGETS ${TEST_NAME} DESTINATION bin)
+
+add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
+set_property(TEST ${TEST_NAME} PROPERTY LABELS unit)

--- a/test/unit/sipiconnectionmetrics/connection_metrics_adapter_test.cpp
+++ b/test/unit/sipiconnectionmetrics/connection_metrics_adapter_test.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2026 Swiss National Data and Service Center for the Humanities
+ * and/or DaSCH Service Platform contributors. SPDX-License-Identifier:
+ * AGPL-3.0-or-later
+ */
+
+// Unit tests for Sipi::SipiConnectionMetricsAdapter — the GoF Adapter that
+// bridges shttps's ConnectionMetrics strategy interface to the legacy
+// SipiMetrics singleton. Each test fires one callback and asserts the
+// expected mutation on SipiMetrics::instance() via a before/after delta
+// (the singleton is process-global, so absolute values are not reliable).
+
+#include "SipiConnectionMetricsAdapter.h"
+#include "SipiMetrics.h"
+
+#include "gtest/gtest.h"
+
+namespace {
+
+TEST(SipiConnectionMetricsAdapter, OnConnectionsRejectedIncrementsCounterByN)
+{
+  Sipi::SipiConnectionMetricsAdapter adapter;
+  auto &counter = SipiMetrics::instance().rejected_connections_total;
+
+  const double before = counter.Value();
+  adapter.onConnectionsRejected(7);
+  const double after = counter.Value();
+
+  EXPECT_DOUBLE_EQ(after - before, 7.0);
+}
+
+TEST(SipiConnectionMetricsAdapter, OnWaitingConnectionsChangedSetsGaugeAbsolute)
+{
+  Sipi::SipiConnectionMetricsAdapter adapter;
+  auto &gauge = SipiMetrics::instance().waiting_connections;
+
+  // Gauge::Set is absolute: the post-call value equals the supplied depth
+  // regardless of prior state.
+  adapter.onWaitingConnectionsChanged(42);
+  EXPECT_DOUBLE_EQ(gauge.Value(), 42.0);
+
+  adapter.onWaitingConnectionsChanged(0);
+  EXPECT_DOUBLE_EQ(gauge.Value(), 0.0);
+}
+
+TEST(SipiConnectionMetricsAdapter, OnRequestCompleteRecordsHistogramObservation)
+{
+  Sipi::SipiConnectionMetricsAdapter adapter;
+  auto &histogram = SipiMetrics::instance().request_duration_seconds;
+
+  const auto before = histogram.Collect();
+  adapter.onRequestComplete(0.125);
+  const auto after = histogram.Collect();
+
+  ASSERT_EQ(before.histogram.sample_count + 1, after.histogram.sample_count);
+  EXPECT_DOUBLE_EQ(after.histogram.sample_sum - before.histogram.sample_sum, 0.125);
+}
+
+}// namespace

--- a/test/unit/sipiconnectionmetrics/main.cpp
+++ b/test/unit/sipiconnectionmetrics/main.cpp
@@ -1,0 +1,13 @@
+/*
+ * Copyright © 2026 Swiss National Data and Service Center for the Humanities
+ * and/or DaSCH Service Platform contributors. SPDX-License-Identifier:
+ * AGPL-3.0-or-later
+ */
+
+#include "gtest/gtest.h"
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Fixes DEV-6339

## Motivation

`shttps/Server.cpp` reaches into `Sipi::SipiMetrics` from inside the shttps bounded context. This violates the SIPI → shttps one-way dependency direction declared in `CONTEXT-MAP.md:14`. Until now the violation was suppressed by an allow-list entry in `scripts/shttps-context-check.sh` and tracked as a known layering leak.

This PR is a **pre-Y prerequisite** for the [Sipi Bazel migration](https://github.com/dasch-swiss/dasch-specs/pull/96). Bazel's PR Y enables Clang `layering_check` on `//shttps:shttps`, which would fail-build until this leak is fixed. Doing the rehome now, on the existing CMake build, keeps PR Y focused on "Bazel build works" rather than mixing a domain refactor into a build-system PR. It also operationalises the migration plan's framing: the canonical violation gets fixed *before* Bazel proves it can enforce the boundary.

## Summary

- shttps owns a new `ConnectionMetrics` Strategy interface; SIPI installs a `SipiConnectionMetricsAdapter` at startup that bridges to the `SipiMetrics` singleton. shttps holds zero references to any `Sipi::` symbol.
- `scripts/shttps-context-check.sh` ALLOWLIST is now empty — future violations fail-check instead of being silently suppressed.
- No observable behaviour change: the four metric mutations previously emitted directly from shttps now emit through the adapter; `/metrics` output is identical.

## Key Changes

### shttps side — Strategy

- `shttps/ConnectionMetrics.h` (new): pure-virtual interface with three event-shaped methods (`onConnectionsRejected`, `onWaitingConnectionsChanged`, `onRequestComplete`). Depends only on `<cstddef>` — no SIPI types.
- `shttps/Server.h`: adds `std::shared_ptr<ConnectionMetrics> metrics_` field + `setMetrics()` accessor. Default null = no-op path.
- `shttps/Server.cpp`: drops `#include "SipiMetrics.h"`; replaces the four `SipiMetrics::instance().X` call sites at lines 1021, 1030, 1207, 1340 with null-guarded `metrics_->onX(...)` delegations.

### SIPI side — Adapter

- `include/SipiConnectionMetricsAdapter.h` + `src/SipiConnectionMetricsAdapter.cpp` (new): three-method Adapter forwarding to the corresponding `SipiMetrics::instance()` member (counter, gauge, histogram).
- `src/sipi.cpp`: installs `Sipi::SipiConnectionMetricsAdapter` on the server immediately after construction (before any other configuration), so early-startup events still reach `SipiMetrics`.

### Tests

- `test/unit/sipiconnectionmetrics/` (new): three GoogleTest cases — one per virtual method — asserting the expected `SipiMetrics::instance()` mutation via before/after deltas. Layout mirrors `test/unit/sipiicc/`. Wired into `test/CMakeLists.txt` and the `libsipi_testable` source list.

### Docs and enforcement

- `CONTEXT-MAP.md:14`: replaces the "one known violation" sentence with a description of the strategy/adapter seam.
- `shttps/CONTEXT.md`: rewrites the maintainer-dialogue example and the Flagged-ambiguity entry to describe what is, not what was.
- `scripts/shttps-context-check.sh`: empties `ALLOWLIST` and updates the surrounding comment.

## Challenges and Decisions

### Pattern naming — Observer vs Strategy

**Problem:** The original Linear issue framed this as "observer-pattern inversion." Observer (GoF) is 1:N publish-subscribe with a subscriber list and notify-all semantics. What's actually wanted here is 1:1 delegation to a single, optionally-installed, interchangeable policy.

**Tried:** Keeping the "observer" wording for continuity with the issue title.

**Solution:** Corrected to **Strategy + Adapter**. shttps's `ConnectionMetrics` is a Strategy interface (single field, single delegate, interchangeable implementations); the SIPI-side `SipiConnectionMetricsAdapter` is correctly named because it bridges that strategy to the legacy singleton API. The architectural principle being applied is SOLID Dependency Inversion. Linear DEV-6339 was updated to reflect the correct pattern naming with a "Pattern note (correction)" section.

### Commit shape — single revert vs split

**Problem:** Splitting into "expand → migrate → contract" produces three commits of which one (the migrate-only commit) silently breaks `/metrics` emission between commits, because the adapter wiring lives in a different commit from the call-site swap.

**Tried:** A four-commit shape — interface, adapter+tests, atomic-swap-and-wire, docs.

**Solution:** Per the conventions in `docs/src/development/commit-conventions.md` ("Internal work is hidden from changelog — squash aggressively") and the issue's own Rollback statement ("Single revert. The refactor lands as one PR with one logical change"), squashed to one `refactor:` commit. Single revert restores the prior direct calls cleanly.

### Wiring location

**Problem:** Where to call `server.setMetrics()` in `src/sipi.cpp`. Late wiring (after all other configuration) loses early-startup metric emissions; too-early wiring conflicts with object construction.

**Solution:** Install the adapter immediately after `Sipi::SipiHttpServer server(...)` construction and before any other `server.X(...)` configuration. This is the earliest valid point and ensures any rejection/queue-depth event during warm-up reaches `SipiMetrics`.

## Gotchas

- **`SipiMetrics::instance()` is still a process-global singleton.** Adapter unit tests use before/after deltas — not absolute values — because any other test in the same process can mutate the same metric. Future singleton retirement is tracked as part of DEV-6104 (OTel migration); see the "Retire the SipiMetrics::instance() singleton" section in that issue for the roadmap.
- **Method names on `shttps::ConnectionMetrics` are event-shaped (`onConnectionsRejected`, `onRequestComplete`).** The structure is Strategy (1:1 delegation), not Observer. Adding a fourth method is a breaking change for any external embedder of shttps; today there is only one embedder (SIPI).
- **Adapter must be installed before `server.run()`.** The current call site in `src/sipi.cpp` runs immediately after construction — preserve that ordering. Future contributors moving setup logic should not move `setMetrics()` after `server.run()` or after long config-loading work that itself emits events.
- **Pre-existing TIFF palette ASan finding is unrelated.** Local macOS arm64 `just nix-build-sanitized` flags an ASan `container-overflow` in `Sipi::SipiIOTiff::read` from the `SipiImage.PALETTE_Conversion` test. `test/unit/sipiimage/CMakeLists.txt:16-18` already excludes this test on Linux+Debug+Clang for a separate Kakadu SIGILL, so CI's `sanitizer.yml` does not exercise this path. Zero overlap with this diff (`git diff main..HEAD --stat` confirms no TIFF or SipiImage files touched). CI sanitizer remains green.

## Test Plan

- [x] `grep -n 'SipiMetrics' shttps/*.cpp shttps/*.h` returns zero matches.
- [x] `grep -nE '#include.*Sipi' shttps/*.cpp shttps/*.h` returns zero matches.
- [x] `just nix-build` (.#dev) succeeds; checkPhase ran all unit + approval tests in the Nix sandbox, including the three new `SipiConnectionMetricsAdapter` cases.
- [x] `just nix-test-e2e` — 23/23 e2e tests pass across `health`, `cli`, `iiif_compliance`, `lua_smoke`, `metrics_smoke`, `process`, `sipi_e2e`, `smoke`, `upload`.
- [x] `just nix-test-smoke` — 3/3 Docker smoke tests pass against the Nix-built `daschswiss/sipi:latest` image.
- [x] `bash scripts/shttps-context-check.sh` exits 0 with empty `ALLOWLIST`.
- [x] `CONTEXT-MAP.md` no longer lists `SipiMetrics` as a known violation.
- [ ] `just hurl-test` 16/16 green — deferred to CI (requires `hurl` binary from dev shell).
- [ ] `curl -sf http://localhost:1024/metrics` shows `sipi_rejected_connections_total`, `sipi_waiting_connections`, `sipi_request_duration_seconds` updating under exercise — deferred to operator verification post-deploy.
- [x] CI sanitizer (`sanitizer.yml`) green — adapter callbacks introduce no new findings; pre-existing unrelated TIFF palette finding excluded by existing test filter.