### PR TITLE
ci(bazel-build): disable persistent repository-cache to stop 10 GB cap eviction

### DIFF
--- a/.github/workflows/bazel-build.yml
+++ b/.github/workflows/bazel-build.yml
@@ -196,7 +196,18 @@ jobs:
         with:
           bazelisk-cache: true
           disk-cache: false
-          repository-cache: true
+          # repository-cache is intentionally OFF (DEV-6373). It would persist
+          # the LLVM 19.1.x toolchain (~2 GB), Chromium debian sysroots
+          # (~500 MB each), and 22 ext lib http_archive source tarballs across
+          # runs — ~4 GB per arch, ~12 GB across linux-x86_64 + linux-aarch64
+          # + darwin-aarch64 — which blows GHA's 10 GB per-repo cache cap and
+          # LRU-evicts the small (~33 MB) bazel-disk-cache that actually
+          # delivers the speedup (3.3× on cache hit; see DEV-6371). Bazel
+          # still uses an in-job repository cache for de-dup within a single
+          # build; the cost is a one-time http_archive re-download per arch
+          # per run (~30-60s on a bandwidth-rich runner). Trade is heavily
+          # in favour of reliable disk-cache hits across PRs.
+          repository-cache: false
           # `--disk_cache` is set on the bazelisk command line below so bash
           # can expand `$HOME`. We deliberately do NOT inject it here via
           # setup-bazel's `bazelrc:` input: setup-bazel writes that content


### PR DESCRIPTION
Fixes DEV-6373

## Motivation

DEV-6371 shipped tier 1 (cache save fix + key decoupling) and proved a 3.3× speedup on cache hit for `bazel build / linux-x86_64` (16.08 min cold → 4.87 min hot, 73 of 73 sandboxable actions hit cache including kakadu and openssl). But the win was only locally observable — the actual GHA cache state showed `total cache size: 12.62 GB / 10 GB cap`, with the persistent `repository-cache` alone using 11.8 GB across 3 arches. Two concurrent PRs reliably evicted each other's `bazel-disk-cache` entries within ~1 hour. The 3.3× speedup was unreachable in steady-state CI because the cache that delivered it kept getting evicted by the cache that didn't.

## Summary

- Disables `setup-bazel`'s persistent `repository-cache` (one-line YAML change + 12 lines of inline rationale).
- Drops per-PR GHA cache footprint from ~9 GB to ~320 MB, fitting 5-10 active PRs in the 10 GB cap.
- No measurable cold-start penalty (empirically faster — see Challenges).

## Key Changes

### `.github/workflows/bazel-build.yml`
- `repository-cache: true` → `false` on the `bazel-contrib/setup-bazel@0.19.0` step.
- 12-line comment block explaining the trade-off, referencing DEV-6371's eviction observation and the GHA 10 GB cap.

### Cache footprint shape
- **Before:** ~9 GB per PR (4.4 GB linux-x64 repo + 3.9 GB darwin-arm64 repo + 3.5 GB linux-arm64 repo + bazelisk + bazel-disk).
- **After:** ~320 MB per PR (bazelisk × 3 arches ≈ 220 MB + bazel-disk × 3 arches ≈ 100 MB).

## Challenges and Decisions

### Predicted cold-start penalty did not materialise

**Problem:** Forecast was a +30-60s wall-clock penalty per arch — Bazel would re-download every `http_archive` (LLVM 19.1.x toolchain ~2 GB tarball, Chromium debian sysroots ~500 MB each, 22 ext lib source tarballs).

**Tried:** Treated the change as a measurable trade — accept some cold-start cost to fix cross-PR eviction.

**Solution:** External research on `--repository_cache` semantics revealed that the cache stores ONLY raw download blobs (sha256-keyed at `{output_user_root}/cache/repos/v1/content_addressable/sha256/<hash>/file`), **never the extracted directory tree**. Extraction always happens, on every build, regardless of cache state. So `repository-cache: true` was buying us network bandwidth savings only, not CPU/IO savings. The 4.4 GB GHA cache restore (~30-60s of download + decompression) was paying to save ~30s of upstream HTTP fetches — net-negative even before the cross-PR eviction cost.

