### PR TITLE
ci(bazel-build): decouple disk-cache key + use actions/cache@v4

### DIFF
--- a/.github/workflows/bazel-build.yml
+++ b/.github/workflows/bazel-build.yml
@@ -197,11 +197,13 @@ jobs:
           bazelisk-cache: true
           disk-cache: false
           repository-cache: true
-          # Inject the --disk_cache flag pointing at the path managed by
-          # actions/cache@v4 above. setup-bazel writes `bazelrc` content
-          # to a user .bazelrc; Bazel expands $HOME at flag-parse time.
-          bazelrc: |
-            common --disk_cache=$HOME/.cache/bazel-disk
+          # `--disk_cache` is set on the bazelisk command line below so bash
+          # can expand `$HOME`. We deliberately do NOT inject it here via
+          # setup-bazel's `bazelrc:` input: setup-bazel writes that content
+          # verbatim to ~/.bazelrc, and Bazel does not expand environment
+          # variables in .bazelrc flag values (bazelbuild/bazel#15856), so
+          # a literal `$HOME` would land in --disk_cache and Bazel would
+          # create a directory called `$HOME` instead of honouring the path.
 
       - name: bazel build ${{ inputs.bazel_target || '//src:sipi' }}
         env:
@@ -225,8 +227,14 @@ jobs:
           # the sandbox; without `--sandbox_debug` the sandbox is wiped on
           # action failure and the Make.log is lost. Removable once kakadu
           # builds reliably across all three platforms.
+          #
+          # `--disk_cache` is set on the command line (not in .bazelrc) so
+          # bash expands `$HOME` here — Bazel does not expand env vars in
+          # .bazelrc paths (bazelbuild/bazel#15856). Path matches the
+          # `actions/cache@v4` step above so the cache is restored and
+          # saved to/from this directory across CI runs.
           nix develop --command bash -c "
-            bazelisk build --verbose_failures --sandbox_debug $BAZEL_TARGET
+            bazelisk build --disk_cache=\$HOME/.cache/bazel-disk --verbose_failures --sandbox_debug $BAZEL_TARGET
           "
 
       # On any bazel failure, locate and dump every foreign_cc Make.log

--- a/.github/workflows/bazel-build.yml
+++ b/.github/workflows/bazel-build.yml
@@ -131,24 +131,77 @@ jobs:
           extra-conf: |
             extra-experimental-features = configurable-impure-env
 
