### PR TITLE
chore: enable my-eng Claude Code plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,6 +20,7 @@
   "enabledPlugins": {
     "eng@dasch-claude-plugins": true,
     "linear@claude-plugins-official": true,
-    "sentry@claude-plugins-official": true
+    "sentry@claude-plugins-official": true,
+    "my-eng@subotic-claude-plugins": true
   }
 }


### PR DESCRIPTION
## Summary

- Adds `my-eng@subotic-claude-plugins` to `.claude/settings.json` enabled plugins.

## Test plan

- [ ] No code changes; configuration only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)