Empirical confirmation from PR #610's first run:
- linux-x86_64: **13.55 min** (vs 16.08 min on PR #606's cold run with `repository-cache: true`) — **2.5 min FASTER**
- Pre-bazel setup time: **1:14** (vs ~2:17 incl. 4.4 GB cache restore) — ~1 min saved

### Why not options B/C/D from the original DEV-6373 design

**Problem:** The original issue body listed four options (split key, remote cache, pre-built artifacts, per-arch cache); option A (this PR) was recommended as cheapest.

**Tried:** Considered remote cache (BuildBuddy / bazel-remote on a VM) and pre-built artifact in `dsp-ci-assets`.

**Solution:** Option A is sufficient on its own — empirical data shows ~320 MB per PR fits 5-10 PRs comfortably, well below the 10 GB cap. Remote cache (option C) was deferred per parent plan §219-221 ("Remote cache selection ... is deferred. Phase 1 ships with no remote cache"). Pre-built artifact (option D) adds asset-distribution work for a problem we just demonstrated doesn't exist. Re-evaluate after PR #610 has observed steady-state cross-PR behaviour (~1 week).

### `LocalRepoContentsCache` is the future-state fix

**Problem:** Even with `repository-cache: true`, every CI build re-extracts the LLVM toolchain (~2 GB unpacked) into the output base because `--repository_cache` doesn't store extracted trees.

**Tried:** Looked for a Bazel flag to cache the extracted external repos.

**Solution:** Bazel has `--experimental_repo_contents_cache` (gated; tracked in [bazel#27509](https://github.com/bazelbuild/bazel/discussions/27509)) that WOULD cache extracted trees and eliminate the per-build re-extraction cost. Not stable yet but worth tracking — it's the structural fix once it lands. Out of scope for this PR.

## Gotchas

- **Bazel's `--repository_cache` only caches tarballs, not extracted trees.** Future readers of `bazel-build.yml` may be tempted to re-enable `repository-cache: true` thinking it would persist the LLVM toolchain. It doesn't. The toolchain re-extracts on every build regardless of cache state — cache only saves the upstream HTTP fetch.
- **GHA cache is per-repo (10 GB), not per-PR.** Adding any large cache to `bazel-build.yml` (e.g. a future `--distdir` for sysroots) must stay well under the cap or it'll evict the small `bazel-disk-cache` again.
- **Don't trust setup-bazel's "cache restored 4 GB" log line as a win.** That restore is paid in wall-clock time too. If you see the build slowing down after enabling new caches, check whether the restore time exceeds the work it skips.
- **`--distdir=<path>`** is the surgical lever for selective archive caching if cold-start cost regresses under heavier CI load. Pre-stage just the LLVM + sysroot tarballs (the largest fixed-version blobs from `MODULE.bazel.lock`) in a directory; cache that via `actions/cache` keyed on the lock hash. The 22 small ext lib tarballs would still re-download (cheap). Estimated footprint: ~3 GB per arch. Worth considering if PR #610's net-positive result reverses.

## Test Plan

- [x] CI bazel-build green on all 3 arches (linux-x86_64 13.55 min, linux-aarch64 10.18 min, darwin-aarch64 11.98 min).
- [x] No `Path Validation Error` warning on cache save step.
- [x] `bazel-disk-${arch}-…` entries saved cleanly (verified via `gh api .../actions/caches`).
- [x] Per-PR cache footprint < 3 GB (~320 MB observed).
- [x] No cold-start penalty (cold run is ~2.5 min faster than PR #606's baseline).
- [ ] Cross-PR cache hit consistency: another PR running concurrently with PR #610 doesn't evict its `bazel-disk-cache`. Verifies over the next 24-48h after merge as more PRs land.

## Refs

- Linear: [DEV-6373](https://linear.app/dasch/issue/DEV-6373)
- Predecessor: DEV-6371 (tier 1, merged in [PR #606](https://github.com/dasch-swiss/sipi/pull/606))
- Parent: DEV-6341 (Bazel migration umbrella)
- Cache-state evidence: empirical measurements posted in [DEV-6371's tier-1-validation comment](https://linear.app/dasch/issue/DEV-6371) and [DEV-6373's option-A-validation comment](https://linear.app/dasch/issue/DEV-6373)