### PR TITLE
feat: add --version flag to CLI

### DIFF
--- a/src/sipi.cpp
+++ b/src/sipi.cpp
@@ -863,7 +863,15 @@ int main(int argc, char *argv[])
   std::string optSipiSentryEnvironment;
   sipiopt.add_option("--sentry-environment", optSipiSentryEnvironment)->envname("SIPI_SENTRY_ENVIRONMENT");
 
+  bool optVersion = false;
+  sipiopt.add_flag("--version", optVersion, "Print the SIPI version and exit.");
+
   CLI11_PARSE(sipiopt, argc, argv);
+
+  if (optVersion) {
+    std::cout << "sipi " << VERSION << std::endl;
+    return 0;
+  }
 
   /*
   argc -= (argc > 0);

--- a/test/e2e-rust/tests/cli.rs
+++ b/test/e2e-rust/tests/cli.rs
@@ -1,4 +1,4 @@
-use sipi_e2e::{find_sipi_bin, test_data_dir};
+use sipi_e2e::{find_sipi_bin, repo_root, test_data_dir};
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -210,4 +210,34 @@ fn cli_metadata_fidelity() {
     for path in [&jp2_output, &tif_output, &jpg_output, &png_output] {
         let _ = std::fs::remove_file(path);
     }
+}
+
+#[test]
+fn cli_version_flag() {
+    let sipi_bin =
+        std::env::var("SIPI_BIN").unwrap_or_else(|_| find_sipi_bin().to_string_lossy().to_string());
+
+    let result = Command::new(&sipi_bin)
+        .arg("--version")
+        .output()
+        .unwrap_or_else(|e| panic!("Failed to run sipi --version: {}", e));
+
+    assert!(
+        result.status.success(),
+        "sipi --version exited non-zero: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+
+    let expected_version = std::fs::read_to_string(repo_root().join("version.txt"))
+        .expect("read version.txt")
+        .trim()
+        .to_string();
+    let stdout = String::from_utf8_lossy(&result.stdout);
+    let expected = format!("sipi {}", expected_version);
+    assert!(
+        stdout.trim() == expected,
+        "expected stdout to be {:?}, got {:?}",
+        expected,
+        stdout
+    );
 }


### PR DESCRIPTION
Prints "sipi <VERSION>" using the existing compile-time VERSION macro
from generated/SipiVersion.h, then exits 0. Matches the early-exit
pattern of --query and --compare.