### PR TITLE
docs: align CONVENTIONS, REVIEW, RELEASING with current repo state

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -37,6 +37,43 @@ If a new build configuration is genuinely needed across the team (non-trivial
 CMake flags, specialized toolchain), that configuration deserves a Nix
 variant in `flake.nix`, not a recipe wrapping imperative cmake.
 
+The Bazel migration (DEV-6343..DEV-6348) adds a parallel `cc_test` inner
+loop that is currently local-only. CMake/ctest via `just nix-build`
+remains the CI canonical path. Until DEV-6348 cuts CI over, treat
+`just bazel-test-unit` and `just bazel-test-approval` as a local
+fast-feedback path — not a substitute for `nix-build`.
+
+## Build Completeness Invariant
+
+Every build target must succeed on every supported platform:
+macOS (darwin-aarch64), linux-x86_64, and linux-aarch64. Linux-only
+outputs (`docker`, `docker-stream`, `sipi-debug`) are gated by
+`pkgs.lib.optionalAttrs isLinux` in `flake.nix`; everything else must
+build on every platform. CI is Linux-only — **a green CI run does not
+verify macOS**. Before shipping changes to `flake.nix`, `package.nix`,
+or a justfile build recipe, run every affected variant locally on
+macOS (`just nix-build-<variant>`) and dispatch Linux variants via
+Determinate's native-linux-builder
+(`nix build .#packages.{x86_64,aarch64}-linux.<variant>`). See CLAUDE.md
+"Build completeness invariant" for the full checklist.
+
+## Scope Discipline
+
+These rules govern *what* to build (mirrored from CLAUDE.md so
+contributors and Claude share the same contract):
+
+- **No backwards-compatibility shims.** Update every caller in the same
+  change. Rebase-merge preserves history; deprecated aliases,
+  re-exports, and "kept for now" pointers are not needed.
+- **No defense-in-depth.** Validate at system boundaries only — HTTP
+  request handlers, FFI boundaries, CLI parsers. See
+  `REVIEW.md` § "Security (input validation)" for what qualifies.
+- **No enterprise abstractions — KISS.** Three similar lines beat one
+  parameterised helper. Introduce an abstraction only for a *second
+  real* caller, not a hypothetical one.
+- **Ask when in doubt.** Surface ambiguous decisions to the maintainer
+  before acting. "Suggest, don't decide" is the default.
+
 ## Naming Conventions
 
 The codebase has mixed naming styles. For new code, prefer the C++23 style guide (`camelCase` functions, `trailing_underscore_` members). When modifying existing code, match the surrounding style.
@@ -47,6 +84,25 @@ The codebase has mixed naming styles. For new code, prefer the C++23 style guide
 | Functions / Methods | Mixed `camelCase` / `snake_case` | `imgroot()`, `send_error()`, `get_canonical_url()` |
 | Private members | `_leading_underscore` | `_imgroot`, `_nthreads` |
 | Namespaces | `PascalCase` | `Sipi::`, `shttps::` |
+
+## Module Layout
+
+The codebase has two coexisting layouts:
+
+- **Historical (current default):** `src/<mod>/Foo.cpp` paired with
+  `include/<mod>/Foo.h`, unit tests under `test/unit/<mod>/`.
+- **Module-co-located ([ADR-0003](docs/adr/0003-module-co-located-source-and-tests.md), proposed):**
+  `src/<mod>/{Foo.cpp, Foo.h, foo_test.cpp}` with flat-style includes
+  (`#include "metadata/Foo.h"` cross-module, `#include "Foo.h"`
+  intra-module). `shttps/` and `src/handlers/` already follow this.
+  Migration is staged behind the Bazel build-tool migration
+  (DEV-6343..DEV-6348) and lands as five mechanical per-module PRs
+  (Y+8a..Y+8e).
+
+Until ADR-0003 is accepted and a module is migrated, follow the
+historical layout for that module. After migration, follow the new
+layout. ADR-0003 is the source of truth for migration order and
+per-module diff shape.
 
 ## Route Registration
 
