### PR TITLE
revert: remove mkdocs from nix devShells

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -421,16 +421,6 @@
               imagemagick
               libxml2
               libxslt
-
-              # Documentation tooling (mkdocs + plugins) for `just docs-build` /
-              # `just docs-serve`. Versions track nixpkgs, not docs/requirements.txt;
-              # CI uses pip from the pinned requirements.txt — this is for local
-              # inner-loop preview only.
-              (python3.withPackages (ps: with ps; [
-                mkdocs
-                mkdocs-material
-                mkdocs-llmstxt
-              ]))
             ];
 
             shellHook = ''
@@ -460,13 +450,6 @@
               imagemagick
               libxml2
               libxslt
-
-              # Documentation tooling — see `clang` shell for rationale.
-              (python3.withPackages (ps: with ps; [
-                mkdocs
-                mkdocs-material
-                mkdocs-llmstxt
-              ]))
             ];
 
             shellHook = ''
@@ -496,13 +479,6 @@
               imagemagick
               libxml2
               libxslt
-
-              # Documentation tooling — see `clang` shell for rationale.
-              (python3.withPackages (ps: with ps; [
-                mkdocs
-                mkdocs-material
-                mkdocs-llmstxt
-              ]))
             ];
 
             shellHook = ''


### PR DESCRIPTION
## Summary
- Reverts commit 3701736 (\`build(devshell): add mkdocs to nix devShells for docs preview\`).
- The Python + mkdocs closure bloats every dev shell (clang / gcc / valgrind) without benefiting the inner-loop C++ build/test cycle.
- Local docs preview can still be done via a one-shot \`nix shell\` invocation or a pip venv against \`docs/requirements.txt\`; CI is unaffected (it uses the pinned pip requirements, not the dev shell).

## Test plan
- [ ] \`nix develop\` (clang shell) enters successfully and \`cmake --build build\` still works.
- [ ] \`nix develop .#gcc\` still works.
- [ ] \`nix develop .#valgrind\` still works.
- [ ] Docs CI workflow is untouched and still green on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)