### PR TITLE
test(bazel): port test/unit/sipiimage to bazel cc_test (DEV-6354)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ just nix-valgrind                # run sipi under Valgrind
 
 # Bazel inner loop (DEV-6343, PR Y+1 — local-only; CI runs unit + approval
 # tests via just nix-build's checkPhase until DEV-6348 (Y+6))
-just bazel-test-unit             # bazel test //test/unit/...  (11 of 12 components; sipiimage tagged manual, DEV-6354)
+just bazel-test-unit             # bazel test //test/unit/...  (12 of 12 components)
 just bazel-test-approval         # bazel test //test/approval:approvaltests  (24 cases, env-injected SOURCE_DATE_EPOCH)
 
 # Dev-shell inner loop (non-recipe — see "Inner-loop development" below)

--- a/justfile
+++ b/justfile
@@ -190,11 +190,8 @@ nix-coverage:
 # Requires `bazelisk` from the Nix dev shell (added to flake.nix in Y).
 #####################################
 
-# Run every GoogleTest unit-test target under //test/unit/.
-# Excludes //test/unit/sipiimage:sipi_image_tests, which is tagged
-# `manual` because its test bodies write to the source `_test_data/`
-# tree — Bazel runfiles is read-only. Tracked for follow-up in
-# DEV-6354. CMake/ctest still exercises sipiimage on `main`.
+# Run every GoogleTest unit-test target under //test/unit/. Covers all
+# 12 components (sipiimage joined the Bazel run in DEV-6354).
 bazel-test-unit:
     bazel test //test/unit/...
 