-      # Bazel-contrib's setup-bazel handles repository-cache + action-cache +
-      # output-base separation under GHA's 10 GB cache limit. `--incompatible_strict_action_env`
-      # is set in `.bazelrc` so it applies to every invocation; no need to
-      # pass it on the command line here.
-      - uses: bazel-contrib/setup-bazel@0.15.0
+      # CACHE STRATEGY (DEV-6371):
+      #
+      # The disk-cache is managed by `actions/cache@v4` directly rather than
+      # through `setup-bazel`'s built-in disk-cache wiring. Two failure modes
+      # in the previous setup made this necessary:
+      #
+      #   1. 0-byte poisoning. setup-bazel <=0.17 saves the disk-cache from
+      #      its post-step unconditionally — a bazel build that failed during
+      #      analysis (e.g. a transient `http_archive` 415 from zlib.net)
+      #      would write an empty `~/.cache/bazel-disk` to GHA under the
+      #      input-content-derived cache key. GHA cache keys are immutable,
+      #      so every subsequent run hashing to the same inputs restored
+      #      0 bytes and re-built kakadu/openssl from source (~12 min on
+      #      linux-x86_64). setup-bazel 0.18+ added a `cache-save` input,
+      #      but it accepts only static `true|false` — `${{ success() }}`
+      #      is captured at step-init when the build hasn't run yet.
+      #      `actions/cache@v4` saves only on job success by default.
+      #
+      #   2. Cache-key churn from incidental edits. The previous key hashed
+      #      `flake.nix` (carries comments and docs) and `**/BUILD.bazel`
+      #      (sweeps in app-level test/ + src/ BUILD files that don't affect
+      #      ext/ action keys). Replaced with the targeted minimum below.
+      #      `flake.lock` is what actually pins the dev-shell store paths
+      #      consumed via `--action_env=PATH/NIX_LDFLAGS/ACLOCAL_PATH`.
+      #
+      # Note: foreign_cc actions for kakadu/openssl still rebuild on every
+      # `flake.lock` advance because `--action_env=PATH` embeds /nix/store
+      # hashes that vary across nixpkgs versions (`.bazelrc:30,42,54`). That
+      # is tracked as DEV-6371 tier 2 (action-env hygiene); tier 1 here only
+      # fixes the GHA-cache-side poisoning + key churn.
+      - uses: actions/cache@v4
+        id: bazel-disk-cache
+        with:
+          path: ~/.cache/bazel-disk
+          # Inputs that genuinely affect a foreign_cc action's cache key:
+          # MODULE.bazel{,.lock} pin all third-party deps; root + ext/ + bazel/
+          # + patches/ + platforms/ shape the rule graph + kakadu Makefile
+          # patches; .bazelrc / .bazelversion shape the build engine and
+          # action env; flake.lock pins the dev-shell store paths.
+          # NOT in the key: src/**, include/**, shttps/**, test/**, fuzz/**,
+          # tools/**, config/** — app/test code does not change ext/ action
+          # outputs, so changes there should not evict the foreign_cc cache.
+          key: bazel-disk-${{ matrix.arch }}-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock', 'BUILD.bazel', 'ext/**/BUILD.bazel', 'bazel/**', 'patches/**', 'platforms/**', '.bazelrc', '.bazelversion', 'flake.lock') }}
+          # Fallback: when the primary key bumps, restore the most recent
+          # prior cache for this arch. Bazel's --disk_cache only consumes
+          # action entries whose action key still matches, so a few extra
+          # MB of stale entries is harmless and amortises the cost of
+          # genuine input changes (e.g. a kakadu version bump).
+          restore-keys: |
+            bazel-disk-${{ matrix.arch }}-
+
+      # `setup-bazel` continues to manage bazelisk + repository-cache (the
+      # `--repository_cache` for http_archive downloads, e.g. the openssl
+      # tarball or the Chromium debian sysroot — these are content-addressed
+      # by sha256 and have no poisoning risk). disk-cache is disabled here
+      # so the action above is the single owner. `--incompatible_strict_action_env`
+      # is set in `.bazelrc` so it applies to every invocation.
+      #
+      # 0.19.0 (was 0.15.0) carries `post-if: !cancelled()` which together
+      # with the explicit `actions/cache@v4` above eliminates the
+      # cancellation-and-failure save paths that produced 0-byte entries.
+      - uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelisk-cache: true
-          # Cache key includes a hash of every file that influences a
-          # Bazel build action — MODULE.bazel.lock pins all third-party
-          # versions, the per-package BUILD.bazel files describe rule
-          # shapes, the helpers in `bazel/` shape AR/sysroot env, and
-          # flake.nix gates the dev-shell tools that feed action_env.
-          # Any change to those busts the cache, which avoids
-          # disk-cache-restored-but-output-missing failure modes (a
-          # previous run's failed kakadu action left a cached entry
-          # pointing at a libkdu.a that was never actually emitted).
-          disk-cache: bazel-build-${{ matrix.arch }}-${{ hashFiles('MODULE.bazel.lock', '**/BUILD.bazel', 'bazel/**', 'flake.nix') }}
+          disk-cache: false
           repository-cache: true
+          # Inject the --disk_cache flag pointing at the path managed by
+          # actions/cache@v4 above. setup-bazel writes `bazelrc` content
+          # to a user .bazelrc; Bazel expands $HOME at flag-parse time.
+          bazelrc: |
+            common --disk_cache=$HOME/.cache/bazel-disk
 
       - name: bazel build ${{ inputs.bazel_target || '//src:sipi' }}
         env:


### PR DESCRIPTION
[DEV-6371](https://linear.app/dasch/issue/DEV-6371)

## Summary

- Replace `setup-bazel@0.15.0`'s built-in disk-cache wiring with explicit `actions/cache@v4` so failed builds no longer save 0-byte caches that poison the input-content-derived key.
- Decouple the GHA cache key from incidental edits: drop `flake.nix` (carries comments) and `**/BUILD.bazel` (sweeps in app/test BUILD files), narrow to the minimum set that genuinely affects foreign_cc action hashes.
- Bump `setup-bazel` `0.15.0` → `0.19.0` for `post-if: !cancelled()`.
- Pass `--disk_cache=$HOME/.cache/bazel-disk` on the bazelisk command line (not via `.bazelrc`) so bash expands `$HOME` — Bazel does not expand env vars in `.bazelrc` paths ([bazelbuild/bazel#15856](https://github.com/bazelbuild/bazel/issues/15856)). The first version of this PR injected the flag via `setup-bazel`'s `bazelrc:` input which left `$HOME` literal; commit 2 fixed it.

## Empirically validated

| Run | Event | Cache state | linux-x86_64 wall-clock |
|---|---|---|---|
| `25260539134/1` | push (cold) | new key, no prior save | 16.08 min |
| `25260539134/2` | rerun | restore MISSED (cache evicted by PR #607) | 16.60 min |
| `25262086013` | post-rebase push | **restore HIT** | **4.87 min** (3.3× speedup) |

Bazel build summary on the cache-hit run: `INFO: 152 processes: 73 disk cache hit, 79 internal.` — every cacheable action including kakadu and openssl hit cache.

## What does NOT change

- The kakadu fetch/build pipeline (`bazel/kakadu*.bzl`, `patches/kakadu-*.patch`, `ext/kakadu/BUILD.bazel`) — untouched.
- `--incompatible_strict_action_env` and the rest of `.bazelrc` — untouched.
- `setup-bazel`'s `bazelisk-cache` and `repository-cache` — still managed by `setup-bazel`. Only `disk-cache` moves to `actions/cache@v4`.
- Workflow trigger paths — `flake.nix` is still in `paths:` so a touch of `flake.nix` still runs the workflow; it just does not bust the cache.

## Acceptance criteria (DEV-6371) — all satisfied

- [x] Root cause documented for both 0-byte cache poisoning and the foreign_cc output not persisting → see Linear comments.
- [x] CI run on a no-Bazel-input-change PR shows kakadu + openssl restored from cache, not rebuilt → run `25262086013` linux-x86_64, `73 disk cache hit`.
- [x] Cache-key strategy decoupled so a `flake.nix` comment edit doesn't evict kakadu → narrowed `hashFiles()` set in this PR.
- [x] Wall-clock for `bazel build / linux-x86_64` on a cache-hit run < 5 min → **4.87 min**.
- [x] Decision recorded inline in `bazel-build.yml` → comment block at the top of the cache step explains the strategy and failure modes.

## Out of scope (follow-up issue, not this PR)

GHA's 10 GB per-repo cache cap is currently the binding constraint on cross-PR cache reliability — repository-cache alone uses 11.8 GB across 3 arches (Chromium sysroots + LLVM toolchain + 22 ext lib source tarballs), so two concurrent PRs blow past the cap and LRU-evict each other within ~1 hour. The cheap fix is to disable `repository-cache: false` and accept ~30s of cold-start http_archive downloads per arch (drops per-PR cache from 11.8 GB to ~50 MB, fits 4-5 PRs concurrently in 10 GB). Will draft a follow-up issue.

## Test Plan

- [x] CI bazel-build green on all 3 arches across multiple attempts.
- [x] Cache hit empirically validated on linux-x86_64 (4.87 min vs 16 min cold).
- [x] Cache save events visible in GHA cache list (`bazel-disk-${arch}-250df9209f...`).
- [x] No `Path Validation Error` warning on save.

## Refs

- Linear: DEV-6371
- Parent: DEV-6341 (Bazel migration umbrella) — plan §219-221 deferred remote-cache; tier 3 finding may justify revisiting
- Triggered by: PR #604 CI investigation (May 2026)
- Failed run that surfaced the bug: [actions/runs/25255829101/attempts/1](https://github.com/dasch-swiss/sipi/actions/runs/25255829101/attempts/1)
- Cache-hit validation run: [actions/runs/25262086013](https://github.com/dasch-swiss/sipi/actions/runs/25262086013)