### PR TITLE
fix(sanitizer): symbolize frames so Lua leak suppressions match

### DIFF
--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -56,7 +56,12 @@ jobs:
         with:
           name: dasch-swiss
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - run: nix profile install --inputs-from . nixpkgs#just
+      # `just` drives the build; `llvmPackages_19.llvm` ships
+      # `llvm-symbolizer`, which ASan/LSan need to resolve the
+      # `(/nix/store/.../sipi+0xOFFSET)` frames into function names.
+      # Without it the name-based suppressions in
+      # `.lsan_suppressions.txt` (`leak:lua*`) can never match.
+      - run: nix profile install --inputs-from . nixpkgs#just nixpkgs#llvmPackages_19.llvm
 
       - name: Build with sanitizers (ASan + UBSan) — unit tests run in sandbox
         env:
@@ -75,7 +80,14 @@ jobs:
         # by the previous step); the test client doesn't need to be
         # sanitized, so building it via crane in a regular sandbox is
         # fine (filter-syscalls only matters for the sanitizer build).
-        run: just nix-test-e2e
+        # Pass `ASAN_SYMBOLIZER_PATH` explicitly so the symbolizer
+        # is found regardless of what's on PATH at exec time
+        # (sanitizers honour this env before doing PATH lookup); the
+        # `.#sanitized` variant in flake.nix keeps DWARF inline so
+        # the symbolizer has something to read.
+        run: |
+          export ASAN_SYMBOLIZER_PATH="$(command -v llvm-symbolizer)"
+          just nix-test-e2e
 
       - name: Check for sanitizer findings in e2e
         if: always()

--- a/flake.nix
+++ b/flake.nix
@@ -319,10 +319,22 @@
           # Mirrors sanitizer.yml's pre-Nix imperative invocation, now as a
           # derivation so `just nix-build-sanitized` routes through Cachix
           # and runs the sanitizer-instrumented gtest suite in-sandbox.
-          sanitized = pkgs.sipi.override {
+          #
+          # Override `separateDebugInfo` / `dontStrip`: the default `pkgs.sipi`
+          # derivation strips the binary into a separate `debug` output, but
+          # the sanitizer e2e step only fetches `result/bin/sipi`. Without
+          # DWARF inline, ASan's symbolizer can't resolve frames, so the
+          # `leak:lua*` patterns in `.lsan_suppressions.txt` never match —
+          # known Lua exit-time leaks then surface as gate failures. Keep
+          # DWARF in the binary for this variant only; production variants
+          # (`.#default`, `.#release`) keep the small stripped layout.
+          sanitized = (pkgs.sipi.override {
             cmakeBuildType = "Debug";
             enableSanitizers = true;
             enableTests = true;
+          }).overrideAttrs {
+            separateDebugInfo = false;
+            dontStrip = true;
           };
 
           # Fuzz harness build. Uses llvmPackages_19.stdenv (libstdc++)


### PR DESCRIPTION
## Summary

- Keep DWARF inline (and skip strip) for the `.#sanitized` Nix variant only — production variants are unchanged.
- Install `llvmPackages_19.llvm` in the sanitizer workflow and export `ASAN_SYMBOLIZER_PATH` for the e2e step.

## Why

The sanitizer gate has been silently broken since the Nix-build migration in `aae582d` (2026-04-17). Two things landed together:

1. `package.nix:182 separateDebugInfo = true` strips the binary at install; DWARF moves to a separate `debug` output that the sanitizer workflow doesn't fetch.
2. The e2e driver (`nix/rust-tests.nix runE2eDriver`) has nothing on PATH besides the test binaries — no `llvm-symbolizer`.

Without DWARF and a symbolizer, every frame in ASan output reads `(/nix/store/.../sipi+0xOFFSET)`. The name-based patterns in `.lsan_suppressions.txt` (`leak:luaM_realloc_`, `leak:luaL_openlibs`, `leak:luaopen_`) can't match hex offsets, so the known Lua-VM exit-time leaks (295 indirect / 23 525 bytes, surfaced by `test/e2e-rust/tests/shutdown.rs::server_exits_cleanly_after_sigterm`) get reported as gate failures.

The pre-migration imperative `cmake` build embedded DWARF inline and apt's `clang` left `llvm-symbolizer` on PATH, so suppressions worked transparently. The last green sanitizer run on `main` was 2026-03-15 — the regression has been latent since then because no PR touched the trigger paths until #596.

## Verification

The flake change matches the existing `.#release` pattern (`overrideAttrs { dontStrip = true; }`) so it composes cleanly with `pkgs.sipi`'s overrides.

## Test plan

- [ ] `sanitizer / asan-ubsan / amd64` passes — frames in any new ASan output should be symbolized (function names + file:line), `leak:lua*` suppressions match the Lua exit-time leaks at SIGTERM.
- [ ] No new closure bloat for production: `.#default` / `.#release` paths are untouched; the larger debug-included variant is only `.#sanitized`.
- [ ] Build still hits Cachix on the next sanitizer run — only the override changes the derivation hash for `.#sanitized`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)