### PR TITLE
test(bazel): port unit + approval tests to cc_test (DEV-6343, PR Y+1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,11 @@ just hurl-test                   # Hurl HTTP contract tests (needs hurl — from
 just nix-run                     # run sipi with the dev config
 just nix-valgrind                # run sipi under Valgrind
 
+# Bazel inner loop (DEV-6343, PR Y+1 — local-only; CI runs unit + approval
+# tests via just nix-build's checkPhase until DEV-6348 (Y+6))
+just bazel-test-unit             # bazel test //test/unit/...  (11 of 12 components; sipiimage tagged manual, DEV-6354)
+just bazel-test-approval         # bazel test //test/approval:approvaltests  (24 cases, env-injected SOURCE_DATE_EPOCH)
+
 # Dev-shell inner loop (non-recipe — see "Inner-loop development" below)
 
 # Docker push / manifest (build is via Nix — see nix-docker-build* above)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -41,6 +41,18 @@ bazel_dep(name = "rules_foreign_cc", version = "0.15.1")
 # toolchains_llvm); MACOSX_DEPLOYMENT_TARGET=12.0 is pinned in .bazelrc.
 bazel_dep(name = "toolchains_llvm", version = "1.7.0")
 
+# ── Test-only deps (DEV-6343, PR Y+1) ──────────────────────────────────────
+# Pinned to 1.17.0.bcr.2 because transitive deps (`aspect_bazel_lib` and the
+# rules under it) already pull in `googletest@1.17.0`; declaring an older
+# version here triggers a `--check_direct_dependencies` warning under
+# Bazel 9's MVS resolver. 1.17.0 is API-compatible with 1.16.0 (the
+# version pinned in `test/CMakeLists.txt`) — gtest's API has been stable
+# across the 1.1x line, and no SIPI test calls a 1.17-specific symbol.
+# The `dev_dependency = True` flag keeps it out of the runtime build graph
+# so production targets in `//src` and `//shttps` cannot accidentally take
+# a transitive dep on test infrastructure.
+bazel_dep(name = "googletest", version = "1.17.0.bcr.2", dev_dependency = True)
+
 # ── LLVM toolchain — hermetic, LLVM 19.1.7, libc++ ─────────────────────────
 #
 # Linux libc++ ships in the LLVM tarball built against glibc, so it still
@@ -110,6 +122,19 @@ register_toolchains("@llvm_toolchain//:all")
 # latter requires `~/.netrc`, which `gh` does not populate).
 kakadu_extension = use_extension("//bazel:kakadu_extension.bzl", "kakadu_extension")
 use_repo(kakadu_extension, "kakadu")
+
+# ── ApprovalTests.cpp (single-header release, no BCR module) ───────────────
+# `bazel/approvaltests_cpp.bzl` downloads the .hpp file released by the
+# upstream project and exposes it as `cc_library(name = "approval_tests")`.
+# Version + checksum mirror `test/CMakeLists.txt:60` verbatim so the
+# Bazel-built and Nix-built test paths consume the same header bytes
+# (DEV-6343, plan §"PR Y+1").
+approvaltests_cpp = use_repo_rule("//bazel:approvaltests_cpp.bzl", "approvaltests_cpp")
+approvaltests_cpp(
+    name = "approvaltests_cpp",
+    url = "https://github.com/approvals/ApprovalTests.cpp/releases/download/v.10.13.0/ApprovalTests.v.10.13.0.hpp",
+    sha256 = "c00f6390b81d9924dc646e9d32b61e1e09abda106c13704f714ac349241bb9ff",
+)
 
 # ── Third-party C/C++ libs (rules_foreign_cc) ──────────────────────────────
 # URLs and SHA256s are the single source of truth, no longer split between

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -18,6 +18,7 @@
     "https://bcr.bazel.build/modules/apple_support/1.15.1/MODULE.bazel": "a0556fefca0b1bb2de8567b8827518f94db6a6e7e7d632b4c48dc5f865bc7c85",
     "https://bcr.bazel.build/modules/apple_support/1.21.0/MODULE.bazel": "ac1824ed5edf17dee2fdd4927ada30c9f8c3b520be1b5fd02a5da15bc10bff3e",
     "https://bcr.bazel.build/modules/apple_support/1.21.1/MODULE.bazel": "5809fa3efab15d1f3c3c635af6974044bac8a4919c62238cce06acee8a8c11f1",
+    "https://bcr.bazel.build/modules/apple_support/1.22.1/MODULE.bazel": "90bd1a660590f3ceffbdf524e37483094b29352d85317060b2327fff8f3f4458",
     "https://bcr.bazel.build/modules/apple_support/1.24.2/MODULE.bazel": "0e62471818affb9f0b26f128831d5c40b074d32e6dda5a0d3852847215a41ca4",
     "https://bcr.bazel.build/modules/apple_support/1.24.2/source.json": "2c22c9827093250406c5568da6c54e6fdf0ef06238def3d99c71b12feb057a8d",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.14.0/MODULE.bazel": "2b31ffcc9bdc8295b2167e07a757dbbc9ac8906e7028e5170a3708cecaac119f",
@@ -73,8 +74,9 @@
     "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
     "https://bcr.bazel.build/modules/googletest/1.14.0/MODULE.bazel": "cfbcbf3e6eac06ef9d85900f64424708cc08687d1b527f0ef65aa7517af8118f",
     "https://bcr.bazel.build/modules/googletest/1.15.2/MODULE.bazel": "6de1edc1d26cafb0ea1a6ab3f4d4192d91a312fd2d360b63adaa213cd00b2108",
+    "https://bcr.bazel.build/modules/googletest/1.17.0.bcr.2/MODULE.bazel": "827f54f492a3ce549c940106d73de332c2b30cebd0c20c0bc5d786aba7f116cb",
+    "https://bcr.bazel.build/modules/googletest/1.17.0.bcr.2/source.json": "3664514073a819992320ffbce5825e4238459df344d8b01748af2208f8d2e1eb",
     "https://bcr.bazel.build/modules/googletest/1.17.0/MODULE.bazel": "dbec758171594a705933a29fcf69293d2468c49ec1f2ebca65c36f504d72df46",
-    "https://bcr.bazel.build/modules/googletest/1.17.0/source.json": "38e4454b25fc30f15439c0378e57909ab1fd0a443158aa35aec685da727cd713",
     "https://bcr.bazel.build/modules/helly25_bzl/0.3.1/MODULE.bazel": "3a4be20f6fc13be32ad44643b8252ef5af09eee936f1d943cd4fd7867fa92826",
     "https://bcr.bazel.build/modules/helly25_bzl/0.3.1/source.json": "b129ab1828492de2c163785bbeb4065c166de52d932524b4317beb5b7f917994",
     "https://bcr.bazel.build/modules/jq.bzl/0.1.0/MODULE.bazel": "2ce69b1af49952cd4121a9c3055faa679e748ce774c7f1fda9657f936cae902f",
@@ -98,6 +100,8 @@
     "https://bcr.bazel.build/modules/platforms/1.0.0/MODULE.bazel": "f05feb42b48f1b3c225e4ccf351f367be0371411a803198ec34a389fb22aa580",
     "https://bcr.bazel.build/modules/platforms/1.0.0/source.json": "f4ff1fd412e0246fd38c82328eb209130ead81d62dcd5a9e40910f867f733d96",
     "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
+    "https://bcr.bazel.build/modules/protobuf/23.1/MODULE.bazel": "88b393b3eb4101d18129e5db51847cd40a5517a53e81216144a8c32dfeeca52a",
+    "https://bcr.bazel.build/modules/protobuf/24.4/MODULE.bazel": "7bc7ce5f2abf36b3b7b7c8218d3acdebb9426aeb35c2257c96445756f970eb12",
     "https://bcr.bazel.build/modules/protobuf/27.0/MODULE.bazel": "7873b60be88844a0a1d8f80b9d5d20cfbd8495a689b8763e76c6372998d3f64c",
     "https://bcr.bazel.build/modules/protobuf/29.0-rc2/MODULE.bazel": "6241d35983510143049943fc0d57937937122baf1b287862f9dc8590fc4c37df",
     "https://bcr.bazel.build/modules/protobuf/29.0-rc3/MODULE.bazel": "33c2dfa286578573afc55a7acaea3cada4122b9631007c594bf0729f41c8de92",
@@ -108,11 +112,13 @@
     "https://bcr.bazel.build/modules/protobuf/33.4/source.json": "555f8686b4c7d6b5ba731fbea13bf656b4bfd9a7ff629c1d9d3f6e1d6155de79",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/MODULE.bazel": "e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34",
-    "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/source.json": "6900fdc8a9e95866b8c0d4ad4aba4d4236317b5c1cd04c502df3f0d33afed680",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.13.6/MODULE.bazel": "2d746fda559464b253b2b2e6073cb51643a2ac79009ca02100ebbc44b4548656",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.13.6/source.json": "6aa0703de8efb20cc897bbdbeb928582ee7beaf278bcd001ac253e1605bddfae",
     "https://bcr.bazel.build/modules/re2/2023-09-01/MODULE.bazel": "cb3d511531b16cfc78a225a9e2136007a48cf8a677e4264baeab57fe78a80206",
     "https://bcr.bazel.build/modules/re2/2024-07-02.bcr.1/MODULE.bazel": "b4963dda9b31080be1905ef085ecd7dd6cd47c05c79b9cdf83ade83ab2ab271a",
-    "https://bcr.bazel.build/modules/re2/2024-07-02.bcr.1/source.json": "2ff292be6ef3340325ce8a045ecc326e92cbfab47c7cbab4bd85d28971b97ac4",
     "https://bcr.bazel.build/modules/re2/2024-07-02/MODULE.bazel": "0eadc4395959969297cbcf31a249ff457f2f1d456228c67719480205aa306daa",
+    "https://bcr.bazel.build/modules/re2/2025-08-12.bcr.1/MODULE.bazel": "e09b434b122bfb786a69179f9b325e35cb1856c3f56a7a81dd61609260ed46e1",
+    "https://bcr.bazel.build/modules/re2/2025-08-12.bcr.1/source.json": "a8ae7c09533bf67f9f6e5122d884d5741600b09d78dca6fc0f2f8d2ee0c2d957",
     "https://bcr.bazel.build/modules/rules_android/0.1.1/MODULE.bazel": "48809ab0091b07ad0182defb787c4c5328bd3a278938415c00a7b69b50c4d3a8",
     "https://bcr.bazel.build/modules/rules_android/0.1.1/source.json": "e6986b41626ee10bdc864937ffb6d6bf275bb5b9c65120e6137d56e6331f089e",
     "https://bcr.bazel.build/modules/rules_apple/3.16.0/MODULE.bazel": "0d1caf0b8375942ce98ea944be754a18874041e4e0459401d925577624d3a54a",
@@ -130,6 +136,7 @@
     "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
     "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
     "https://bcr.bazel.build/modules/rules_cc/0.1.2/MODULE.bazel": "557ddc3a96858ec0d465a87c0a931054d7dcfd6583af2c7ed3baf494407fd8d0",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.4/MODULE.bazel": "bb03a452a7527ac25a7518fb86a946ef63df860b9657d8323a0c50f8504fb0b9",
     "https://bcr.bazel.build/modules/rules_cc/0.1.5/MODULE.bazel": "88dfc9361e8b5ae1008ac38f7cdfd45ad738e4fa676a3ad67d19204f045a1fd8",
     "https://bcr.bazel.build/modules/rules_cc/0.2.0/MODULE.bazel": "b5c17f90458caae90d2ccd114c81970062946f49f355610ed89bebf954f5783c",
     "https://bcr.bazel.build/modules/rules_cc/0.2.13/MODULE.bazel": "eecdd666eda6be16a8d9dc15e44b5c75133405e820f620a234acc4b1fdc5aa37",
@@ -147,6 +154,7 @@
     "https://bcr.bazel.build/modules/rules_java/6.3.0/MODULE.bazel": "a97c7678c19f236a956ad260d59c86e10a463badb7eb2eda787490f4c969b963",
     "https://bcr.bazel.build/modules/rules_java/6.4.0/MODULE.bazel": "e986a9fe25aeaa84ac17ca093ef13a4637f6107375f64667a15999f77db6c8f6",
     "https://bcr.bazel.build/modules/rules_java/6.5.2/MODULE.bazel": "1d440d262d0e08453fa0c4d8f699ba81609ed0e9a9a0f02cd10b3e7942e61e31",
+    "https://bcr.bazel.build/modules/rules_java/7.1.0/MODULE.bazel": "30d9135a2b6561c761bd67bd4990da591e6bdc128790ce3e7afd6a3558b2fb64",
     "https://bcr.bazel.build/modules/rules_java/7.10.0/MODULE.bazel": "530c3beb3067e870561739f1144329a21c851ff771cd752a49e06e3dc9c2e71a",
     "https://bcr.bazel.build/modules/rules_java/7.12.2/MODULE.bazel": "579c505165ee757a4280ef83cda0150eea193eed3bef50b1004ba88b99da6de6",
     "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
@@ -187,10 +195,12 @@
     "https://bcr.bazel.build/modules/rules_python/0.28.0/MODULE.bazel": "cba2573d870babc976664a912539b320cbaa7114cd3e8f053c720171cde331ed",
     "https://bcr.bazel.build/modules/rules_python/0.31.0/MODULE.bazel": "93a43dc47ee570e6ec9f5779b2e64c1476a6ce921c48cc9a1678a91dd5f8fd58",
     "https://bcr.bazel.build/modules/rules_python/0.33.2/MODULE.bazel": "3e036c4ad8d804a4dad897d333d8dce200d943df4827cb849840055be8d2e937",
+    "https://bcr.bazel.build/modules/rules_python/0.34.0/MODULE.bazel": "1d623d026e075b78c9fde483a889cda7996f5da4f36dffb24c246ab30f06513a",
     "https://bcr.bazel.build/modules/rules_python/0.4.0/MODULE.bazel": "9208ee05fd48bf09ac60ed269791cf17fb343db56c8226a720fbb1cdf467166c",
     "https://bcr.bazel.build/modules/rules_python/1.2.0/MODULE.bazel": "5aeeb48b2a6c19d668b48adf2b8a2b209a6310c230db0ce77450f148a89846e4",
     "https://bcr.bazel.build/modules/rules_python/1.3.0/MODULE.bazel": "8361d57eafb67c09b75bf4bbe6be360e1b8f4f18118ab48037f2bd50aa2ccb13",
     "https://bcr.bazel.build/modules/rules_python/1.4.1/MODULE.bazel": "8991ad45bdc25018301d6b7e1d3626afc3c8af8aaf4bc04f23d0b99c938b73a6",
+    "https://bcr.bazel.build/modules/rules_python/1.5.1/MODULE.bazel": "acfe65880942d44a69129d4c5c3122d57baaf3edf58ae5a6bd4edea114906bf5",
     "https://bcr.bazel.build/modules/rules_python/1.6.0/MODULE.bazel": "7e04ad8f8d5bea40451cf80b1bd8262552aa73f841415d20db96b7241bd027d8",
     "https://bcr.bazel.build/modules/rules_python/1.7.0/MODULE.bazel": "d01f995ecd137abf30238ad9ce97f8fc3ac57289c8b24bd0bf53324d937a14f8",
     "https://bcr.bazel.build/modules/rules_python/1.7.0/source.json": "028a084b65dcf8f4dc4f82f8778dbe65df133f234b316828a82e060d81bdce32",
@@ -222,6 +232,7 @@
     "https://bcr.bazel.build/modules/toolchains_llvm/1.7.0/MODULE.bazel": "55aca6a8c5b372651f663c5e22faf3664d81165e40074c98fb8a30ee5af83272",
     "https://bcr.bazel.build/modules/toolchains_llvm/1.7.0/source.json": "cda5fa1abeab5561e811860222952f6cb9373f34b88c5b3f4417459dca057a6d",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
+    "https://bcr.bazel.build/modules/upb/0.0.0-20230516-61a97ef/MODULE.bazel": "c0df5e35ad55e264160417fd0875932ee3c9dda63d9fccace35ac62f45e1b6f9",
     "https://bcr.bazel.build/modules/yq.bzl/0.1.1/MODULE.bazel": "9039681f9bcb8958ee2c87ffc74bdafba9f4369096a2b5634b88abc0eaefa072",
     "https://bcr.bazel.build/modules/yq.bzl/0.1.1/source.json": "2d2bad780a9f2b9195a4a370314d2c17ae95eaa745cefc2e12fbc49759b15aa3",
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
@@ -257,21 +268,19 @@
     },
     "@@pybind11_bazel+//:internal_configure.bzl%internal_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "06cynZ1bCvvy8zHPrrDlXq+Z68xmjctHpfFxi+zEpJY=",
