### PR TITLE
fix: --version exits before library init (sanitizer leak gate)

### DIFF
--- a/src/sipi.cpp
+++ b/src/sipi.cpp
@@ -10,6 +10,7 @@
 #include <dirent.h>
 #include <iostream>
 #include <string>
+#include <string_view>
 #include <sys/stat.h>
 #ifdef __APPLE__
 #include <sys/sysctl.h>
@@ -424,6 +425,15 @@ void my_terminate_handler()
  */
 int main(int argc, char *argv[])
 {
+  // Fast path: print version and exit before any library initialisation.
+  // Doing this after curl/exiv2/TIFF init leaks their static registries
+  // at exit and trips the LSan gate in the sanitizer e2e suite.
+  for (int i = 1; i < argc; ++i) {
+    if (std::string_view(argv[i]) == "--version") {
+      std::cout << "sipi " << VERSION << std::endl;
+      return 0;
+    }
+  }
 
   // Set top-level exception handler. Unhandled C++ exceptions are sent to Sentry
   // as message events, then std::abort() is called. The resulting SIGABRT is caught
@@ -863,15 +873,7 @@ int main(int argc, char *argv[])
   std::string optSipiSentryEnvironment;
   sipiopt.add_option("--sentry-environment", optSipiSentryEnvironment)->envname("SIPI_SENTRY_ENVIRONMENT");
 
-  bool optVersion = false;
-  sipiopt.add_flag("--version", optVersion, "Print the SIPI version and exit.");
-
   CLI11_PARSE(sipiopt, argc, argv);
-
-  if (optVersion) {
-    std::cout << "sipi " << VERSION << std::endl;
-    return 0;
-  }
 
   /*
   argc -= (argc > 0);


### PR DESCRIPTION
## Summary

- Move `--version` handling to a small argv sniff at the very top of `main()`, before `std::set_terminate`, sentry init, and `LibraryInitialiser::instance()`.
- Drop the now-dead CLI11 `add_flag("--version", ...)` block plus its `optVersion` check after `CLI11_PARSE`.

## Why

The CLI11-based `--version` path returned `0` after `CLI11_PARSE` — but `main()` had already initialised curl, exiv2, and the TIFF library. Their global static registries stay alive across the early return; LSan reports them as 295 indirect allocations (~23.5 KB) at process exit. The `cli_version_flag` e2e test added in #(0c5da66/82c4dcb) was the first test to actually exercise that fast-exit path under sanitizers, so the latent leak surfaced as a sanitizer-job failure on PR #596 (the bazel-migration PR, which rebased onto a main that already contained the `--version` flag).

The existing suppressions in `.lsan_suppressions.txt` target Lua names (`luaM_realloc_`, `luaL_openlibs`, `luaopen_`); they don't apply here, and they couldn't match anyway because `package.nix` builds with `separateDebugInfo = true` and the workflow has no `llvm-symbolizer` on PATH — every frame is `(/nix/store/.../sipi+0xOFFSET)`.

Sniffing argv directly avoids the entire init/teardown round-trip. Most CLIs treat `--version` and `--help` this way for the same reason.

## Behaviour

- `sipi --version` still prints `sipi <version>` and exits 0 — `cli_version_flag` e2e test continues to pass unchanged.
- All other invocations are unaffected; the loop bails on the first match and falls through otherwise.

## Test plan

- [ ] `sanitizer / asan-ubsan / amd64` passes (the gate that was failing on PR #596).
- [ ] `test / amd64` and `test / arm64` pass (e2e suite including `cli_version_flag`).
- [ ] `nix-macos / arm64 build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)