@@ -110,7 +166,8 @@ New config options need:
 
 ## Prometheus Metrics
 
-Singleton at `SipiMetrics::instance()` (`include/SipiMetrics.h`). Exposed at `GET /metrics`.
+SIPI-side singleton at `Sipi::SipiMetrics::instance()`
+(`include/SipiMetrics.h`); exposed at `GET /metrics`.
 
 ```cpp
 prometheus::Counter &my_counter_total =
@@ -120,3 +177,15 @@ prometheus::Counter &my_counter_total =
     .Register(*SipiMetrics::instance().registry)
     .Add({});
 ```
+
+shttps-side instrumentation goes through the
+`shttps::ConnectionMetrics` Strategy interface (see
+`shttps/ConnectionMetrics.h`). At startup, `src/sipi.cpp` installs a
+`SipiConnectionMetricsAdapter` (Adapter pattern) that bridges shttps
+events into the `SipiMetrics` singleton. **Do not call
+`SipiMetrics::instance()` from `shttps/` code** — that direction is
+the SIPI ← shttps leak that
+[ADR-0001](docs/adr/0001-shttps-as-strangler-fig-target.md)'s
+strangler-fig is closing (commit `f2ee8cfd`, Apr 30 2026). New
+shttps-emitted events go on the `ConnectionMetrics` interface and
+are implemented in the adapter.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,27 +1,74 @@
-## Releasing
+# Releasing SIPI
 
