### PR TITLE
ci: replace deadsnakes-PPA python install with actions/setup-python@v5

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -10,17 +10,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install Python
-      shell: bash
-      run: |
-        sudo add-apt-repository -y ppa:deadsnakes/ppa
-        sudo apt install -qyyy --no-install-recommends python${{inputs.version}} python${{inputs.version}}-dev python${{inputs.version}}-distutils 
-        sudo ln -nsf /usr/bin/python${{inputs.version}} /usr/bin/python3
-    - name: Install PIP
-      shell: bash
-      run: |
-        which pip || curl -sS https://bootstrap.pypa.io/get-pip.py | sudo python3
-    - name: Upgrade pip and setuptools
-      shell: bash
-      run: |
-        pip3 install --upgrade pip setuptools wheel
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.version }}
+        cache: pip


### PR DESCRIPTION
## Motivation

`docs` job in `ci.yml` has been failing 100% of the time over the past several hours. The composite action `.github/actions/setup-python` shells out to `sudo add-apt-repository -y ppa:deadsnakes/ppa`, which hits Launchpad's API and has been timing out (`TimeoutError: [Errno 110] Connection timed out`) — Launchpad's reachability from GitHub-hosted runners is intermittently flaky.

## Summary

- Replace the deadsnakes-PPA + apt-install shell-out with `actions/setup-python@v5`. Python comes from the runner toolcache (pre-populated by `actions/python-versions` for all major releases) and falls back to GitHub's mirror — no Launchpad dependency.
- Drop the manual `get-pip.py` curl and the `pip/setuptools/wheel` upgrade step. `actions/setup-python@v5` handles pip + cache in the same action.

## Key Changes

- `.github/actions/setup-python/action.yml`: replaced the three shell steps with a single `uses: actions/setup-python@v5` step. Action contract (`inputs.version`, default `3.11`) is unchanged, so the `docs` consumer in `ci.yml` needs no updates.

## Gotchas

- The new step caches pip (`cache: pip`) keyed by `requirements*.txt` / `pyproject.toml` lock files in the repo root. If the docs build's pip resolves change on every run for some reason, cache hits will be rare — that's still strictly faster than the old PPA path.
- `actions/setup-python@v5` requires the runner OS to have an internet connection to GitHub's CDN for the toolcache fetch, but that's a baseline assumption everywhere else in CI.

## Test Plan

- [ ] CI green on this PR — `docs` should now complete without the Launchpad timeout.