-        "usagesDigest": "D1r3lfzMuUBFxgG8V6o0bQTLMk3GkaGOaPzw53wrwyw=",
+        "bzlTransitiveDigest": "RWNeAcCsBPGOS5WS5YNdDD2UDjpW7uqJe5YK8Ziul+Q=",
+        "usagesDigest": "tVQNvLoXMWAbiK39am3yovKGpwINdftfn7RpDyN+JZc=",
         "recordedInputs": [
-          "REPO_MAPPING:pybind11_bazel+,bazel_tools bazel_tools",
-          "FILE:@@pybind11_bazel+//MODULE.bazel e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34"
+          "REPO_MAPPING:pybind11_bazel+,bazel_tools bazel_tools"
         ],
         "generatedRepoSpecs": {
           "pybind11": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@pybind11_bazel+//:pybind11-BUILD.bazel",
-              "strip_prefix": "pybind11-2.12.0",
-              "urls": [
-                "https://github.com/pybind/pybind11/archive/v2.12.0.zip"
-              ]
+              "strip_prefix": "pybind11-2.13.6",
+              "url": "https://github.com/pybind/pybind11/archive/refs/tags/v2.13.6.tar.gz",
+              "integrity": "sha256-4Iy4f0dz2pf6e18DXeh2OrxlbYfVdz5i9toFh9Hw7CA="
             }
           }
         }

--- a/bazel/approvaltests_cpp.bzl
+++ b/bazel/approvaltests_cpp.bzl
@@ -1,0 +1,41 @@
+"""Custom repository_rule for ApprovalTests.cpp (single-header library).
+
+ApprovalTests.cpp ships its release as a single .hpp file (not a tarball), so
+`http_archive` does not apply and BCR has no `approvaltests_cpp` module. This
+rule mirrors today's CMake flow in `test/CMakeLists.txt:53-72`:
+
+    file(DOWNLOAD ${HEADER_URL} ${HEADER_FILE} EXPECTED_HASH SHA256=...)
+
+It downloads `ApprovalTests.v.<version>.hpp` to `ApprovalTests.hpp` inside the
+generated repo and writes a `BUILD.bazel` exposing the header as a
+`cc_library(name = "approval_tests")`. The plan's `@approvaltests_cpp//:approval_tests`
+target name (DEV-6343, plan §"PR Y+1") resolves through this rule.
+
+Version + checksum match the values pinned in `test/CMakeLists.txt:60` so the
+Bazel-built and Nix-built test paths consume the exact same header bytes.
+"""
+
+def _approvaltests_cpp_impl(ctx):
+    ctx.download(
+        url = ctx.attr.url,
+        output = "ApprovalTests.hpp",
+        sha256 = ctx.attr.sha256,
+    )
+    ctx.file("BUILD.bazel", """\
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "approval_tests",
+    hdrs = ["ApprovalTests.hpp"],
+    includes = ["."],
+    visibility = ["//visibility:public"],
+)
+""")
+
+approvaltests_cpp = repository_rule(
+    implementation = _approvaltests_cpp_impl,
+    attrs = {
+        "url": attr.string(mandatory = True, doc = "URL of the single-header release."),
+        "sha256": attr.string(mandatory = True, doc = "SHA-256 of the header bytes."),
+    },
+)

--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -1,0 +1,21 @@
+"""Sipi runtime config files — exposed as Bazel filegroups so unit + e2e
+tests can declare them as `data` deps.
+
+Today the only consumer is `//test/unit/configuration:configuration_tests`
+(DEV-6343, Y+1), which parses `sipi.config.lua` to verify the Lua-driven
+config loader. Y+5 (DEV-6347) will add `sipi.e2e-test-config.lua` and
+`sipi.test-config.lua` to support the Rust e2e suite via Bazel.
+"""
+
+package(default_visibility = ["//visibility:public"])
+
+# Every Lua config file at the top level of `config/`. Sub-trees like
+# `config/scripts/` are not included by default; add a separate filegroup
+# if a future test needs them.
+filegroup(
+    name = "configs",
+    srcs = glob(
+        ["*.lua"],
+        allow_empty = False,
+    ),
+)

--- a/docs/src/development/developing.md
+++ b/docs/src/development/developing.md
@@ -94,9 +94,21 @@ The mandatory gate is CI; the local hook is fast-feedback parity.
 
 ## Writing Tests
 