- 1. Communicate that a release is about to be released in the [DaSCH Github Channel](https://github.com/orgs/dhlab-basel/teams/dasch), so that no new Pull Requests are merged
- 1. Create a new branch, e.g., `releasing-vX.X.X`
- 1. Update the version number in `CMakeLists.txt`, `manual/conf.py`.
- 1. Remove the `(not released yet)` text in the title of the release notes.
- 1. Create a new page with the next version number including the `(not released yet)` text and add page to TOC.
- 1. Update links in the new page to point to correct release tag and milestone.
- 1. On Github - Create new milestone
- 1. On Github - Move any open issues from current release milestone to the next release milestone and so on.
- 1. On Github - Close current milestone.
- 1. Push and merge PR to `main`.
- 1. Travis CI will start a [CI build](https://travis-ci.org/dhlab-basel/Sipi/builds) for the new tag and publish
-    artifacts to Docker Hub.
- 1. On Github - Tag the commit with the version string, e.g., `vX.X.X` and create a release.
- 1. On Github - Copy the release notes from the docs to the release.
- 1. Publish documentation.
+Releases are fully automated via [release-please](https://github.com/googleapis/release-please).
+CI/CD details live in [`docs/src/development/ci.md`](docs/src/development/ci.md);
+this file lists only the manual steps a human maintainer takes around an
+automated release.
 
+## How a release happens (overview)
 
-## Under the Travis hood
+1. [Conventional Commit](https://www.conventionalcommits.org/) prefixes on
+   `main` drive release-please. The full prefix-to-release mapping table is
+   in [`ci.md`](docs/src/development/ci.md#release-automation-release-please).
+2. release-please opens (or updates) a release PR with title
+   `chore(main): release X.Y.Z`. The PR diff updates `version.txt`,
+   `CHANGELOG.md`, and `.github/release-please/manifest.json`.
+3. Merging the release PR pushes a `vX.Y.Z` tag.
+4. The tag triggers [`.github/workflows/publish.yml`](.github/workflows/publish.yml):
+   - `validate-docker` — per-arch Nix-built Docker image + smoke test.
+   - `publish-docker` — push images to Docker Hub, generate SBOM, upload
+     debug symbols to Sentry.
+   - `manifest` — multi-arch Docker manifest combining amd64 + arm64.
+   - `docs` — mkdocs deploy to https://sipi.io.
+   - `sentry` — release finalisation.
 
-Here is what happens in detail when Travis CI is building a git tagged commit. According to the `.travis.yml` file,
-the `publish` stage runs the following task:
-   
- 1. Credentials are read from the `DOCKER_USER` and `DOCKER_PASS` environment variables which are stored encrypted
-    inside `.travis.yml`.
- 1. The `sipi` docker image is build, tagged, and published.
+## Maintainer checklist (per release)
+
+**Before merging the release PR:**
+
+- [ ] Announce the upcoming release in the DaSCH GitHub team channel so no
+      last-minute PRs are merged.
+- [ ] Sanity-check the diff: `version.txt`, `CHANGELOG.md`, manifest.
+- [ ] Confirm CI is green on `main` for the commit being released.
+
+**After merging the release PR (publish.yml runs automatically):**
+
+- [ ] Watch `publish.yml` to green: `validate-docker` →
+      `publish-docker` → `manifest` → `docs` → `sentry`.
+- [ ] Verify the Docker manifest exists:
+      `docker pull daschswiss/sipi:vX.Y.Z`.
+- [ ] Verify the GitHub release page shows the changelog from
+      release-please.
+- [ ] Verify https://sipi.io reflects the new docs.
+
+## Manual interventions (rare)
+
+When release-please goes wrong:
+
+- **Wrong commit prefix shipped to `main`** — open a follow-up commit with
+  the correct prefix (or a `Release-As: X.Y.Z` footer commit) so
+  release-please catches up. Do not edit `version.txt` / `CHANGELOG.md`
+  by hand.
+- **Need to skip a release** — merge only non-release-bumping commits
+  (`docs:`, `chore:`, `refactor:`, `test:`, `build:`, `ci:`, `style:`).
+- **Emergency patch on an old version** — branch from the tag, cherry-pick
+  the fix, push a tag manually. `publish.yml` runs the same way.
+- **`publish.yml` fails after a tag** — fix forward; do not delete the tag.
+  Push a new patch-bump tag via release-please.
+
+## What is NOT manual any more
+
+For the avoidance of doubt — none of the following are manual steps:
+
+- Bumping the version in `CMakeLists.txt`. The CMake project version is
+  read from `version.txt`, which release-please owns.
+- Editing `manual/conf.py`. The file no longer exists; mkdocs is the
+  documentation system.
+- Creating or closing GitHub milestones.
+- Tagging the release commit. release-please does this on PR merge.
+- Building or pushing Docker images. `publish.yml` does this.
+- Publishing documentation. `publish.yml`'s `docs` job does this.
+- Travis CI. Replaced by GitHub Actions.
+
+See [`docs/src/development/ci.md`](docs/src/development/ci.md) for the
+canonical CI/release pipeline description.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -38,6 +38,7 @@
 ### Configuration consistency
 - New config options added to all four surfaces: `SipiConf.h`/`.cpp` (Lua), `sipi.cpp` (CLI11), `SipiHttpServer.hpp` (accessor), and `config/sipi.config.lua` (documentation)
 - Defaults identical across all entry points
+- `docs/src/development/reviewer-guidelines.md` summarises this as "Lua / CLI / env" for review-checklist brevity; the four-surface list above is the authoritative one
 - Invalid values produce clear startup errors with guidance on valid values
 
 ### Testing
@@ -46,11 +47,13 @@
 - New HTTP behavior tested in Rust e2e or Hurl (not Python — Python tests are frozen)
 - Tests verify behavior (dimensions, content, structure), not just HTTP status codes
 - **Sanitizer gate:** PRs touching `src/`, `shttps/`, `include/`, or `test/` automatically run the sanitizer CI workflow (`sanitizer.yml`). Zero findings required to merge
+- **Bazel `cc_test` parity:** PRs that add a new unit test should also add the matching `cc_test` target in `test/unit/<mod>/BUILD.bazel`. CMake/ctest via `just nix-build` remains the CI canonical path until DEV-6348 cuts CI over; `just bazel-test-unit` and `just bazel-test-approval` are the local fast-feedback path until then
 
 ### Metrics
 - New metrics use correct Prometheus types (counter for monotonic, gauge for current state, histogram for distributions)
 - Metric names follow `sipi_` prefix convention with `_total` suffix for counters
 - Instrumentation in the correct layer (not duplicated across call chain)
+- shttps-side instrumentation (request lifecycle, queue events) emits through the `shttps::ConnectionMetrics` Strategy interface (`shttps/ConnectionMetrics.h`) — never call `Sipi::SipiMetrics::instance()` directly from `shttps/`. The SIPI → shttps direction is enforced by `package_group()` visibility under Bazel and by `scripts/shttps-context-check.sh` under CMake
 
 ### Thread safety
 - Shared mutable state protected by `std::mutex` + `std::scoped_lock` or `std::atomic`


### PR DESCRIPTION
## Motivation

Three repo-root markdown files had drifted from the current state of the
codebase:

- **RELEASING.md** described a Travis CI manual release flow that no
  longer exists. Releases are now fully automated via release-please
  (`.github/workflows/release-please.yml` → tag push → `publish.yml`).
  The file referenced `manual/conf.py` (deleted), Travis encrypted
  secrets, and manual milestone/tag management — all gone.
- **REVIEW.md** pre-dated the `SipiMetrics → ConnectionMetrics`
  Strategy/Adapter inversion (commit f2ee8cfd, Apr 30 2026) and was
  inconsistent with `docs/src/development/reviewer-guidelines.md` on
  the configuration-surface count.
- **CONVENTIONS.md** pre-dated the Bazel `cc_test` inner-loop recipes
  (DEV-6343), the SipiMetrics Strategy/Adapter seam, ADR-0003
  (module-co-location, proposed), and the scope-discipline /
  build-completeness invariants now codified in CLAUDE.md.

This change brings all three files in sync with the May 2026 reality
without duplicating `docs/src/development/ci.md` (the canonical CI
source).

## Summary

- **RELEASING.md** — full rewrite as a slim maintainer checklist that
  defers to `ci.md` for all automation detail.
- **REVIEW.md** — three targeted bullets covering the
  ConnectionMetrics Strategy seam, Bazel `cc_test` parity, and the
  configuration-surface cross-reference.
- **CONVENTIONS.md** — five additions/edits: Bazel inner-loop note,
  Build Completeness Invariant, Scope Discipline, Module Layout
  (ADR-0003 pointer), and Prometheus Metrics rewrite for the
  Strategy/Adapter seam.

## Key Changes

### RELEASING.md (full rewrite)

- Removed: Travis CI references, `manual/conf.py` editing, manual
  version bumps, manual milestone management, manual tagging,
  "Under the Travis hood" section.
- Added: release-please overview, before/after-merge maintainer
  checklist, rare-intervention guidance (wrong prefix, skip release,
  emergency patch, publish.yml failure), explicit "what is NOT
  manual" list.

### REVIEW.md

- **Configuration consistency**: cross-reference to
  `reviewer-guidelines.md`'s shorter "Lua / CLI / env" formulation,
  marking the four-surface list as authoritative.
- **Testing**: Bazel `cc_test` parity bullet — new unit tests should
  add the matching `cc_test` target; CMake/ctest remains CI-canonical
  until DEV-6348.
- **Metrics**: shttps-side instrumentation must go through
  `shttps::ConnectionMetrics`, never `Sipi::SipiMetrics::instance()`
  from `shttps/`.

### CONVENTIONS.md

- **Build Reproducibility Invariant**: appended Bazel inner-loop note.
- **Build Completeness Invariant** (new): mirrors CLAUDE.md — every
  target must build on macOS-arm64, linux-x86_64, linux-aarch64; CI
  is Linux-only.
- **Scope Discipline** (new): no shims, no defense-in-depth, KISS,
  ask when in doubt.
- **Module Layout** (new): historical vs ADR-0003 co-located layout
  with migration guidance.
- **Prometheus Metrics**: rewritten to describe the
  `SipiConnectionMetricsAdapter` Strategy/Adapter seam and the
  SIPI ← shttps boundary rule.

## Challenges and Decisions

### How to treat RELEASING.md

**Problem**: RELEASING.md was so out of date (Travis CI, deleted
`manual/conf.py`, manual everything) that almost nothing in it was
salvageable.

**Tried**: A targeted edit to drop Travis references would still
leave the file misleading because the entire process model has
shifted from manual-with-CI-publish to fully-automated.

**Solution**: Slim maintainer checklist — keep the file (since CLAUDE
and contributors expect to find it at the repo root) but defer all
automation detail to `docs/src/development/ci.md`. The file now
covers only the human-side of a release: comms, sanity-check, watch
publish.yml, and rare manual interventions.

### Including ADR-0003 in CONVENTIONS.md

**Problem**: ADR-0003 (module-co-location, flat-style includes) is
"proposed", not "accepted". Including it bakes in a pre-decision.

**Solution**: Add a Module Layout section that explicitly notes the
proposed status, describes both layouts (historical default vs
ADR-0003), and tells contributors to follow the historical layout
until ADR-0003 is accepted and a module is migrated. Pointer to
ADR-0003 for the migration plan rather than duplicating it.

### Prometheus Metrics direction

**Problem**: The previous CONVENTIONS.md text told contributors to
call `SipiMetrics::instance()` directly, which is exactly the
SIPI ← shttps leak that ADR-0001's strangler-fig is closing.

**Solution**: Keep the SIPI-side `SipiMetrics::instance()` example
(still correct for SIPI-side code) but add a paragraph clarifying
that shttps-side instrumentation goes through the
`shttps::ConnectionMetrics` Strategy, with `SipiConnectionMetricsAdapter`
bridging the events. This matches the post-f2ee8cfd shape and stops
new code from re-introducing the leak.

## Gotchas

- **Cross-doc consistency**: REVIEW.md's Configuration section lists
  four surfaces (Lua / CLI / accessor / docs) while
  `reviewer-guidelines.md` lists three (Lua / CLI / env). Both files
  now explicitly cross-reference each other and call out REVIEW.md
  as authoritative — don't reconcile these by deleting one.
- **ADR-0003 status**: still proposed. The Module Layout section in
  CONVENTIONS.md must be updated when the ADR is accepted (status
  change to "accepted" + per-module migration completion).
- **Bazel migration phasing**: REVIEW.md and CONVENTIONS.md describe
  Bazel as local-only "until DEV-6348 cuts CI over". When DEV-6348
  lands, both bullets need updating to reflect the new CI shape.
- **No mkdocs nav impact**: none of the three files are in the
  mkdocs nav (they remain repo-root-only). No `docs/mkdocs.yml`
  update needed.

## Test Plan

- [x] `grep -rIn 'CONVENTIONS\|REVIEW.md\|RELEASING' --include='*.md' --include='*.yml'`
      — confirmed all surviving cross-references resolve to existing
      sections (CONVENTIONS.md → REVIEW.md "Security (input
      validation)"; CLAUDE.md → REVIEW.md same section; reviewer-
      guidelines.md → REVIEW.md "C library boundary safety";
      claude.yml → REVIEW.md generally).
- [x] Verified `SipiConnectionMetricsAdapter` is the actual class
      name in `src/SipiConnectionMetricsAdapter.{h,cpp}` and is
      installed via `server.setMetrics(...)` in `src/sipi.cpp:1575`.
- [x] Verified ADR-0003 path
      (`docs/adr/0003-module-co-located-source-and-tests.md`).
- [x] Verified release-please flow described in RELEASING.md
      against `.github/workflows/release-please.yml`,
      `.github/workflows/publish.yml`, and
      `.github/release-please/{config,manifest}.json`.
- [ ] Eyeball read-through on the GitHub PR diff to catch any
      awkward seams before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)