--- a/test/unit/sipiimage/BUILD.bazel
+++ b/test/unit/sipiimage/BUILD.bazel
@@ -1,35 +1,23 @@
-"""SipiImage unit tests — DEFERRED from Bazel runs in Y+1.
-
-The test bodies write to the source `test/_test_data/` tree mid-flight
-(both `images/thumbs/<X>` and `_<temp>` filenames in `images/{knora,unit}/`).
-CMake/ctest gets away with this because the workspace is read-write, but
-Bazel's runfiles tree is read-only on macOS-darwin sandbox.
-
-Properly porting requires per-line audit of every hardcoded path in
-`*.cpp` to split source-reads from write-targets — tracked in DEV-6354
-(`Bazel migration follow-up — port test/unit/sipiimage to Bazel cc_test`).
-The infrastructure to support the port is already in place:
-  * `//test:test_paths` provides `sipi::test::data_dir()` and `tmp_dir()`.
-  * `//test/_test_data:images` is the data filegroup.
-  * 5 of the 6 sources in this dir already use `sipi::test::data_dir()`
-    via the env-var pattern (the env-unset fallback preserves CMake
-    behaviour).
-
-`tags = ["manual"]` keeps this target out of `bazel test //test/unit/...`.
-The CMake/ctest path (`just nix-build`'s `checkPhase`) continues to
-exercise these tests on `main`, so coverage is preserved.
-
-Drop `manual` and finalise paths in DEV-6354.
+"""SipiImage unit tests. Fixture paths resolve via //test:test_paths,
+which honours SIPI_WORKSPACE_ROOT and TEST_TMPDIR.
 """
 
 load("@rules_cc//cc:defs.bzl", "cc_test")
+
+# Mirrors the CMake guard in CMakeLists.txt: Kakadu's JPEG2000 encoder
+# SIGILLs on palette images when compiled with Clang on Linux in Debug.
+# Bazel's `fastbuild` (the default for `bazel test`) is Debug-like
+# (-O0 -g, no NDEBUG), so apply the filter on Linux unconditionally.
+_LINUX_GTEST_FILTER = {"GTEST_FILTER": "-SipiImage.PALETTE_Conversion"}
 
 cc_test(
     name = "sipi_image_tests",
     srcs = glob(["*.cpp"]),
     data = ["//test/_test_data:images"],
-    env = {"SIPI_WORKSPACE_ROOT": "."},
-    tags = ["manual"],
+    env = select({
+        "@platforms//os:linux": {"SIPI_WORKSPACE_ROOT": "."} | _LINUX_GTEST_FILTER,
+        "//conditions:default": {"SIPI_WORKSPACE_ROOT": "."},
+    }),
     deps = [
         "//src:sipi_lib",
         "//test:test_paths",

--- a/test/unit/sipiimage/sipiimage.cpp
+++ b/test/unit/sipiimage/sipiimage.cpp
@@ -8,8 +8,14 @@
 #include "../../../src/SipiImage.hpp"
 #include "../../../src/SipiImageError.hpp"
 #include "SipiIOTiff.h"
+#include "test_paths.hpp"
 #include <cmath>
 #include <ranges>
+#include <sys/stat.h>
+
+// See test/test_paths.hpp for the data_dir/tmp_dir env-var contract.
+static const std::string test_images = sipi::test::data_dir() + "/images/";
+static const std::string tmp_dir = sipi::test::tmp_dir() + "/";
 
 // small function to check if file exist
 inline bool exists_file(const std::string &name)
@@ -30,20 +36,20 @@ inline bool image_identical(const std::string &name1, const std::string &name2)
   return (img1 == img2);
 }
 
-const std::string leavesSmallWithAlpha = "../../../../test/_test_data/images/knora/Leaves-small-alpha.tif";
-const std::string leavesSmallNoAlpha = "../../../../test/_test_data/images/knora/Leaves-small-no-alpha.tif";
-const std::string png16bit = "../../../../test/_test_data/images/knora/png_16bit.png";
-const std::string pngPaletteAlpha = "../../../../test/_test_data/images/unit/mario.png";
-const std::string leaves8tif = "../../../../test/_test_data/images/knora/Leaves8.tif";
-const std::string cielab = "../../../../test/_test_data/images/unit/cielab.tif";
-const std::string cielab16 = "../../../../test/_test_data/images/unit/CIELab16.tif";
-const std::string palette = "../../../../test/_test_data/images/unit/palette.tif";
-const std::string wrongrotation = "../../../../test/_test_data/images/unit/image_orientation.jpg";
-const std::string watermark_correct = "../../../../test/_test_data/images/unit/watermark_correct.tif";
-const std::string watermark_incorrect = "../../../../test/_test_data/images/unit/watermark_incorrect.tif";
-const std::string tiffJpegScanlineBug = "../../../../test/_test_data/images/knora/tiffJpegScanlineBug.tif";
-const std::string imgExifGps = "../../../../test/_test_data/images/unit/img_exif_gps.jpg";
-const std::string imgExifGpsTifOut = "../../../../test/_test_data/images/unit/img_exif_gps_out.tif";
+const std::string leavesSmallWithAlpha = test_images + "knora/Leaves-small-alpha.tif";
+const std::string leavesSmallNoAlpha = test_images + "knora/Leaves-small-no-alpha.tif";
+const std::string png16bit = test_images + "knora/png_16bit.png";
+const std::string pngPaletteAlpha = test_images + "unit/mario.png";
+const std::string leaves8tif = test_images + "knora/Leaves8.tif";
+const std::string cielab = test_images + "unit/cielab.tif";
+const std::string cielab16 = test_images + "unit/CIELab16.tif";
+const std::string palette = test_images + "unit/palette.tif";
+const std::string wrongrotation = test_images + "unit/image_orientation.jpg";
+const std::string watermark_correct = test_images + "unit/watermark_correct.tif";
+const std::string watermark_incorrect = test_images + "unit/watermark_incorrect.tif";
+const std::string tiffJpegScanlineBug = test_images + "knora/tiffJpegScanlineBug.tif";
+const std::string imgExifGps = test_images + "unit/img_exif_gps.jpg";
+const std::string imgExifGpsTifOut = tmp_dir + "img_exif_gps_out.tif";
 
 // Check if configuration file can be found
 TEST(SipiImage, CheckIfTestImagesCanBeFound)
@@ -79,7 +85,7 @@ TEST(SipiImage, ConvertTiffWithAlphaToJPG)
 
   EXPECT_NO_THROW(img.read(leavesSmallWithAlpha, region, size));
 
-  EXPECT_NO_THROW(img.write("jpg", "../../../../test/_test_data/images/thumbs/Leaves-small-with-alpha.jpg"));
+  EXPECT_NO_THROW(img.write("jpg", tmp_dir + "Leaves-small-with-alpha.jpg"));
 }
 
 // Convert Tiff with no alpha channel to JPG
@@ -93,7 +99,7 @@ TEST(SipiImage, ConvertTiffWithNoAlphaToJPG)
 
   EXPECT_NO_THROW(img.read(leavesSmallNoAlpha, region, size));
 
-  EXPECT_NO_THROW(img.write("jpg", "../../../../test/_test_data/images/thumbs/Leaves-small-no-alpha.jpg"));
+  EXPECT_NO_THROW(img.write("jpg", tmp_dir + "Leaves-small-no-alpha.jpg"));
 }
 
 // Convert PNG 16 bit with alpha channel and ICC profile to TIFF and back
@@ -102,12 +108,12 @@ TEST(SipiImage, ConvertPng16BitToJpxToPng)
   Sipi::SipiIOTiff::initLibrary();
   Sipi::SipiImage img1;
   ASSERT_NO_THROW(img1.read(png16bit));
-  ASSERT_NO_THROW(img1.write("tif", "../../../../test/_test_data/images/knora/png_16bit.tif"));
+  ASSERT_NO_THROW(img1.write("tif", tmp_dir + "png_16bit.tif"));
 
   Sipi::SipiImage img2;
-  ASSERT_NO_THROW(img2.read("../../../../test/_test_data/images/knora/png_16bit.tif"));
-  ASSERT_NO_THROW(img2.write("png", "../../../../test/_test_data/images/knora/png_16bit_X.png"));
-  // EXPECT_TRUE(image_identical(png16bit, "../../../../test/_test_data/images/knora/png_16bit_X.png"));
+  ASSERT_NO_THROW(img2.read(tmp_dir + "png_16bit.tif"));
+  ASSERT_NO_THROW(img2.write("png", tmp_dir + "png_16bit_X.png"));
+  // EXPECT_TRUE(image_identical(png16bit, tmp_dir + "png_16bit_X.png"));
 }
 
 // Convert PNG 16 bit with alpha channel and ICC profile to JPX
@@ -118,9 +124,9 @@ TEST(SipiImage, ConvertPng16BitToJpx)
 
   ASSERT_NO_THROW(img1.read(png16bit));
 
-  ASSERT_NO_THROW(img1.write("jpx", "../../../../test/_test_data/images/knora/png_16bit.jpx"));
+  ASSERT_NO_THROW(img1.write("jpx", tmp_dir + "png_16bit.jpx"));
 
-  EXPECT_TRUE(image_identical(png16bit, "../../../../test/_test_data/images/knora/png_16bit.jpx"));
+  EXPECT_TRUE(image_identical(png16bit, tmp_dir + "png_16bit.jpx"));
 }
 
 
@@ -132,9 +138,9 @@ TEST(SipiImage, ConvertPng16BitToTiff)
 
   ASSERT_NO_THROW(img1.read(png16bit));
 
-  ASSERT_NO_THROW(img1.write("tif", "../../../../test/_test_data/images/knora/png_16bit.tif"));
+  ASSERT_NO_THROW(img1.write("tif", tmp_dir + "png_16bit.tif"));
 
-  EXPECT_TRUE(image_identical(png16bit, "../../../../test/_test_data/images/knora/png_16bit.tif"));
+  EXPECT_TRUE(image_identical(png16bit, tmp_dir + "png_16bit.tif"));
 }
 
 // Convert PNG 16 bit with alpha channel and ICC profile to JPEG
@@ -145,7 +151,7 @@ TEST(SipiImage, ConvertPng16BitToJpg)
 
   ASSERT_NO_THROW(img1.read(png16bit));
 
-  ASSERT_NO_THROW(img1.write("jpg", "../../../../test/_test_data/images/knora/png_16bit.jpg"));
+  ASSERT_NO_THROW(img1.write("jpg", tmp_dir + "png_16bit.jpg"));
 }
 
 TEST(SipiImage, ConvertPNGPaletteAlphaToTiff)
@@ -154,9 +160,8 @@ TEST(SipiImage, ConvertPNGPaletteAlphaToTiff)
   Sipi::SipiImage img1;
 
   ASSERT_NO_THROW(img1.read(pngPaletteAlpha));
-  ASSERT_NO_THROW(img1.write("tif", "../../../../test/_test_data/images/unit/_mario.tif"));
-  EXPECT_TRUE(image_identical(
-    "../../../../test/_test_data/images/unit/mario.tif", "../../../../test/_test_data/images/unit/_mario.tif"));
+  ASSERT_NO_THROW(img1.write("tif", tmp_dir + "_mario.tif"));
+  EXPECT_TRUE(image_identical(test_images + "unit/mario.tif", tmp_dir + "_mario.tif"));
 }
 
 TEST(SipiImage, CIELab_Conversion)
@@ -167,14 +172,14 @@ TEST(SipiImage, CIELab_Conversion)
   Sipi::SipiImage img3;
 
   ASSERT_NO_THROW(img1.read(cielab));
-  ASSERT_NO_THROW(img1.write("jpx", "../../../../test/_test_data/images/unit/_cielab.jpx"));
-  ASSERT_NO_THROW(img2.read("../../../../test/_test_data/images/unit/_cielab.jpx"));
-  ASSERT_NO_THROW(img2.write("tif", "../../../../test/_test_data/images/unit/_cielab.tif"));
+  ASSERT_NO_THROW(img1.write("jpx", tmp_dir + "_cielab.jpx"));
+  ASSERT_NO_THROW(img2.read(tmp_dir + "_cielab.jpx"));
+  ASSERT_NO_THROW(img2.write("tif", tmp_dir + "_cielab.tif"));
 
   // now test if conversion back to TIFF gives an identical image
-  EXPECT_TRUE(image_identical(cielab, "../../../../test/_test_data/images/unit/_cielab.tif"));
-  ASSERT_NO_THROW(img3.read("../../../../test/_test_data/images/unit/_cielab.jpx"));
-  ASSERT_NO_THROW(img3.write("png", "../../../../test/_test_data/images/unit/_cielab.png"));
+  EXPECT_TRUE(image_identical(cielab, tmp_dir + "_cielab.tif"));
+  ASSERT_NO_THROW(img3.read(tmp_dir + "_cielab.jpx"));
+  ASSERT_NO_THROW(img3.write("png", tmp_dir + "_cielab.png"));
 }
 
 TEST(SipiImage, CIELab16_Conversion)
@@ -186,16 +191,16 @@ TEST(SipiImage, CIELab16_Conversion)
   Sipi::SipiImage img4;
 
   ASSERT_NO_THROW(img1.read(cielab16));
-  ASSERT_NO_THROW(img1.write("jpx", "../../../../test/_test_data/images/unit/_CIELab16.jpx"));
-  ASSERT_NO_THROW(img2.read("../../../../test/_test_data/images/unit/_CIELab16.jpx"));
-  ASSERT_NO_THROW(img2.write("tif", "../../../../test/_test_data/images/unit/_CIELab.tif"));
+  ASSERT_NO_THROW(img1.write("jpx", tmp_dir + "_CIELab16.jpx"));
+  ASSERT_NO_THROW(img2.read(tmp_dir + "_CIELab16.jpx"));
+  ASSERT_NO_THROW(img2.write("tif", tmp_dir + "_CIELab.tif"));
 
   // now test if conversion back to TIFF gives an identical image
-  EXPECT_TRUE(image_identical(cielab16, "../../../../test/_test_data/images/unit/_CIELab.tif"));
-  ASSERT_NO_THROW(img3.read("../../../../test/_test_data/images/unit/_CIELab16.jpx"));
-  ASSERT_NO_THROW(img3.write("png", "../../../../test/_test_data/images/unit/_CIELab16.png"));
-  ASSERT_NO_THROW(img4.read("../../../../test/_test_data/images/unit/_CIELab16.jpx"));
-  ASSERT_NO_THROW(img4.write("jpg", "../../../../test/_test_data/images/unit/_CIELab16.jpg"));
+  EXPECT_TRUE(image_identical(cielab16, tmp_dir + "_CIELab.tif"));
+  ASSERT_NO_THROW(img3.read(tmp_dir + "_CIELab16.jpx"));
+  ASSERT_NO_THROW(img3.write("png", tmp_dir + "_CIELab16.png"));
+  ASSERT_NO_THROW(img4.read(tmp_dir + "_CIELab16.jpx"));
+  ASSERT_NO_THROW(img4.write("jpg", tmp_dir + "_CIELab16.jpg"));
 }
 
 TEST(SipiImage, CMYK_Conversion)
@@ -206,20 +211,20 @@ TEST(SipiImage, CMYK_Conversion)
   Sipi::SipiImage img3;
   Sipi::SipiImage img4;
 
-  const std::string cmyk = "../../../../test/_test_data/images/unit/cmyk.tif";
+  const std::string cmyk = test_images + "unit/cmyk.tif";
   EXPECT_TRUE(exists_file(cmyk));
 
   ASSERT_NO_THROW(img1.read(cmyk));
-  ASSERT_NO_THROW(img1.write("jpx", "../../../../test/_test_data/images/unit/_cmyk.jpx"));
-  ASSERT_NO_THROW(img2.read("../../../../test/_test_data/images/unit/_cmyk.jpx"));
-  ASSERT_NO_THROW(img2.write("tif", "../../../../test/_test_data/images/unit/_cmyk_2.tif"));
+  ASSERT_NO_THROW(img1.write("jpx", tmp_dir + "_cmyk.jpx"));
+  ASSERT_NO_THROW(img2.read(tmp_dir + "_cmyk.jpx"));
+  ASSERT_NO_THROW(img2.write("tif", tmp_dir + "_cmyk_2.tif"));
 
   // now test if conversion back to TIFF gives an identical image
-  EXPECT_TRUE(image_identical(cmyk, "../../../../test/_test_data/images/unit/_cmyk_2.tif"));
-  ASSERT_NO_THROW(img3.read("../../../../test/_test_data/images/unit/_cmyk.jpx"));
-  ASSERT_NO_THROW(img3.write("png", "../../../../test/_test_data/images/unit/_cmyk.png"));
-  ASSERT_NO_THROW(img4.read("../../../../test/_test_data/images/unit/_cmyk.jpx"));
-  ASSERT_NO_THROW(img4.write("jpg", "../../../../test/_test_data/images/unit/_cmyk.jpg"));
+  EXPECT_TRUE(image_identical(cmyk, tmp_dir + "_cmyk_2.tif"));
+  ASSERT_NO_THROW(img3.read(tmp_dir + "_cmyk.jpx"));
+  ASSERT_NO_THROW(img3.write("png", tmp_dir + "_cmyk.png"));
+  ASSERT_NO_THROW(img4.read(tmp_dir + "_cmyk.jpx"));
+  ASSERT_NO_THROW(img4.write("jpg", tmp_dir + "_cmyk.jpg"));
 }
 
 TEST(SipiImage, PALETTE_Conversion)
@@ -227,7 +232,7 @@ TEST(SipiImage, PALETTE_Conversion)
   Sipi::SipiIOTiff::initLibrary();
   Sipi::SipiImage img1;
   ASSERT_NO_THROW(img1.read(palette));
-  ASSERT_NO_THROW(img1.write("jpx", "../../../../test/_test_data/images/unit/_palette.jpx"));
+  ASSERT_NO_THROW(img1.write("jpx", tmp_dir + "_palette.jpx"));
 }
 
 TEST(SipiImage, GRAYICC_Conversion_01)
@@ -237,8 +242,8 @@ TEST(SipiImage, GRAYICC_Conversion_01)
   Sipi::SipiImage img2;
   Sipi::SipiImage img3;
 
-  const std::string grayicc_jp2 = "../../../../test/_test_data/images/unit/gray_with_icc.jp2";
-  const std::string grayicc_jp2_to_jpeg = "../../../../test/_test_data/images/unit/_gray_with_icc.jpg";
+  const std::string grayicc_jp2 = test_images + "unit/gray_with_icc.jp2";
+  const std::string grayicc_jp2_to_jpeg = tmp_dir + "_gray_with_icc.jpg";
 
   EXPECT_TRUE(exists_file(grayicc_jp2));
 
@@ -255,8 +260,8 @@ TEST(SipiImage, GRAYICC_Conversion_02)
   Sipi::SipiImage img2;
   Sipi::SipiImage img3;
 
-  const std::string gray_icc_another_jpeg = "../../../../test/_test_data/images/unit/gray_with_icc_another.jpg";
-  const std::string gray_icc_another_jpeg_to_jp2 = "../../../../test/_test_data/images/unit/_gray_with_icc_another.jpx";
+  const std::string gray_icc_another_jpeg = test_images + "unit/gray_with_icc_another.jpg";
+  const std::string gray_icc_another_jpeg_to_jp2 = tmp_dir + "_gray_with_icc_another.jpx";
 
   EXPECT_TRUE(exists_file(gray_icc_another_jpeg));
 
@@ -273,16 +278,15 @@ TEST(SipiImage, CMYK_lossy_compression)
   const std::shared_ptr<Sipi::SipiRegion> region = nullptr;
   const std::shared_ptr<Sipi::SipiSize> size = nullptr;
 
-  const std::string cmyk = "../../../../test/_test_data/images/unit/cmyk.tif";
+  const std::string cmyk = test_images + "unit/cmyk.tif";
   EXPECT_TRUE(exists_file(cmyk));
 
   ASSERT_NO_THROW(img.readOriginal(cmyk, region, size, shttps::HashType::sha256));
   Sipi::SipiCompressionParams params = {
     { Sipi::J2K_rates, "0.5 0.2 0.1 0.025" }, { Sipi::J2K_Clayers, "4" }, { Sipi::J2K_Clevels, "3" }
   };
-  ASSERT_NO_THROW(img.write("jpx", "../../../../test/_test_data/images/unit/_cmyk_lossy.jp2", &params));
-  EXPECT_TRUE(image_identical("../../../../test/_test_data/images/unit/cmyk_lossy.jp2",
-    "../../../../test/_test_data/images/unit/_cmyk_lossy.jp2"));
+  ASSERT_NO_THROW(img.write("jpx", tmp_dir + "_cmyk_lossy.jp2", &params));
+  EXPECT_TRUE(image_identical(test_images + "unit/cmyk_lossy.jp2", tmp_dir + "_cmyk_lossy.jp2"));
 }
 
 TEST(SipiImage, WrongRotation)
@@ -301,9 +305,8 @@ TEST(SipiImage, WrongRotation)
   // EXPECT_EQ(img.getNy(), 3264);
   // EXPECT_EQ(img.getNc(), 3);
   // EXPECT_EQ(img.getOrientation(), Sipi::TOPLEFT);
-  ASSERT_NO_THROW(img.write("tif", "../../../../test/_test_data/images/unit/_image_orientation.tif"));
-  EXPECT_TRUE(image_identical("../../../../test/_test_data/images/unit/image_orientation.tif",
-    "../../../../test/_test_data/images/unit/_image_orientation.tif"));
+  ASSERT_NO_THROW(img.write("tif", tmp_dir + "_image_orientation.tif"));
+  EXPECT_TRUE(image_identical(test_images + "unit/image_orientation.tif", tmp_dir + "_image_orientation.tif"));
 }
 
 // Apply watermark to image
@@ -315,9 +318,9 @@ TEST(SipiImage, Watermark)
   Sipi::SipiImage img3;
   Sipi::SipiImage img4;
 
-  std::string maori = "../../../../test/_test_data/images/unit/MaoriFigure.jpg";
-  std::string gradstars = "../../../../test/_test_data/images/unit/gradient-stars.tif";
-  std::string maoriWater = "../../../../test/_test_data/images/unit/MaoriFigureWatermark.jpg";
+  std::string maori = test_images + "unit/MaoriFigure.jpg";
+  std::string gradstars = test_images + "unit/gradient-stars.tif";
+  std::string maoriWater = test_images + "unit/MaoriFigureWatermark.jpg";
 
   EXPECT_TRUE(exists_file(maori));
   EXPECT_TRUE(exists_file(gradstars));
@@ -348,15 +351,11 @@ TEST(SipiImage, CMYK_With_Alpha_Conversion)
   Sipi::SipiImage img1;
   Sipi::SipiImage img2;
 
-  const std::string tif_cmyk_with_alpha = "../../../../test/_test_data/images/unit/cmyk_with_alpha.tif";
-  const std::string tif_cmyk_with_alpha_converted_to_jpx =
-    "../../../../test/_test_data/images/unit/cmyk_with_alpha.jpx";
-  const std::string tif_cmyk_with_alpha_converted_from_jpx_to_tif =
-    "../../../../test/_test_data/images/unit/cmyk_with_alpha_.tif";
-  const std::string tif_cmyk_with_alpha_converted_to_jpg =
-    "../../../../test/_test_data/images/unit/cmyk_with_alpha_.jpg";
-  const std::string tif_cmyk_with_alpha_converted_to_png =
-    "../../../../test/_test_data/images/unit/cmyk_with_alpha_.png";
+  const std::string tif_cmyk_with_alpha = test_images + "unit/cmyk_with_alpha.tif";
+  const std::string tif_cmyk_with_alpha_converted_to_jpx = tmp_dir + "cmyk_with_alpha.jpx";
+  const std::string tif_cmyk_with_alpha_converted_from_jpx_to_tif = tmp_dir + "cmyk_with_alpha_.tif";
+  const std::string tif_cmyk_with_alpha_converted_to_jpg = tmp_dir + "cmyk_with_alpha_.jpg";
+  const std::string tif_cmyk_with_alpha_converted_to_png = tmp_dir + "cmyk_with_alpha_.png";
 
   ASSERT_NO_THROW(img1.read(tif_cmyk_with_alpha));
   ASSERT_NO_THROW(img1.write("jpx", tif_cmyk_with_alpha_converted_to_jpx));
@@ -382,7 +381,7 @@ TEST(SipiImage, CMYK_With_Alpha_Conversion)
 /*   Sipi::SipiImage img; */
 
 /*   EXPECT_NO_THROW(img.read(tiffJpegScanlineBug)); */
-/*   EXPECT_NO_THROW(img.write("jpx", "../../../../test/_test_data/images/thumbs/tiffJpegScanlineBug.jp2")); */
+/*   EXPECT_NO_THROW(img.write("jpx", tmp_dir + "tiffJpegScanlineBug.jp2")); */
 /* } */
 
 double errorPercent(double actual, double expected) { return abs((actual - expected) / expected); }


### PR DESCRIPTION
Fixes DEV-6354

## Motivation

`test/unit/sipiimage` was the one component deferred from DEV-6343 (Y+1) — its tests intermix source-reads and write-targets in the same `_test_data/` paths, so they fail under Bazel's read-only runfiles. The `BUILD.bazel` was wired up but tagged `manual` to keep `bazel test //test/unit/...` green at the cost of one missing component. This PR finishes the port and restores 12-of-12 test-count parity.

## Summary

- Audit every hardcoded `../../../../test/_test_data/...` path in `sipiimage.cpp` (~50 sites) and route reads through `sipi::test::data_dir()`, writes through `sipi::test::tmp_dir()`.
- Drop `tags = ["manual"]` so the target joins `bazel test //test/unit/...`.
- CI is unaffected — `just nix-build`'s `checkPhase` continues to drive unit + approval ctest until DEV-6348 (Y+6) cuts CI fully over to Bazel.

## Key Changes

### `test/unit/sipiimage/sipiimage.cpp`

- Two top-level constants set up the prefixes once: `test_images = sipi::test::data_dir() + "/images/"`, `tmp_dir = sipi::test::tmp_dir() + "/"`.
- Each call site classified per-line:
  - Reads (`img.read`, `img.readOriginal`, `image_identical(fixture, …)` first arg) → `test_images + "knora/<X>"` or `"unit/<X>"`.
  - Writes (`img.write`) and read-back-of-write (`img.read(<just-written-tmp>)`, `image_identical(…, <just-written-tmp>)` second arg) → `tmp_dir + "<filename>"`.
- Adds explicit `<sys/stat.h>` (was being included transitively via SipiIO headers).

### `test/unit/sipiimage/BUILD.bazel`

- Drop `tags = ["manual"]`. Trim the docstring to two lines (the helper contract is documented in `test/test_paths.hpp`).
- Add a Linux-only `GTEST_FILTER=-SipiImage.PALETTE_Conversion` via `select({"@platforms//os:linux": ...} | <env>)`. Mirrors the existing CMake guard against Kakadu's JPEG2000 SIGILL on Clang+Debug+Linux. Bazel `fastbuild` is Debug-like, so the filter applies unconditionally on Linux rather than gated on build mode.

### `CLAUDE.md`, `justfile`

- Drop the now-stale "sipiimage tagged manual / 11 of 12 components / tracked in DEV-6354" references — those advertised a deferred state that no longer exists.

## Challenges and Decisions

### CMake-fallback write directory

**Problem:** Under CMake/ctest, `tmp_dir()` falls back to `data_dir() + "/images/thumbs"`, so writes that previously landed in `images/unit/` (mixed with the source fixtures) and `images/knora/` now land in `images/thumbs/`.
**Decision:** Accept the change. `images/thumbs/*` is gitignored, the 5 sibling tests already use this exact path under CMake since DEV-6343, and the alternative (carrying the unit/knora write paths through the helper) would re-introduce the source-tree pollution that DEV-6354 is here to fix.

### Linux PALETTE_Conversion filter granularity

**Problem:** The CMake guard is `Linux + Clang + Debug` only. Bazel can `select()` on `@platforms//os:linux` cleanly, but build-mode and compiler are not as easy to route into a per-target env at BUILD-load time.
**Decision:** Filter on Linux unconditionally. `bazel test` defaults to `fastbuild` (Debug-like, no NDEBUG) and `bazel-test-unit` is local-only until Y+6, so the broader filter has no production blast radius. Anyone wanting to actually run `PALETTE_Conversion` on Linux Bazel can `bazel test --test_filter=*PALETTE*`.

### Where the verification details go

**Decision:** Per `docs/src/development/commit-conventions.md`, verification belongs in the PR (not the commit body). Reviewer/learnings audience reads the PR; release notes don't show `test:` commits at all.

## Gotchas

- The two `static const std::string` at namespace scope dynamic-init from `std::getenv` via the helper. This is fine (test binary, single TU at this level), but anyone adding a *second* TU that also reads `test_paths.hpp` at namespace scope should keep static-init-order in mind.
- `images/thumbs/` must exist as a directory for the CMake fallback to write into. It currently has a `.gitkeep`; if anyone ever cleans up the fixtures dir aggressively, restore the `.gitkeep`.

## Test Plan

- [x] `bazel test //test/unit/sipiimage:sipi_image_tests` — 74 tests pass (1 disabled), macOS-aarch64.
- [x] `bazel test //test/unit/...` — 12/12 components green, macOS-aarch64.
- [x] `bazel test //test/approval:approvaltests` — green (cross-check that the unrelated approval target still passes after the BUILD edits).
- [x] `just nix-build` — green; `checkPhase` (CMake/ctest) reports no regression and the binary is produced.
- [x] Source-tree mtime invariant: `stat` snapshot of every `.tif`/`.png`/`.jp2`/`.jpg` under `test/_test_data/images/{knora,unit}/` taken before and after a Bazel run; `diff` reports no change. No `_*` artefacts under those dirs.
- [ ] linux-x86_64 / linux-aarch64 — CI-validated.