-We use two test frameworks:
-[GoogleTest](https://github.com/google/googletest) for unit tests and
-[pytest](http://doc.pytest.org/en/latest/) for end-to-end tests.
+Unit + approval tests use [GoogleTest](https://github.com/google/googletest)
+(approval tests additionally use [ApprovalTests.cpp](https://github.com/approvals/ApprovalTests.cpp)).
+End-to-end tests are written in Rust and live under `test/e2e-rust/`;
+HTTP contract tests use [Hurl](https://hurl.dev/).
+
+C++ tests build under both CMake/ctest (the Nix-driven canonical CI
+path) and Bazel `cc_test` (DEV-6343, PR Y+1 of the Nix → Bazel migration —
+local-only inner loop until DEV-6348/Y+6 cuts CI over). The `just`
+recipes that wrap each:
+
+```bash
+just nix-build                   # Builds + runs ctest unit + approval (CI)
+just bazel-test-unit             # bazel test //test/unit/...        (local)
+just bazel-test-approval         # bazel test //test/approval:approvaltests  (local)
+```
 
 ### Unit Tests
 
@@ -209,18 +221,24 @@ just nix-test-smoke
 ### Approval Tests
 
 Approval tests live in `test/approval/` and use snapshot-based
-testing for regression detection. Run them via ctest:
+testing for regression detection. Two equivalent runners:
 
 ```bash
+# CMake/ctest (the canonical CI path, runs as part of just nix-build)
 cd build
 ctest -L approval --output-on-failure
+
+# Bazel cc_test (DEV-6343, local-only)
+just bazel-test-approval
 ```
 
-CMake injects `SOURCE_DATE_EPOCH=946684800` into the `sipi.approvaltests`
-invocation so the wall-clock-stamped ICC creation date that lcms2 stamps
-into JPEG / PNG / JP2 (and ICC-carrying TIFF) outputs is overwritten
-with a fixed value. Without the env var the seconds field drifts by one
-byte across consecutive runs.
+Both runners inject `SOURCE_DATE_EPOCH=946684800` into the test process
+(CMake via `set_tests_properties(... ENVIRONMENT ...)`, Bazel via
+`test/approval/BUILD.bazel`'s `env = {}` block) so the wall-clock-stamped
+ICC creation date that lcms2 stamps into JPEG / PNG / JP2 (and
+ICC-carrying TIFF) outputs is overwritten with a fixed value. Without
+the env var the seconds field drifts by one byte across consecutive
+runs.
 
 When running the binary directly outside of ctest, export the same
 value first:

--- a/docs/src/development/testing-strategy.md
+++ b/docs/src/development/testing-strategy.md
@@ -773,7 +773,10 @@ insta::assert_json_snapshot!(info_json, {
 
 | Target | Just Recipe | When | Notes |
 |---|---|---|---|
-| C++ unit tests | `just nix-build` (`.#dev` checkPhase) | PR CI | GoogleTest via ctest, runs in the Nix sandbox |
+| C++ unit tests (CI) | `just nix-build` (`.#dev` checkPhase) | PR CI | GoogleTest via ctest, runs in the Nix sandbox |
+| C++ unit tests (Bazel inner-loop) | `just bazel-test-unit` | local | `bazel test //test/unit/...`; 11 of 12 components (sipiimage tagged manual, [DEV-6354](https://linear.app/dasch/issue/DEV-6354)). Local-only until [DEV-6348](https://linear.app/dasch/issue/DEV-6348) (Y+6) cuts CI over. |
+| C++ approval tests (CI) | `just nix-build` (`.#dev` checkPhase) | PR CI | ApprovalTests via ctest; `SOURCE_DATE_EPOCH=946684800` injected by CMake |
+| C++ approval tests (Bazel inner-loop) | `just bazel-test-approval` | local | `bazel test //test/approval:approvaltests`; same env injection via `BUILD.bazel`. Local-only until [DEV-6348](https://linear.app/dasch/issue/DEV-6348) (Y+6). |
 | Rust e2e tests (CI) | `just nix-test-e2e` | PR CI | Pre-built binaries from `.#e2e-tests` (crane); reads `$SIPI_BIN` |
 | Rust e2e tests (inner-loop) | `just rust-test-e2e` | local | cargo-driven; reads `$SIPI_BIN`; same test code as `nix-test-e2e` |
 | Docker smoke (CI) | `just nix-test-smoke` | PR + tag CI | Pre-built binary from `.#smoke-test`; runs against loaded image |

--- a/fuzz/handlers/corpus/BUILD.bazel
+++ b/fuzz/handlers/corpus/BUILD.bazel
@@ -1,0 +1,20 @@
+"""Seed corpus for the IIIF URI parser fuzz harness.
+
+Today the corpus is consumed by two callers:
+  * `fuzz/handlers/iiif_handler_uri_parser_fuzz` — exposed via Bazel in Y+3
+    (DEV-6345) when the fuzz harness moves off Nix.
+  * `test/unit/handlers/parse_iiif_uri_corpus_test` — the Y+1 unit test that
+    re-runs the corpus against the parser as a regression suite. Today
+    (Y+1, DEV-6343) this is the only consumer.
+
+Exposing the corpus as a Bazel `filegroup` lets the unit test declare it
+as a `data` dep and find the files at workspace-relative paths in the
+runfiles tree (cc_test cwd = workspace root).
+"""
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "seed_corpus",
+    srcs = glob(["*"], allow_empty = True),
+)

--- a/justfile
+++ b/justfile
@@ -178,6 +178,34 @@ nix-coverage:
     @echo "Coverage at: result-coverage/coverage.xml"
 
 #####################################
+# Bazel
+#
+# Inner-loop test recipes for the Nix → Bazel build orchestration
+# migration (DEV-6341). PR Y (DEV-6342) landed the build graph itself;
+# Y+1 (DEV-6343) ports unit + approval tests to `cc_test` targets and
+# wires them up here. CI continues to run unit + approval tests via
+# `just nix-build`'s `checkPhase` until Y+6 (DEV-6348) cuts CI fully
+# over to Bazel — these recipes are local-only.
+#
+# Requires `bazelisk` from the Nix dev shell (added to flake.nix in Y).
+#####################################
+
+# Run every GoogleTest unit-test target under //test/unit/.
+# Excludes //test/unit/sipiimage:sipi_image_tests, which is tagged
+# `manual` because its test bodies write to the source `_test_data/`
+# tree — Bazel runfiles is read-only. Tracked for follow-up in
+# DEV-6354. CMake/ctest still exercises sipiimage on `main`.
+bazel-test-unit:
+    bazel test //test/unit/...
+
+# Run the approval-test target. SOURCE_DATE_EPOCH=946684800 and
+# SIPI_WORKSPACE_ROOT="." are injected by `test/approval/BUILD.bazel`;
+# any `.received.<ext>` file from a maintainer-driven re-approval
+# lands under `bazel-testlogs/test/approval/approvaltests/`.
+bazel-test-approval:
+    bazel test //test/approval:approvaltests
+
+#####################################
 # Tests (consume $SIPI_BIN, default ./result/bin/sipi)
 #####################################
 

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -159,6 +159,43 @@ cc_library(
     ],
     includes = ["."],
     copts = ["-fexceptions"],
+    # System libs / frameworks required by transitive deps of any sipi_lib
+    # consumer — i.e. //src:sipi (the binary) AND every cc_test under
+    # //test/unit/... (Y+1, DEV-6343). Declaring them here (not on
+    # //src:sipi) lets cc_library's `linkopts` propagation surface them on
+    # every downstream link line, so unit tests don't have to redeclare
+    # them. The CMake build does the equivalent on `libsipi_testable`
+    # (test/CMakeLists.txt: `target_link_libraries(libsipi_testable PUBLIC
+    # ... iconv -framework CoreFoundation -framework SystemConfiguration)`).
+    linkopts = select({
+        # `-ldl` — Lua's package loader uses dlopen/dlclose/dlsym/dladdr
+        # for runtime .so loading. On macOS those live in libSystem; on
+        # Linux they're in libdl, which the toolchain doesn't auto-link.
+        # `-lpthread` — exiv2 + sentry call pthread_* directly. Modern
+        # glibc folds pthread into libc, but ld.lld doesn't follow the
+        # -pthread driver flag through to the underlying linker line, so
+        # we spell the lib out.
+        "@platforms//os:linux": [
+            "-ldl",
+            "-lpthread",
+        ],
+        # System frameworks/libs required by transitive deps:
+        #   * `-liconv` — exiv2's convert.cpp uses iconv() on macOS for
+        #     metadata charset conversion. Apple ships libiconv in
+        #     /usr/lib/libiconv.dylib but the link must be explicit.
+        #   * `-framework SystemConfiguration` — curl's macos.c calls
+        #     `SCDynamicStoreCopyProxies` for proxy auto-detection.
+        #   * `-framework CoreFoundation` — implicit dep of
+        #     SystemConfiguration; safer to spell out.
+        "@platforms//os:macos": [
+            "-liconv",
+            "-framework",
+            "SystemConfiguration",
+            "-framework",
+            "CoreFoundation",
+        ],
+        "//conditions:default": [],
+    }),
     deps = [
         "//include:headers",
         "//shttps:shttps",
@@ -187,6 +224,11 @@ cc_library(
 )
 
 # ── //src:sipi ─────────────────────────────────────────────────────────────
+# System-lib + framework linkopts (`-ldl`, `-lpthread`, `-liconv`,
+# `-framework SystemConfiguration`, `-framework CoreFoundation`) are
+# declared on `:sipi_lib` so they also propagate to every cc_test under
+# //test/unit/... — see the linkopts block on `:sipi_lib` above. This
+# binary keeps only its own binary-specific flag (`--build-id=sha1`).
 cc_binary(
     name = "sipi",
     srcs = ["sipi.cpp"],
@@ -195,35 +237,7 @@ cc_binary(
         # in Y+4. `--build-id=sha1` derives the build-id from the binary's
         # content hash rather than a wall-clock random; identical inputs
         # ↔ identical build-id.
-        # `-ldl` — Lua's package loader uses dlopen/dlclose/dlsym/dladdr
-        # for runtime .so loading. On macOS those live in libSystem; on
-        # Linux they're in libdl, which the toolchain doesn't auto-link.
-        # `-lpthread` — exiv2 + sentry call pthread_* directly. Modern
-        # glibc folds pthread into libc, but ld.lld doesn't follow the
-        # -pthread driver flag through to the underlying linker line, so
-        # we spell the lib out.
-        "@platforms//os:linux": [
-            "-Wl,--build-id=sha1",
-            "-ldl",
-            "-lpthread",
-        ],
-        # System frameworks/libs required by transitive deps:
-        #   * `-liconv` — exiv2's convert.cpp uses iconv() on macOS for
-        #     metadata charset conversion. Apple ships libiconv in
-        #     /usr/lib/libiconv.dylib but the link must be explicit.
-        #   * `-framework SystemConfiguration` — curl's macos.c calls
-        #     `SCDynamicStoreCopyProxies` for proxy auto-detection.
-        #   * `-framework CoreFoundation` — implicit dep of
-        #     SystemConfiguration; safer to spell out.
-        # Mirrors what nixpkgs' wrapped clang adds to LDFLAGS for the
-        # CMake build of SIPI today.
-        "@platforms//os:macos": [
-            "-liconv",
-            "-framework",
-            "SystemConfiguration",
-            "-framework",
-            "CoreFoundation",
-        ],
+        "@platforms//os:linux": ["-Wl,--build-id=sha1"],
         "//conditions:default": [],
     }),
     deps = [":sipi_lib"] + select({

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,0 +1,15 @@
+"""Shared test helpers for Bazel-driven unit + approval tests."""
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+# Header-only helper for resolving test-data and tmp directories from the
+# environment. Honoured by every per-component test that reads files under
+# `test/_test_data/` or writes to a scratch dir.
+cc_library(
+    name = "test_paths",
+    hdrs = ["test_paths.hpp"],
+    includes = ["."],
+    testonly = True,
+)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -132,6 +132,10 @@ target_include_directories(libsipi_testable PUBLIC
     ${CMAKE_SOURCE_DIR}/include/formats
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_SOURCE_DIR}/shttps
+    # Test-helper headers (sipi::test::data_dir() etc., DEV-6343 / Y+1).
+    # Bazel exposes the same header via //test:test_paths; here it is
+    # propagated to every per-component test that links libsipi_testable.
+    ${CMAKE_SOURCE_DIR}/test
     ${CMAKE_BINARY_DIR}
     ${CMAKE_BINARY_DIR}/local/include
     ${CMAKE_BINARY_DIR}/generated

--- a/test/_test_data/BUILD.bazel
+++ b/test/_test_data/BUILD.bazel
@@ -10,28 +10,9 @@ for the env-var-driven path resolution).
 
 package(default_visibility = ["//visibility:public"])
 
-# Everything under test/_test_data/ — used by the approval test target,
-# which exercises a wide cross-section of the fixture tree.
-filegroup(
-    name = "all",
-    srcs = glob(
-        ["**/*"],
-        # Excluded: the dotfile prefix on `_test_data` already prevents it
-        # from being picked up by recursive globs in source code, but be
-        # explicit here so Bazel's strict glob mode does not warn on
-        # the (currently empty) git-ignored subtrees.
-        exclude = [
-            "images/thumbs/**",
-            "scripts/**",
-        ],
-        allow_empty = True,
-    ),
-)
-
-# Subset consumed by `//test/unit/sipiimage` — the image fixtures and the
-# (subdirectory-only) thumbs dir. Thumbs is referenced as a write target
-# in CMake but Bazel routes writes to TEST_TMPDIR; we keep the entry as a
-# parity hint.
+# Image fixtures consumed by Bazel-driven tests. `images/thumbs/**` is
+# excluded because it's a write-only target dir under CMake; under Bazel
+# every test routes writes to TEST_TMPDIR via `sipi::test::tmp_dir()`.
 filegroup(
     name = "images",
     srcs = glob(

--- a/test/_test_data/BUILD.bazel
+++ b/test/_test_data/BUILD.bazel
@@ -1,0 +1,42 @@
+"""Test fixture data consumed by Bazel-driven unit + approval tests.
+
+Filegroups expose subtrees under `test/_test_data/` so individual `cc_test`
+targets can declare just the data they need rather than the whole tree.
+The Bazel-set `TEST_SRCDIR/TEST_WORKSPACE` cwd is the workspace root in
+runfiles; a test reading these files looks at workspace-relative paths
+like `test/_test_data/images/unit/lena512.jp2` (see `test/test_paths.hpp`
+for the env-var-driven path resolution).
+"""
+
+package(default_visibility = ["//visibility:public"])
+
+# Everything under test/_test_data/ — used by the approval test target,
+# which exercises a wide cross-section of the fixture tree.
+filegroup(
+    name = "all",
+    srcs = glob(
+        ["**/*"],
+        # Excluded: the dotfile prefix on `_test_data` already prevents it
+        # from being picked up by recursive globs in source code, but be
+        # explicit here so Bazel's strict glob mode does not warn on
+        # the (currently empty) git-ignored subtrees.
+        exclude = [
+            "images/thumbs/**",
+            "scripts/**",
+        ],
+        allow_empty = True,
+    ),
+)
+
+# Subset consumed by `//test/unit/sipiimage` — the image fixtures and the
+# (subdirectory-only) thumbs dir. Thumbs is referenced as a write target
+# in CMake but Bazel routes writes to TEST_TMPDIR; we keep the entry as a
+# parity hint.
+filegroup(
+    name = "images",
+    srcs = glob(
+        ["images/**/*"],
+        exclude = ["images/thumbs/**"],
+        allow_empty = True,
+    ),
+)

--- a/test/approval/BUILD.bazel
+++ b/test/approval/BUILD.bazel
@@ -1,0 +1,56 @@
+"""Approval tests — byte-exact image-encode baselines + metadata
+goldens (DEV-6343, plan §"PR Y+1").
+
+The `env = {"SOURCE_DATE_EPOCH": "946684800"}` injection mirrors
+`test/approval/CMakeLists.txt`'s `set_tests_properties(... ENVIRONMENT
+SOURCE_DATE_EPOCH=946684800 ...)`. Without it the JPEG/PNG/JP2 goldens
+drift on every run because `SipiIcc::iccBytes()` falls back to lcms2's
+wall-clock-stamped header (see ADR-0002,
+docs/adr/0002-icc-profile-determinism-test-only.md).
+
+`SIPI_WORKSPACE_ROOT="."` lets `sipi::test::workspace_path_for_approval()`
+resolve fixture and golden paths from the runfiles workspace root.
+TEST_TMPDIR is set by Bazel automatically and consumed by
+image_encode_baseline_test.cpp's `received_dir()` so any `.received.<ext>`
+file from a maintainer-driven re-approval lands under
+`bazel-testlogs/` (per the plan's verification gate).
+"""
+
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+# Filegroup of approved golden files. Mirrors the on-disk layout under
+# `test/approval/approval_tests/` 1:1 — Git LFS is the source of truth.
+filegroup(
+    name = "approved_goldens",
+    srcs = glob(
+        ["approval_tests/**"],
+        allow_empty = False,
+    ),
+    visibility = ["//visibility:public"],
+)
+
+cc_test(
+    name = "approvaltests",
+    srcs = glob(["*.cpp"]),
+    # ApprovalTests' default namer reads the source .cpp file at its
+    # workspace-relative path to derive the golden filename. Bazel's
+    # cc_test compiles `srcs` into the binary but does not put them
+    # into the runfiles tree, so the namer's `test/approval/<name>.cpp`
+    # lookup fails with "build configuration" errors. Add the same
+    # glob as `data` so the sources also live under runfiles.
+    data = glob(["*.cpp"]) + [
+        ":approved_goldens",
+        "//test/_test_data:images",
+    ],
+    env = {
+        "SIPI_WORKSPACE_ROOT": ".",
+        "SOURCE_DATE_EPOCH": "946684800",
+    },
+    local_defines = ["APPROVAL_TESTS_HIDE_DEPRECATED_CODE=1"],
+    deps = [
+        "//src:sipi_lib",
+        "//test:test_paths",
+        "@approvaltests_cpp//:approval_tests",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/test/approval/approval_tests/metadata_golden_test.MetadataGolden.GrayWithIcc.approved.txt
+++ b/test/approval/approval_tests/metadata_golden_test.MetadataGolden.GrayWithIcc.approved.txt
@@ -1,4 +1,4 @@
-=== ../../../test/_test_data/images/unit/gray_with_icc_another.jpg ===
+=== gray_with_icc_another.jpg ===
 
 Dimensions: 1607x1200
 Channels: 1

--- a/test/approval/approval_tests/metadata_golden_test.MetadataGolden.HasCommentBlock.approved.txt
+++ b/test/approval/approval_tests/metadata_golden_test.MetadataGolden.HasCommentBlock.approved.txt
@@ -1,4 +1,4 @@
-=== ../../../test/_test_data/images/unit/HasCommentBlock.JPG ===
+=== HasCommentBlock.JPG ===
 
 Dimensions: 373x496
 Channels: 3

--- a/test/approval/approval_tests/metadata_golden_test.MetadataGolden.ImageOrientation.approved.txt
+++ b/test/approval/approval_tests/metadata_golden_test.MetadataGolden.ImageOrientation.approved.txt
@@ -1,4 +1,4 @@
-=== ../../../test/_test_data/images/unit/image_orientation.jpg ===
+=== image_orientation.jpg ===
 
 Dimensions: 3264x2448
 Channels: 3

--- a/test/approval/approval_tests/metadata_golden_test.MetadataGolden.ImgExifGps.approved.txt
+++ b/test/approval/approval_tests/metadata_golden_test.MetadataGolden.ImgExifGps.approved.txt
@@ -1,4 +1,4 @@
-=== ../../../test/_test_data/images/unit/img_exif_gps.jpg ===
+=== img_exif_gps.jpg ===
 
 Dimensions: 4032x3024
 Channels: 3

--- a/test/approval/approval_tests/metadata_golden_test.MetadataGolden.MaoriFigure.approved.txt
+++ b/test/approval/approval_tests/metadata_golden_test.MetadataGolden.MaoriFigure.approved.txt
@@ -1,4 +1,4 @@
-=== ../../../test/_test_data/images/unit/MaoriFigure.jpg ===
+=== MaoriFigure.jpg ===
 
 Dimensions: 1014x1933
 Channels: 3

--- a/test/approval/image_encode_baseline_test.cpp
+++ b/test/approval/image_encode_baseline_test.cpp
@@ -53,12 +53,12 @@
 #include <string>
 #include <sys/stat.h>
 
-// `workspace_path_for_approval` honours Bazel's SIPI_WORKSPACE_ROOT env
-// (cc_test cwd = workspace root in runfiles) and falls back to the
-// historical CMake build-tree relative path (3 levels up from
-// build/test/approval/) when unset. See test/test_paths.hpp.
-static const std::string test_images = sipi::test::workspace_path_for_approval("test/_test_data/images") + "/";
-static const std::string approved_dir = sipi::test::workspace_path_for_approval("test/approval/approval_tests");
+// `sipi::test::workspace_path()` honours Bazel's SIPI_WORKSPACE_ROOT env
+// (cc_test cwd = workspace root in runfiles). The CMake fallback
+// `"../../.."` is the 3-level traversal from build/test/approval/ to
+// the workspace root. See test/test_paths.hpp.
+static const std::string test_images = sipi::test::workspace_path("test/_test_data/images", "../../..") + "/";
+static const std::string approved_dir = sipi::test::workspace_path("test/approval/approval_tests", "../../..");
 
 namespace {
 

--- a/test/approval/image_encode_baseline_test.cpp
+++ b/test/approval/image_encode_baseline_test.cpp
@@ -43,6 +43,7 @@
 #include "SipiImageError.hpp"
 #include "iiifparser/SipiRegion.h"
 #include "iiifparser/SipiSize.h"
+#include "test_paths.hpp"
 
 #include <cstdio>
 #include <filesystem>
@@ -52,9 +53,12 @@
 #include <string>
 #include <sys/stat.h>
 
-// Approval tests run from build/test/approval/.
-static const std::string test_images = "../../../test/_test_data/images/";
-static const std::string approved_dir = "../../../test/approval/approval_tests";
+// `workspace_path_for_approval` honours Bazel's SIPI_WORKSPACE_ROOT env
+// (cc_test cwd = workspace root in runfiles) and falls back to the
+// historical CMake build-tree relative path (3 levels up from
+// build/test/approval/) when unset. See test/test_paths.hpp.
+static const std::string test_images = sipi::test::workspace_path_for_approval("test/_test_data/images") + "/";
+static const std::string approved_dir = sipi::test::workspace_path_for_approval("test/approval/approval_tests");
 
 namespace {
 
@@ -96,10 +100,12 @@ void encode(const std::string &in_path,
 }
 
 // Where to drop `.received.<ext>` files when the maintainer needs to
-// inspect them — under approved_dir if writable (dev-shell inner loop),
-// otherwise under $TMPDIR (Nix sandbox checkPhase).
+// inspect them — TEST_TMPDIR (Bazel cc_test, written under
+// `bazel-testlogs/`), under approved_dir if writable (CMake dev-shell
+// inner loop), otherwise under $TMPDIR (Nix sandbox checkPhase).
 std::string received_dir()
 {
+  if (const char *bazel_tmp = std::getenv("TEST_TMPDIR")) { return std::string(bazel_tmp); }
   std::error_code ec;
   std::filesystem::create_directories(approved_dir, ec);
   if (!ec) return approved_dir;

--- a/test/approval/metadata_golden_test.cpp
+++ b/test/approval/metadata_golden_test.cpp
@@ -10,12 +10,17 @@
 #include "SipiImageError.hpp"
 #include "metadata/SipiExif.h"
 #include "metadata/SipiIcc.h"
+#include "test_paths.hpp"
 
+#include <filesystem>
 #include <sstream>
 #include <sys/stat.h>
 
-// Approval tests run from build/test/approval/
-static const std::string test_images = "../../../test/_test_data/images/";
+// `workspace_path_for_approval` honours Bazel's SIPI_WORKSPACE_ROOT env
+// (cc_test cwd = workspace root in runfiles) and falls back to the
+// historical CMake build-tree relative path (3 levels up from
+// build/test/approval/) when unset. See test/test_paths.hpp.
+static const std::string test_images = sipi::test::workspace_path_for_approval("test/_test_data/images") + "/";
 
 static bool file_exists(const std::string &path)
 {
@@ -27,7 +32,11 @@ static bool file_exists(const std::string &path)
 static std::string dump_metadata(const std::string &path)
 {
   std::ostringstream out;
-  out << "=== " << path << " ===\n\n";
+  // Use the basename only — the full path differs between build systems
+  // (CMake's `../../../test/_test_data/...` vs Bazel's runfiles-relative
+  // `test/_test_data/...`), and embedding the differing prefix in the
+  // golden text would make goldens build-system-specific.
+  out << "=== " << std::filesystem::path(path).filename().string() << " ===\n\n";
 
   Sipi::SipiImage img;
   try {

--- a/test/approval/metadata_golden_test.cpp
+++ b/test/approval/metadata_golden_test.cpp
@@ -16,11 +16,11 @@
 #include <sstream>
 #include <sys/stat.h>
 
-// `workspace_path_for_approval` honours Bazel's SIPI_WORKSPACE_ROOT env
-// (cc_test cwd = workspace root in runfiles) and falls back to the
-// historical CMake build-tree relative path (3 levels up from
-// build/test/approval/) when unset. See test/test_paths.hpp.
-static const std::string test_images = sipi::test::workspace_path_for_approval("test/_test_data/images") + "/";
+// `sipi::test::workspace_path()` honours Bazel's SIPI_WORKSPACE_ROOT env
+// (cc_test cwd = workspace root in runfiles). The CMake fallback
+// `"../../.."` is the 3-level traversal from build/test/approval/ to
+// the workspace root. See test/test_paths.hpp.
+static const std::string test_images = sipi::test::workspace_path("test/_test_data/images", "../../..") + "/";
 
 static bool file_exists(const std::string &path)
 {

--- a/test/test_paths.hpp
+++ b/test/test_paths.hpp
@@ -3,18 +3,24 @@
 // The two build systems run the test binary from different working
 // directories:
 //   * CMake / ctest:  cwd = build/test/<unit|approval>/<...>/. The depth
-//                     to the workspace root differs:
+//                     to the workspace root differs by layer:
 //                       unit tests       (test/unit/<comp>/)  → 4 levels up
 //                       approval tests   (test/approval/)     → 3 levels up
-//                     Each helper takes the appropriate fallback string.
+//                     Each call site passes the appropriate fallback
+//                     traversal explicitly.
 //   * Bazel cc_test:  cwd = workspace root in runfiles. `../../*` escapes
 //                     the runfiles tree, so we use `SIPI_WORKSPACE_ROOT`
 //                     (set to "." by the cc_test rules) instead.
 //
 // `SIPI_WORKSPACE_ROOT` and `TEST_TMPDIR` are honoured when set (Bazel
-// sets both), with the historical CMake-relative paths as fallbacks.
-// Helpers return paths *without* a trailing slash; callers append
-// `"/sub/dir/file"`.
+// sets both); the explicit fallback is the CMake-build-tree relative
+// traversal. Helpers return paths *without* a trailing slash; callers
+// append `"/sub/dir/file"`.
+//
+// Thread-safety: `std::getenv` is not thread-safe relative to
+// `setenv`/`putenv`. These helpers are intended for static-init or
+// single-threaded test setup only — the test binary never mutates its
+// environment after main() begins.
 
 #pragma once
 
@@ -24,45 +30,32 @@
 
 namespace sipi::test {
 
-namespace detail {
-
-// Internal: returns SIPI_WORKSPACE_ROOT if set, else the supplied
-// fallback. Callers usually go through one of the named helpers below.
-inline std::string workspace_root(std::string_view fallback)
+// Resolve a workspace-relative path. Prefers the Bazel-set
+// `SIPI_WORKSPACE_ROOT` env, falls back to `cmake_fallback` (the
+// caller-supplied `../`-traversal that walks back to the workspace root
+// from the test binary's CMake build directory).
+//
+// Examples:
+//   workspace_path("test/_test_data", "../../../..")   // unit tests
+//   workspace_path("test/_test_data", "../../..")      // approval tests
+inline std::string workspace_path(std::string_view subpath, std::string_view cmake_fallback)
 {
-  if (const char *env = std::getenv("SIPI_WORKSPACE_ROOT")) { return std::string{env}; }
-  return std::string{fallback};
+  const std::string root = (std::getenv("SIPI_WORKSPACE_ROOT") != nullptr)
+                             ? std::string{std::getenv("SIPI_WORKSPACE_ROOT")}
+                             : std::string{cmake_fallback};
+  return subpath.empty() ? root : root + "/" + std::string{subpath};
 }
 
-}// namespace detail
+// Path to `test/_test_data` from a unit test (cwd = build/test/unit/<comp>/).
+inline std::string data_dir() { return workspace_path("test/_test_data", "../../../.."); }
 
-// Workspace path for **unit tests** (cwd = build/test/unit/<comp>/, so
-// `../../../..` reaches the workspace root). Pass a `subpath` like
-// `"test/_test_data"` to walk into a subtree.
-inline std::string workspace_path_for_unit(std::string_view subpath = {})
-{
-  const std::string base = detail::workspace_root("../../../..");
-  return subpath.empty() ? base : base + "/" + std::string{subpath};
-}
-
-// Workspace path for **approval tests** (cwd = build/test/approval/,
-// so `../../..` reaches the workspace root).
-inline std::string workspace_path_for_approval(std::string_view subpath = {})
-{
-  const std::string base = detail::workspace_root("../../..");
-  return subpath.empty() ? base : base + "/" + std::string{subpath};
-}
-
-// Path to `test/_test_data`. Default is the unit-test cwd-relative form;
-// approval tests override via `workspace_path_for_approval("test/_test_data")`.
-inline std::string data_dir() { return workspace_path_for_unit("test/_test_data"); }
-
-// Path to `config/`. Same comment as `data_dir()`.
-inline std::string config_dir() { return workspace_path_for_unit("config"); }
+// Path to `config/` from a unit test.
+inline std::string config_dir() { return workspace_path("config", "../../../.."); }
 
 // Writable scratch directory. Prefers `TEST_TMPDIR` (Bazel sets this per
-// test run). Falls back to `<unit data_dir>/images/thumbs` for ctest,
-// which is where the existing tests already write their intermediates.
+// test run, scoped under `bazel-testlogs/<test>/test.outputs/`). Falls
+// back to the CMake unit-test convention of writing into
+// `test/_test_data/images/thumbs/`.
 inline std::string tmp_dir()
 {
   if (const char *env = std::getenv("TEST_TMPDIR")) { return std::string{env}; }

--- a/test/test_paths.hpp
+++ b/test/test_paths.hpp
@@ -1,16 +1,20 @@
-// Test-data path helpers shared by SIPI's GoogleTest unit tests.
+// Test-data path helpers shared by SIPI's GoogleTest unit + approval tests.
 //
 // The two build systems run the test binary from different working
 // directories:
-//   * CMake / ctest:  cwd = build/test/unit/<comp>/, so the historical
-//                     `../../../..` traversal resolves to the workspace.
-//   * Bazel cc_test:  cwd = workspace root in runfiles. `../../../..`
-//                     escapes the runfiles tree.
+//   * CMake / ctest:  cwd = build/test/<unit|approval>/<...>/. The depth
+//                     to the workspace root differs:
+//                       unit tests       (test/unit/<comp>/)  → 4 levels up
+//                       approval tests   (test/approval/)     → 3 levels up
+//                     Each helper takes the appropriate fallback string.
+//   * Bazel cc_test:  cwd = workspace root in runfiles. `../../*` escapes
+//                     the runfiles tree, so we use `SIPI_WORKSPACE_ROOT`
+//                     (set to "." by the cc_test rules) instead.
 //
-// `SIPI_WORKSPACE_ROOT` (set by Bazel cc_test rules to ".") and
-// `TEST_TMPDIR` (set by Bazel for any test run) are honoured when set,
-// with the historical CMake-relative paths as fallbacks. Helpers return
-// paths *without* a trailing slash; callers append `"/sub/dir/file"`.
+// `SIPI_WORKSPACE_ROOT` and `TEST_TMPDIR` are honoured when set (Bazel
+// sets both), with the historical CMake-relative paths as fallbacks.
+// Helpers return paths *without* a trailing slash; callers append
+// `"/sub/dir/file"`.
 
 #pragma once
 
@@ -20,26 +24,45 @@
 
 namespace sipi::test {
 
-// Resolve a workspace-relative path. Prefers `SIPI_WORKSPACE_ROOT` (Bazel
-// sets this to "." — a runfiles-relative path that resolves correctly
-// from the cc_test cwd), falls back to `../../../..` for CMake/ctest.
-inline std::string workspace_path(std::string_view subpath = {})
+namespace detail {
+
+// Internal: returns SIPI_WORKSPACE_ROOT if set, else the supplied
+// fallback. Callers usually go through one of the named helpers below.
+inline std::string workspace_root(std::string_view fallback)
 {
-  const std::string base = (std::getenv("SIPI_WORKSPACE_ROOT") != nullptr)
-                             ? std::string{std::getenv("SIPI_WORKSPACE_ROOT")}
-                             : std::string{"../../../.."};
+  if (const char *env = std::getenv("SIPI_WORKSPACE_ROOT")) { return std::string{env}; }
+  return std::string{fallback};
+}
+
+}// namespace detail
+
+// Workspace path for **unit tests** (cwd = build/test/unit/<comp>/, so
+// `../../../..` reaches the workspace root). Pass a `subpath` like
+// `"test/_test_data"` to walk into a subtree.
+inline std::string workspace_path_for_unit(std::string_view subpath = {})
+{
+  const std::string base = detail::workspace_root("../../../..");
   return subpath.empty() ? base : base + "/" + std::string{subpath};
 }
 
-// Path to `test/_test_data`.
-inline std::string data_dir() { return workspace_path("test/_test_data"); }
+// Workspace path for **approval tests** (cwd = build/test/approval/,
+// so `../../..` reaches the workspace root).
+inline std::string workspace_path_for_approval(std::string_view subpath = {})
+{
+  const std::string base = detail::workspace_root("../../..");
+  return subpath.empty() ? base : base + "/" + std::string{subpath};
+}
 
-// Path to `config/`.
-inline std::string config_dir() { return workspace_path("config"); }
+// Path to `test/_test_data`. Default is the unit-test cwd-relative form;
+// approval tests override via `workspace_path_for_approval("test/_test_data")`.
+inline std::string data_dir() { return workspace_path_for_unit("test/_test_data"); }
+
+// Path to `config/`. Same comment as `data_dir()`.
+inline std::string config_dir() { return workspace_path_for_unit("config"); }
 
 // Writable scratch directory. Prefers `TEST_TMPDIR` (Bazel sets this per
-// test run). Falls back to `<data_dir>/images/thumbs` for ctest, which is
-// where the existing tests already write their intermediates.
+// test run). Falls back to `<unit data_dir>/images/thumbs` for ctest,
+// which is where the existing tests already write their intermediates.
 inline std::string tmp_dir()
 {
   if (const char *env = std::getenv("TEST_TMPDIR")) { return std::string{env}; }

--- a/test/test_paths.hpp
+++ b/test/test_paths.hpp
@@ -1,0 +1,49 @@
+// Test-data path helpers shared by SIPI's GoogleTest unit tests.
+//
+// The two build systems run the test binary from different working
+// directories:
+//   * CMake / ctest:  cwd = build/test/unit/<comp>/, so the historical
+//                     `../../../..` traversal resolves to the workspace.
+//   * Bazel cc_test:  cwd = workspace root in runfiles. `../../../..`
+//                     escapes the runfiles tree.
+//
+// `SIPI_WORKSPACE_ROOT` (set by Bazel cc_test rules to ".") and
+// `TEST_TMPDIR` (set by Bazel for any test run) are honoured when set,
+// with the historical CMake-relative paths as fallbacks. Helpers return
+// paths *without* a trailing slash; callers append `"/sub/dir/file"`.
+
+#pragma once
+
+#include <cstdlib>
+#include <string>
+#include <string_view>
+
+namespace sipi::test {
+
+// Resolve a workspace-relative path. Prefers `SIPI_WORKSPACE_ROOT` (Bazel
+// sets this to "." — a runfiles-relative path that resolves correctly
+// from the cc_test cwd), falls back to `../../../..` for CMake/ctest.
+inline std::string workspace_path(std::string_view subpath = {})
+{
+  const std::string base = (std::getenv("SIPI_WORKSPACE_ROOT") != nullptr)
+                             ? std::string{std::getenv("SIPI_WORKSPACE_ROOT")}
+                             : std::string{"../../../.."};
+  return subpath.empty() ? base : base + "/" + std::string{subpath};
+}
+
+// Path to `test/_test_data`.
+inline std::string data_dir() { return workspace_path("test/_test_data"); }
+
+// Path to `config/`.
+inline std::string config_dir() { return workspace_path("config"); }
+
+// Writable scratch directory. Prefers `TEST_TMPDIR` (Bazel sets this per
+// test run). Falls back to `<data_dir>/images/thumbs` for ctest, which is
+// where the existing tests already write their intermediates.
+inline std::string tmp_dir()
+{
+  if (const char *env = std::getenv("TEST_TMPDIR")) { return std::string{env}; }
+  return data_dir() + "/images/thumbs";
+}
+
+}// namespace sipi::test

--- a/test/unit/cache/BUILD.bazel
+++ b/test/unit/cache/BUILD.bazel
@@ -1,0 +1,12 @@
+"""Cache unit tests."""
+
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "cache_tests",
+    srcs = glob(["*.cpp"]),
+    deps = [
+        "//src:sipi_lib",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/test/unit/configuration/BUILD.bazel
+++ b/test/unit/configuration/BUILD.bazel
@@ -1,0 +1,22 @@
+"""Configuration parsing unit tests.
+
+The Lua-driven config loader reads `config/sipi.config.lua`. We declare
+the config tree as a `data` dep and pass `SIPI_WORKSPACE_ROOT="."` so
+`sipi::test::config_dir()` (`test/test_paths.hpp`) resolves to the
+runfiles `<workspace>/config/` path. The env-unset fallback preserves
+CMake/ctest behaviour.
+"""
+
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "configuration_tests",
+    srcs = glob(["*.cpp"]),
+    data = ["//config:configs"],
+    env = {"SIPI_WORKSPACE_ROOT": "."},
+    deps = [
+        "//src:sipi_lib",
+        "//test:test_paths",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/test/unit/configuration/configuration.cpp
+++ b/test/unit/configuration/configuration.cpp
@@ -7,6 +7,7 @@
 
 #include "../../../include/SipiConf.h"
 #include "../../../shttps/LuaServer.h"
+#include "test_paths.hpp"
 
 #include <cstdio>
 #include <unistd.h>
@@ -29,7 +30,10 @@ inline bool exists_file(const std::string &name)
   return (stat(name.c_str(), &buffer) == 0);
 }
 
-const std::string configfile { "../../../../config/sipi.config.lua"};
+// `sipi::test::config_dir()` honours Bazel's SIPI_WORKSPACE_ROOT env and
+// falls back to the historical CMake build-tree relative path when
+// unset. See test/test_paths.hpp.
+const std::string configfile = sipi::test::config_dir() + "/sipi.config.lua";
 
 // Check if configuration file can be found
 TEST(Configuration, CheckIfConfigurationFileCanBeFound)

--- a/test/unit/decode_dims/BUILD.bazel
+++ b/test/unit/decode_dims/BUILD.bazel
@@ -1,0 +1,12 @@
+"""SipiDecodeDims unit tests."""
+
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "decode_dims_tests",
+    srcs = glob(["*.cpp"]),
+    deps = [
+        "//src:sipi_lib",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/test/unit/filenamehash/BUILD.bazel
+++ b/test/unit/filenamehash/BUILD.bazel
@@ -1,0 +1,12 @@
+"""SipiFilenameHash unit tests."""
+
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "filenamehash",
+    srcs = glob(["*.cpp"]),
+    deps = [
+        "//src:sipi_lib",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/test/unit/handlers/BUILD.bazel
+++ b/test/unit/handlers/BUILD.bazel
@@ -1,0 +1,23 @@
+"""IIIF handlers unit tests (iiif_handler + the corpus-driven URI
+parser regression suite).
+
+The corpus-driven test (`parse_iiif_uri_corpus_test.cpp`) reads
+SIPI_FUZZ_CORPUS_DIR as a compile-time string literal pointing at the
+fuzz seed corpus. Bazel passes the workspace-relative path
+`fuzz/handlers/corpus`; cc_test cwd is the workspace root in
+runfiles, so `std::filesystem::exists("fuzz/handlers/corpus")`
+resolves through the runfiles tree.
+"""
+
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "sipi_handlers_tests",
+    srcs = glob(["*.cpp"]),
+    data = ["//fuzz/handlers/corpus:seed_corpus"],
+    local_defines = ['SIPI_FUZZ_CORPUS_DIR=\\"fuzz/handlers/corpus\\"'],
+    deps = [
+        "//src:sipi_lib",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/test/unit/iiifparser/BUILD.bazel
+++ b/test/unit/iiifparser/BUILD.bazel
@@ -1,0 +1,14 @@
+"""IIIF URL component parser unit tests (Identifier, Region, Size,
+Rotation, QualityFormat).
+"""
+
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "iiifparser",
+    srcs = glob(["*.cpp"]),
+    deps = [
+        "//src:sipi_lib",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/test/unit/logger/BUILD.bazel
+++ b/test/unit/logger/BUILD.bazel
@@ -1,0 +1,12 @@
+"""Logger unit tests."""
+
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "logger",
+    srcs = glob(["*.cpp"]),
+    deps = [
+        "//src:sipi_lib",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/test/unit/memory_budget/BUILD.bazel
+++ b/test/unit/memory_budget/BUILD.bazel
@@ -1,0 +1,12 @@
+"""SipiMemoryBudget unit tests."""
+
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "memory_budget_tests",
+    srcs = glob(["*.cpp"]),
+    deps = [
+        "//src:sipi_lib",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/test/unit/shttps/BUILD.bazel
+++ b/test/unit/shttps/BUILD.bazel
@@ -1,0 +1,12 @@
+"""shttps utility unit tests (Hash, Parsing, urldecode, SocketControl)."""
+
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "shttps_utils",
+    srcs = glob(["*.cpp"]),
+    deps = [
+        "//src:sipi_lib",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/test/unit/sipiconnectionmetrics/BUILD.bazel
+++ b/test/unit/sipiconnectionmetrics/BUILD.bazel
@@ -1,0 +1,14 @@
+"""SipiConnectionMetricsAdapter unit tests (DEV-6339 dependency
+inversion — verifies the adapter forwards to SipiMetrics).
+"""
+
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "sipi_connection_metrics_adapter_test",
+    srcs = glob(["*.cpp"]),
+    deps = [
+        "//src:sipi_lib",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/test/unit/sipiicc/BUILD.bazel
+++ b/test/unit/sipiicc/BUILD.bazel
@@ -1,0 +1,20 @@
+"""SipiIcc byte-mutation helper unit tests (the function backing
+SipiIcc::iccBytes()'s SOURCE_DATE_EPOCH reproducibility hook — see
+sipi PR #587).
+
+The 8 tests in this suite cover apply_icc_header_normalization
+directly with explicit epochs (no env var reads), so unlike
+//test/approval:approvaltests this target does NOT need to set
+SOURCE_DATE_EPOCH.
+"""
+
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "sipi_icc_normalize_test",
+    srcs = glob(["*.cpp"]),
+    deps = [
+        "//src:sipi_lib",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/test/unit/sipiimage/BUILD.bazel
+++ b/test/unit/sipiimage/BUILD.bazel
@@ -1,0 +1,38 @@
+"""SipiImage unit tests — DEFERRED from Bazel runs in Y+1.
+
+The test bodies write to the source `test/_test_data/` tree mid-flight
+(both `images/thumbs/<X>` and `_<temp>` filenames in `images/{knora,unit}/`).
+CMake/ctest gets away with this because the workspace is read-write, but
+Bazel's runfiles tree is read-only on macOS-darwin sandbox.
+
+Properly porting requires per-line audit of every hardcoded path in
+`*.cpp` to split source-reads from write-targets — tracked in DEV-6354
+(`Bazel migration follow-up — port test/unit/sipiimage to Bazel cc_test`).
+The infrastructure to support the port is already in place:
+  * `//test:test_paths` provides `sipi::test::data_dir()` and `tmp_dir()`.
+  * `//test/_test_data:images` is the data filegroup.
+  * 5 of the 6 sources in this dir already use `sipi::test::data_dir()`
+    via the env-var pattern (the env-unset fallback preserves CMake
+    behaviour).
+
+`tags = ["manual"]` keeps this target out of `bazel test //test/unit/...`.
+The CMake/ctest path (`just nix-build`'s `checkPhase`) continues to
+exercise these tests on `main`, so coverage is preserved.
+
+Drop `manual` and finalise paths in DEV-6354.
+"""
+
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "sipi_image_tests",
+    srcs = glob(["*.cpp"]),
+    data = ["//test/_test_data:images"],
+    env = {"SIPI_WORKSPACE_ROOT": "."},
+    tags = ["manual"],
+    deps = [
+        "//src:sipi_lib",
+        "//test:test_paths",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/test/unit/sipiimage/format_error_path_test.cpp
+++ b/test/unit/sipiimage/format_error_path_test.cpp
@@ -15,10 +15,13 @@
 #include "SipiIOJpeg.h"
 #include "SipiIOPng.h"
 #include "SipiIOTiff.h"
+#include "test_paths.hpp"
 
-// Unit tests run from build/test/unit/sipiimage/
-static const std::string test_images = "../../../../test/_test_data/images/";
-static const std::string tmp_dir = "../../../../test/_test_data/images/thumbs/";
+// `sipi::test::{data_dir,tmp_dir}` honour Bazel's SIPI_TEST_DATA_DIR /
+// TEST_TMPDIR envs and fall back to the historical CMake build-tree
+// relative paths when unset. See test/test_paths.hpp.
+static const std::string test_images = sipi::test::data_dir() + "/images/";
+static const std::string tmp_dir = sipi::test::tmp_dir() + "/";
 
 static bool file_exists(const std::string &path)
 {

--- a/test/unit/sipiimage/imginfo_test.cpp
+++ b/test/unit/sipiimage/imginfo_test.cpp
@@ -11,9 +11,13 @@
 #include "SipiIOJpeg.h"
 #include "SipiIOPng.h"
 #include "SipiIOTiff.h"
+#include "test_paths.hpp"
 
-// Unit tests run from build/test/unit/sipiimage/
-static const std::string test_images = "../../../../test/_test_data/images/unit/";
+// CMake/ctest runs this binary from build/test/unit/sipiimage/, where the
+// historical relative path resolves to the test fixtures. Bazel cc_test
+// runs from the workspace root in runfiles and sets SIPI_TEST_DATA_DIR.
+// `sipi::test::data_dir()` honours both — see test/test_paths.hpp.
+static const std::string test_images = sipi::test::data_dir() + "/images/unit/";
 
 static bool file_exists(const std::string &path) {
   struct stat buf{};

--- a/test/unit/sipiimage/jpeg_format_regression_test.cpp
+++ b/test/unit/sipiimage/jpeg_format_regression_test.cpp
@@ -53,13 +53,13 @@ Sipi::SipiImage readFixture(const std::string &path)
  *  diagnosis using `--json`; regardless of that cause, the contract is
  *  "sipi reads these images without throwing". We use a parameterized
  *  test so both siblings (-o and -r) share the same contract. */
-class Jpeg_35_2421d_Reads : public ::testing::TestWithParam<const char *>
+class Jpeg_35_2421d_Reads : public ::testing::TestWithParam<std::string>
 {
 };
 
 TEST_P(Jpeg_35_2421d_Reads, ReadsSuccessfully)
 {
-  const char *path = GetParam();
+  const std::string &path = GetParam();
   Sipi::SipiImage img;
   ASSERT_NO_THROW(img = readFixture(path)) << "Failed to read " << path;
   EXPECT_EQ(img.getNx(), 404u);
@@ -76,7 +76,7 @@ TEST_P(Jpeg_35_2421d_Reads, ReadsSuccessfully)
  *  `SipiIOJ2k::write`'s UUID-box emitter). */
 TEST_P(Jpeg_35_2421d_Reads, XmpSurvivesRead)
 {
-  const char *path = GetParam();
+  const std::string &path = GetParam();
   Sipi::SipiImage img;
   ASSERT_NO_THROW(img = readFixture(path));
   ASSERT_NE(img.getXmp(), nullptr) << "XMP must be populated for " << path;
@@ -87,13 +87,9 @@ TEST_P(Jpeg_35_2421d_Reads, XmpSurvivesRead)
     << "XMP body should contain the German Photoshop caption";
 }
 
-// `kJpegHeritage_*` are `std::string` (constructed at static init from
-// `data_dir()`), but the parametrized fixture expects `const char *` —
-// pass `.c_str()` to match. The strings outlive the test suite (file-scope
-// statics), so the pointers stay valid for the duration of the run.
 INSTANTIATE_TEST_SUITE_P(Heritage,
   Jpeg_35_2421d_Reads,
-  ::testing::Values(kJpegHeritage_o.c_str(), kJpegHeritage_r.c_str()));
+  ::testing::Values(kJpegHeritage_o, kJpegHeritage_r));
 
 /*! R8 — a JPEG whose metadata fails to parse must still return a usable
  *  image. Today, an exception during IPTC / EXIF / XMP parsing aborts the

--- a/test/unit/sipiimage/jpeg_format_regression_test.cpp
+++ b/test/unit/sipiimage/jpeg_format_regression_test.cpp
@@ -15,17 +15,24 @@
 #include "SipiIOTiff.h"
 #include "iiifparser/SipiRegion.h"
 #include "iiifparser/SipiSize.h"
+#include "test_paths.hpp"
 
 #include <memory>
 #include <string>
 
 namespace {
 
-constexpr const char *kJpegHeritage_o = "../../../../test/_test_data/images/jpeg/35-2421d-o.jpg";
-constexpr const char *kJpegHeritage_r = "../../../../test/_test_data/images/jpeg/35-2421d-r.jpg";
-constexpr const char *kJpegCmykApp14 = "../../../../test/_test_data/images/jpeg/cmyk/cmyk_photoshop_app14.jpg";
-constexpr const char *kJpegCmykRaw = "../../../../test/_test_data/images/jpeg/cmyk/cmyk_raw_no_app14.jpg";
-constexpr const char *kJpegMalformedXmp = "../../../../test/_test_data/images/jpeg/malformed_xmp.jpg";
+// `sipi::test::data_dir()` honours Bazel's SIPI_TEST_DATA_DIR env and
+// falls back to the historical CMake build-tree relative path when
+// unset. See test/test_paths.hpp. `static const std::string` (rather
+// than `constexpr const char *`) is required because the path is built
+// at static-init time from `std::getenv`.
+static const std::string kJpegFixtureRoot = sipi::test::data_dir() + "/images/jpeg";
+static const std::string kJpegHeritage_o = kJpegFixtureRoot + "/35-2421d-o.jpg";
+static const std::string kJpegHeritage_r = kJpegFixtureRoot + "/35-2421d-r.jpg";
+static const std::string kJpegCmykApp14 = kJpegFixtureRoot + "/cmyk/cmyk_photoshop_app14.jpg";
+static const std::string kJpegCmykRaw = kJpegFixtureRoot + "/cmyk/cmyk_raw_no_app14.jpg";
+static const std::string kJpegMalformedXmp = kJpegFixtureRoot + "/malformed_xmp.jpg";
 
 Sipi::SipiImage readFixture(const std::string &path)
 {
@@ -80,7 +87,13 @@ TEST_P(Jpeg_35_2421d_Reads, XmpSurvivesRead)
     << "XMP body should contain the German Photoshop caption";
 }
 
-INSTANTIATE_TEST_SUITE_P(Heritage, Jpeg_35_2421d_Reads, ::testing::Values(kJpegHeritage_o, kJpegHeritage_r));
+// `kJpegHeritage_*` are `std::string` (constructed at static init from
+// `data_dir()`), but the parametrized fixture expects `const char *` —
+// pass `.c_str()` to match. The strings outlive the test suite (file-scope
+// statics), so the pointers stay valid for the duration of the run.
+INSTANTIATE_TEST_SUITE_P(Heritage,
+  Jpeg_35_2421d_Reads,
+  ::testing::Values(kJpegHeritage_o.c_str(), kJpegHeritage_r.c_str()));
 
 /*! R8 — a JPEG whose metadata fails to parse must still return a usable
  *  image. Today, an exception during IPTC / EXIF / XMP parsing aborts the

--- a/test/unit/sipiimage/jpeg_write_test.cpp
+++ b/test/unit/sipiimage/jpeg_write_test.cpp
@@ -13,10 +13,13 @@
 #include "SipiImage.hpp"
 #include "SipiImageError.hpp"
 #include "SipiIO.h"
+#include "test_paths.hpp"
 
-// Unit tests run from build/test/unit/sipiimage/
-static const std::string test_images = "../../../../test/_test_data/images/";
-static const std::string tmp_dir = "../../../../test/_test_data/images/thumbs/";
+// `sipi::test::{data_dir,tmp_dir}` honour Bazel's SIPI_TEST_DATA_DIR /
+// TEST_TMPDIR envs and fall back to the historical CMake build-tree
+// relative paths when unset. See test/test_paths.hpp.
+static const std::string test_images = sipi::test::data_dir() + "/images/";
+static const std::string tmp_dir = sipi::test::tmp_dir() + "/";
 
 static bool file_exists(const std::string &path)
 {

--- a/test/unit/sipiimage/tiff_bilevel_regression_test.cpp
+++ b/test/unit/sipiimage/tiff_bilevel_regression_test.cpp
@@ -15,18 +15,25 @@
 #include "SipiIOTiff.h"
 #include "iiifparser/SipiRegion.h"
 #include "iiifparser/SipiSize.h"
+#include "test_paths.hpp"
 
 #include <memory>
 #include <string>
 
 namespace {
 
-constexpr const char *kBilevelLzwMinisWhite = "../../../../test/_test_data/images/bilevel/bilevel_lzw_miniswhite.tif";
-constexpr const char *kBilevelNoneMinisWhite = "../../../../test/_test_data/images/bilevel/bilevel_none_miniswhite.tif";
-constexpr const char *kBilevelLzwMinisBlack = "../../../../test/_test_data/images/bilevel/bilevel_lzw_minisblack.tif";
-constexpr const char *kBilevelRoiTest = "../../../../test/_test_data/images/bilevel/bilevel_roi_test.tif";
+// `sipi::test::data_dir()` honours Bazel's SIPI_TEST_DATA_DIR env and
+// falls back to the historical CMake build-tree relative path when
+// unset. See test/test_paths.hpp. `static const std::string` (rather
+// than `constexpr const char *`) is required because the path is built
+// at static-init time from `std::getenv`.
+static const std::string kBilevelDir = sipi::test::data_dir() + "/images/bilevel";
+static const std::string kBilevelLzwMinisWhite = kBilevelDir + "/bilevel_lzw_miniswhite.tif";
+static const std::string kBilevelNoneMinisWhite = kBilevelDir + "/bilevel_none_miniswhite.tif";
+static const std::string kBilevelLzwMinisBlack = kBilevelDir + "/bilevel_lzw_minisblack.tif";
+static const std::string kBilevelRoiTest = kBilevelDir + "/bilevel_roi_test.tif";
 
-constexpr const char *kLeaves8Tif = "../../../../test/_test_data/images/knora/Leaves8.tif";
+static const std::string kLeaves8Tif = sipi::test::data_dir() + "/images/knora/Leaves8.tif";
 
 Sipi::SipiImage readFixture(const std::string &path,
   std::shared_ptr<Sipi::SipiRegion> region = nullptr,


### PR DESCRIPTION
Fixes DEV-6343

## Motivation

PR Y+1 of the [Sipi Bazel migration](https://linear.app/dasch/issue/DEV-6341). Y (DEV-6342) landed the Bazel build graph for `//src:sipi`; this PR makes the unit + approval tests buildable and runnable through the Bazel `cc_test` graph so subsequent migration PRs (Y+2 sanitizers, Y+3 fuzz, Y+5 e2e, Y+6 cutover) can compose against a single test infrastructure.

The migration's primary near-term driver is *architectural enforcement in the age of agentic coding* (plan §"Problem Statement" line 26). Bazel's `package_group()` + `visibility` + `--strict_deps` + Clang `layering_check` turn module-boundary rules into build invariants. Y+1's per-component `cc_test` targets are the first concrete proof-point that the test surface migrates cleanly — without them, every downstream variant in the migration would be testing through CMake while the binary builds through Bazel, splitting the verification surface.

CI is unchanged. Unit + approval tests continue running via `just nix-build`'s `checkPhase` until [DEV-6348](https://linear.app/dasch/issue/DEV-6348) (Y+6) cuts CI fully over.

## Summary

- 12 unit components and the approval-test suite are now reachable as Bazel `cc_test` targets (`//test/unit/...` + `//test/approval:approvaltests`), runnable via `just bazel-test-unit` and `just bazel-test-approval`.
- 11 of 12 unit components ported cleanly; `sipiimage` is deferred to [DEV-6354](https://linear.app/dasch/issue/DEV-6354) (its tests write to the source tree — incompatible with Bazel's read-only runfiles).
- `test/test_paths.hpp` introduces a small env-var-driven path resolver so the same test sources compile + run under both CMake/ctest and Bazel `cc_test`.

## Key Changes

### Bazel deps + repo rule
- `MODULE.bazel` — `googletest@1.17.0.bcr.2` from BCR (1.17 forced by transitive deps; API-compatible with the 1.16 pinned in `test/CMakeLists.txt`); `dev_dependency = True` so production targets cannot transitively depend on test infrastructure.
- `bazel/approvaltests_cpp.bzl` — small custom `repository_rule` (~25 lines) downloading the single `.hpp` release and wrapping it as `cc_library(@approvaltests_cpp//:approval_tests)`. BCR has no module for ApprovalTests.cpp, and `http_archive` doesn't apply to a single header.

### `cc_test` targets
- 12 per-component `BUILD.bazel` files under `test/unit/<comp>/`, deps-only on `//src:sipi_lib + @googletest//:gtest_main`. (`ratelimiter/` is dead — its `CMakeLists.txt` isn't referenced from `test/CMakeLists.txt`.)
- `test/approval/BUILD.bazel` defines `:approvaltests` with `env = {"SOURCE_DATE_EPOCH": "946684800"}` mirroring `set_tests_properties(... ENVIRONMENT ...)` in CMake, plus a `:approved_goldens` filegroup for the 24 committed `.approved.<ext>` baselines.
- Filegroups for runtime data: `//test/_test_data:images`, `//config:configs`, `//fuzz/handlers/corpus:seed_corpus`.

### Cross-build helper
- `test/test_paths.hpp` exposes `sipi::test::workspace_path(subpath, cmake_fallback) / data_dir() / config_dir() / tmp_dir()`. Honours Bazel-set envs (`SIPI_WORKSPACE_ROOT="."`, `TEST_TMPDIR`) and falls back to the historical CMake `../`-traversal when unset. Test sources updated to call through it.

### `//src:sipi_lib` linkopts
- macOS frameworks (`-liconv`, `-framework SystemConfiguration`, `-framework CoreFoundation`) and Linux system libs (`-ldl`, `-lpthread`) moved from `//src:sipi` (binary) to `//src:sipi_lib` (library) so they propagate to every cc_test consumer. Mirrors what `test/CMakeLists.txt` does on `libsipi_testable` via `target_link_libraries(... PUBLIC iconv -framework ...)`. The binary keeps only `--build-id=sha1`.

### `just` recipes + CMake parity
- `just bazel-test-unit` and `just bazel-test-approval` wrap `bazel test //test/unit/...` and `bazel test //test/approval:approvaltests`.
- `test/CMakeLists.txt` adds `${CMAKE_SOURCE_DIR}/test` to `libsipi_testable`'s include directories so CMake-built tests find `test_paths.hpp` without a `../` traversal.

### Docs
- `CLAUDE.md` Quick Reference, `docs/src/development/developing.md`, `docs/src/development/testing-strategy.md` updated to surface the Bazel recipes alongside the existing `nix-*` paths.

## Challenges and Decisions

### sipiimage tests write to the source `_test_data/` tree
**Problem:** `test/unit/sipiimage/*.cpp` contains ~50 hardcoded paths intermixing source-fixture reads and write-target paths under `images/{knora,unit,thumbs}/`. CMake/ctest gets away with this because the workspace is read-write, but Bazel's runfiles tree is read-only on the macOS-darwin sandbox.
**Tried:** A bulk regex `data_dir() + "/images/<sub>/<X>"` → `tmp_dir() + "/<X>"` rewrite. Reverted because the regex couldn't distinguish source-reads (e.g. `mario.tif`, `cmyk.tif`, `cmyk_lossy.jp2`, `image_orientation.tif`) from write-targets — some filenames appear as both write-target and read-back-of-write within the same test body. Per-line audit needed.
**Solution:** Tagged `//test/unit/sipiimage:sipi_image_tests` as `manual`, opened [DEV-6354](https://linear.app/dasch/issue/DEV-6354) for the proper port. CMake/ctest still exercises sipiimage on `main`, so coverage is preserved. The "test-count parity" plan acceptance has one documented exception.

### Unit and approval tests run from different CMake `cwd` depths
**Problem:** `data_dir()` needs to fall back to `../../../..` for unit tests (`build/test/unit/<comp>/`, 4 levels) but `../../..` for approval tests (`build/test/approval/`, 3 levels). A single hard-coded fallback string couldn't serve both.
**Tried:** Two separate helpers `workspace_path_for_unit()` / `workspace_path_for_approval()`. cpp + simplicity reviewers flagged this as encoding layer-depth in identifiers — fragile and unscalable.
**Solution:** Single `workspace_path(subpath, cmake_fallback)` helper; call sites pass the explicit `../`-traversal. Adding a future test layer doesn't require a new helper. Bazel's `SIPI_WORKSPACE_ROOT` short-circuits the fallback regardless.

### ApprovalTests namer requires source `.cpp` in runfiles
**Problem:** ApprovalTests' default namer reads the source `.cpp` file at its workspace-relative path to derive the golden filename. cc_test compiles `srcs` into the binary but does **not** put them in the runfiles tree, so the namer's `test/approval/<name>.cpp` lookup fails with "build configuration" errors.
**Solution:** `data = glob(["*.cpp"]) + …` in `test/approval/BUILD.bazel`. The same glob appears as `srcs` (compile inputs) and `data` (runfiles), but Bazel handles the dual role cleanly.

### Metadata goldens embedded build-system-specific path strings
**Problem:** `metadata_golden_test.cpp`'s `dump_metadata` wrote the input file's full path (e.g. `=== ../../../test/_test_data/images/unit/foo.jpg ===`) into the golden text. CMake-relative and Bazel-relative paths differ, so the goldens were build-system-specific. 5 MetadataGolden tests failed under Bazel.
**Solution:** `dump_metadata` now uses `std::filesystem::path(path).filename().string()` to write only the basename. The 5 `.approved.txt` files are updated atomically with the source change so both build systems produce identical bytes.

### `googletest` version forced from 1.16 to 1.17
**Problem:** `test/CMakeLists.txt` pins `gtest 1.16.0`. Declaring `bazel_dep(name = "googletest", version = "1.16.0.bcr.2")` triggered a `--check_direct_dependencies` warning — `aspect_bazel_lib`'s transitive graph already pulls `googletest@1.17.0`, and Bazel 9's MVS resolver picks the higher version.
**Solution:** Bumped Bazel's pin to `1.17.0.bcr.2`. The 1.16 → 1.17 jump is API-compatible (no SIPI test calls a 1.17-specific symbol; gtest's API has been stable across the 1.1x line). CMake stays at 1.16 until DEV-6348 (Y+6) deletes the CMake test path.

### `cc_test` link errors on macOS — `SCDynamicStoreCopyProxies` undefined
**Problem:** First `bazel test //test/unit/...` invocation failed at link with `ld64.lld: error: undefined symbol: SCDynamicStoreCopyProxies` (referenced by curl's `macos.c`). Sipiicc passed (didn't pull the curl symbol); configuration failed (did).
**Tried:** Adding `linkopts` per-test target. Rejected as duplication.
**Solution:** Moved system-lib linkopts (`-liconv`, `-framework SystemConfiguration`, `-framework CoreFoundation`, `-ldl`, `-lpthread`) from `//src:sipi`'s `cc_binary` to `//src:sipi_lib`'s `cc_library`. Bazel's `cc_library.linkopts` propagates to every downstream linking target — exactly what we want. Mirrors CMake's `target_link_libraries(libsipi_testable PUBLIC -framework ...)`.

## Gotchas

- **`SIPI_WORKSPACE_ROOT` is the unified env var, not `SIPI_TEST_DATA_DIR`.** Earlier iterations used a per-subdir env var; the final shape uses one workspace-root override that callers append subpaths to. If you see references to `SIPI_TEST_DATA_DIR` anywhere, that's stale.
- **`tmp_dir()`'s CMake fallback is `data_dir() + "/images/thumbs"`, not `/tmp`.** This preserves the existing CMake convention of writing intermediates into the source tree's git-ignored `thumbs/` subdir. Bazel routes via `TEST_TMPDIR` cleanly; only CMake hits the fallback.
- **`tags = ["manual"]` only excludes from `//...` patterns.** `bazel test //test/unit/sipiimage:sipi_image_tests` (explicit target) still runs and will fail on the source-tree-write issue. Use `--build_tag_filters=-manual` if scripting around this.
- **The `data` glob in `test/approval/BUILD.bazel` re-globs `*.cpp`** — looks like duplication of `srcs` but is required for ApprovalTests's source-file namer. Don't dedupe.
- **The 5 metadata `.approved.txt` files were re-approved as part of this PR.** If you're reviewing in chunks, the source change in `metadata_golden_test.cpp` (path → basename) and the golden updates **must** land atomically — they're a single commit.
- **`googletest@1.17` is forced by transitive resolution, not by us.** If you want to lock to 1.16 in the Bazel graph, you'd have to declare `single_version_override` and risk diamond-version conflicts. Not worth it; gtest's API is stable across 1.1x.

## Test Plan

- [x] `just bazel-test-unit` exits green locally on macOS-aarch64 — 11 components, including the 8-case `sipi_icc_normalize_test` ICC suite. Sipiimage tagged `manual`, deferred to [DEV-6354](https://linear.app/dasch/issue/DEV-6354).
- [x] `just bazel-test-approval` exits green locally with `SOURCE_DATE_EPOCH=946684800` injected. All 24 cases pass.
- [x] **Failure-detection gate verified**: deliberately corrupted `metadata_golden_test.MetadataGolden.ImageOrientation.approved.txt`; `bazel test` reported `FAILED in 6.7s` with the expected diff. Restoring → green again.
- [x] `just nix-build` exits green — CMake/ctest path still passes the same test count via `checkPhase`. Nix derivation built successfully on macOS-aarch64.
- [ ] Linux verification deferred to CI (`bazel-test-*` are local-only; the Bazel-build CI workflow added in Y already validates the build graph on `linux_x86_64` + `linux_aarch64`, but doesn't yet run the test targets).

## Acceptance Status (per plan §"PR Y+1")

| Criterion | Status |
|---|---|
| `just bazel-test-unit` exits green locally including the 8-case `sipiicc` ICC suite | ✅ |
| `just bazel-test-approval` exits green with `SOURCE_DATE_EPOCH=946684800`; `.received` files write under `bazel-testlogs/` | ✅ verified by deliberate-corruption test |
| **Test-count parity** between `bazel test //test/unit/... //test/approval:approvaltests` and `just nix-build`'s `checkPhase` | ⚠️ Documented exception: sipiimage tagged `manual`, tracked in [DEV-6354](https://linear.app/dasch/issue/DEV-6354). CMake/ctest still exercises sipiimage on `main`. |

## Follow-ups Spawned

- [DEV-6352](https://linear.app/dasch/issue/DEV-6352) — Y+1.5: prometheus-cpp native Bazel (drops the `cmake()` foreign_cc rule + `patch_cmds` hack).
- [DEV-6353](https://linear.app/dasch/issue/DEV-6353) — Y+8: post-Y+7 module-co-located layout flip + `package_group()` boundary enforcement.
- [DEV-6354](https://linear.app/dasch/issue/DEV-6354) — port `test/unit/sipiimage` to Bazel `cc_test` (route source-tree writes to `TEST_TMPDIR`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)