### PR TITLE
build(bazel): cut sanitized variant over to Bazel (DEV-6344, PR Y+2)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -145,6 +145,102 @@ build:macos --repo_env=PATH
 build:macos --repo_env=DEVELOPER_DIR=/Library/Developer/CommandLineTools
 build:macos --repo_env=SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
 
+# ── Sanitizers — opt-in via --config=asan and/or --config=ubsan ─────────────
+# Replaces the deleted `.#sanitized` Nix variant. CI's sanitizer.yml uses
+# both together via `just bazel-build-sanitized`
+# (`bazel build --config=asan --config=ubsan //src:sipi`); the e2e step then
+# runs the suite against `bazel-bin/src/sipi` with `.lsan_suppressions.txt`
+# and `ASAN_OPTIONS=log_path=/tmp/asan-e2e`. The two configs are kept
+# separate so a developer can isolate a finding to ASan vs UBSan.
+#
+# `--compilation_mode=dbg` matches the prior Nix variant's `Debug` cmake
+# build and gives us `-g -O0` (clearer ASan stack traces and no compiler
+# elision of UBSan checks); `--strip=never` keeps DWARF inline so LSan's
+# symbol-name suppressions (`leak:lua*` in `.lsan_suppressions.txt`)
+# actually match — the same invariant the old override enforced via
+# `dontStrip = true` + `separateDebugInfo = false`.
+#
+# **Why `--per_file_copt` instead of `--copt` for `-fsanitize=…`.**
+# `rules_foreign_cc`'s `make()` / `cmake()` / `configure_make()` rules
+# collect `--copt` flags from the cc toolchain and forward them to the
+# upstream build via CFLAGS / CXXFLAGS. Adding `--copt=-fsanitize=address`
+# poisons kakadu's hand-written Makefile (which builds `libkdu.a` /
+# `libkdu_aux.a` in `@kakadu`) and the autotools/cmake wrappers around
+# openssl, exiv2, tiff, etc. Many of those Makefiles either ignore
+# foreign-injected CFLAGS or fail to mirror the matching `-fsanitize=…`
+# linkopt, leaving the foreign_cc rule with no `.a` to package.
+#
+# `--per_file_copt=<regex>@<flag>` is action-scoped — it applies only
+# when Bazel itself runs a compile action whose source file path matches
+# the regex, and is NOT consulted when foreign_cc collects toolchain
+# flags for its env-var forwarding. Scoping by `^(src|shttps|fuzz|test)/`
+# instruments every first-party translation unit while leaving the
+# foreign_cc deps unsanitised. Mixing instrumented sipi code with
+# uninstrumented kakadu/openssl/png/etc. is supported by ASan and UBSan;
+# the previous CMake build had the exact same property — the
+# `sanitizer_config` INTERFACE library only attached to `sipi` and
+# `libsipi_testable`, never to the `ext/*` foreign_cc targets.
+#
+# `--linkopt=-fsanitize=…` stays global because foreign_cc's `make()` /
+# `cmake()` rules don't read Bazel linkopts; only the final first-party
+# `cc_binary` link picks them up, which is what we want (the runtime
+# library and its initializers must reach the sipi binary's link line).
+#
+# `-fno-omit-frame-pointer` and `-fno-optimize-sibling-calls` stay as
+# global `--copt`. Both are advisory hints harmless to the foreign_cc
+# deps; keeping them across the whole stack means stack traces from any
+# layer (kakadu / libtiff / openssl / sipi) carry frame pointers and
+# don't get mangled by tail-call optimisation when ASan unwinds.
+#
+# **Note for cmake() deps.** `--compilation_mode=dbg` also propagates
+# into `rules_foreign_cc`'s `cmake()` rules as `-DCMAKE_BUILD_TYPE=Debug`.
+# Two separate hazards follow from that:
+#   1. Some upstream `CMakeLists.txt` files apply
+#      `set_target_properties(... DEBUG_POSTFIX "d")` (libpng, sentry, …)
+#      or `"-d"` (curl) in Debug mode and produce e.g. `libpng16d.a` /
+#      `libcurl-d.a` instead of the unsuffixed name, breaking the
+#      foreign_cc `out_static_libs` invariant.
+#   2. Per-config IMPORTED-target files (`XConfig-debug.cmake`,
+#      `XConfig-relwithdebinfo.cmake`) only exist for the matching
+#      build type; downstream cmake() consumers that resolve a
+#      different config fail with
+#      `IMPORTED_LOCATION not set for … configuration "<X>"`.
+# Each cmake() ext/* dep pins `cache_entries["CMAKE_BUILD_TYPE"] =
+# "RelWithDebInfo"`; that value beats the auto-injected `=Debug` in
+# `rules_foreign_cc`'s `cmake_script.bzl`, so the deps build uniformly
+# at -O2 -g and ship `XConfig-relwithdebinfo.cmake` files that match
+# downstream resolution. Sipi's own first-party translation units are
+# unaffected — they don't go through cmake; their `-fsanitize=…`
+# reaches them via the `--per_file_copt` block above.
+
+build:asan --compilation_mode=dbg
+build:asan --strip=never
+build:asan --copt=-fno-omit-frame-pointer
+build:asan --copt=-fno-optimize-sibling-calls
+build:asan --per_file_copt=^(src|shttps|fuzz|test)/.*\.(cpp|cc|cxx|c|mm)$@-fsanitize=address
+build:asan --linkopt=-fsanitize=address
+
+build:ubsan --compilation_mode=dbg
+build:ubsan --strip=never
+build:ubsan --copt=-fno-omit-frame-pointer
+build:ubsan --copt=-fno-optimize-sibling-calls
+build:ubsan --per_file_copt=^(src|shttps|fuzz|test)/.*\.(cpp|cc|cxx|c|mm)$@-fsanitize=undefined
+# Disable the vptr check. `-fsanitize=undefined` activates it by default,
+# but verifying RTTI at run time requires a UBSan symbol set
+# (`__ubsan_vptr_type_cache`, `__ubsan_handle_dynamic_type_cache_miss`)
+# that toolchains_llvm's compiler-rt only ships in the dynamic
+# `libclang_rt.ubsan_standalone_cxx-…so` form; the toolchain's link
+# line forces static `-l:libc++.a -l:libc++abi.a`, so the dynamic
+# runtime is never pulled in and lld fails the link with `undefined
+# symbol: __ubsan_vptr_type_cache`. The other UBSan checks (integer
+# overflow, null deref, signed-integer wraparound, alignment, etc.)
+# don't need the C++-specific runtime and link cleanly. Sipi's prior
+# CMake build worked with full UBSan because the Nix toolchain linked
+# C++ dynamically and the runtime resolved against the system libc++.
+build:ubsan --per_file_copt=^(src|shttps|fuzz|test)/.*\.(cpp|cc|cxx|c|mm)$@-fno-sanitize=vptr
+build:ubsan --linkopt=-fsanitize=undefined
+build:ubsan --linkopt=-fno-sanitize=vptr
+
 # ── Test ───────────────────────────────────────────────────────────────────
 # Surface test stderr immediately on failure rather than collecting it into
 # bazel-testlogs — useful for inner-loop iteration. CI flips this off.

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -1,4 +1,4 @@
-# Sanitizer build: ASan + UBSan on unit tests and e2e suite.
+# Sanitizer build: ASan + UBSan on the e2e suite.
 # Catches memory errors (buffer overflow, use-after-free, leaks) and
 # undefined behavior that functional tests miss.
 #
@@ -7,9 +7,12 @@
 #
 # Also available on-demand via workflow_dispatch.
 #
-# Unit tests run inside the Nix sandbox via `just nix-build-sanitized`
-# (doCheck = enableTests in package.nix). Any ASan/UBSan finding in the
-# unit suite fails the build before the e2e step even starts.
+# The build step uses Bazel (`just bazel-build-sanitized` ⇒
+# `bazel build --config=asan --config=ubsan //src:sipi`); the e2e step
+# then exercises the resulting `bazel-bin/src/sipi` binary under
+# `just nix-test-e2e` with `LSAN_OPTIONS` and `ASAN_OPTIONS` set as
+# below. Unit-test sanitizer coverage moves to Bazel `cc_test`
+# execution in DEV-6348 (PR Y+6) — until then this workflow is e2e-only.
 
 permissions:
   contents: read
@@ -21,11 +24,21 @@ on:
       - 'shttps/**'
       - 'include/**'
       - 'test/**'
+      - 'tools/**'
+      - 'ext/**'
       - 'CMakeLists.txt'
       - 'flake.nix'
       - 'flake.lock'
       - 'package.nix'
       - 'justfile'
+      - '.bazelrc'
+      - '.bazelversion'
+      - 'MODULE.bazel'
+      - 'MODULE.bazel.lock'
+      - 'BUILD.bazel'
+      - '**/BUILD.bazel'
+      - 'bazel/**'
+      - '.github/workflows/sanitizer.yml'
   workflow_dispatch:
 
 name: sanitizer
@@ -40,6 +53,23 @@ jobs:
     timeout-minutes: 30
     name: asan-ubsan / amd64
     steps:
+      # Sanitizer builds compile every foreign_cc ext lib under
+      # `--compilation_mode=dbg` (`-O0 -g`) — larger object files than the
+      # CI default. Without freeing pre-installed SDKs first, the LLVM 19
+      # toolchain (~3 GB) plus 22 ext libs plus the Bazel disk cache blow
+      # past ubuntu-24.04's ~14 GB free quota and the build dies with
+      # `No space left on device`. Mirrors `.github/workflows/bazel-build.yml`.
+      - name: free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: false
+
       - uses: dasch-swiss/sipi/.github/actions/checkout@main
         with:
           DASCHBOT_PAT: ${{ secrets.DASCHBOT_PAT }}
@@ -56,6 +86,23 @@ jobs:
         with:
           name: dasch-swiss
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+      # Bazel disk cache. Without this, every sanitizer-gate run rebuilds
+      # all foreign_cc ext libs (kakadu, openssl, exiv2, libtiff, …) under
+      # `--compilation_mode=dbg` from cold — easily 10+ minutes per run
+      # and at risk of hitting the 30-minute job timeout on bandwidth-poor
+      # runners. Cache strategy mirrors `.github/workflows/bazel-build.yml`
+      # (DEV-6371): `actions/cache` directly (not setup-bazel's built-in)
+      # to avoid 0-byte poisoning on analysis-phase failures, and a
+      # targeted key formula that excludes app/test sources whose changes
+      # don't affect ext/ action keys.
+      - uses: actions/cache@v5
+        id: bazel-disk-cache
+        with:
+          path: ~/.cache/bazel-disk
+          key: bazel-disk-sanitizer-linux-x86_64-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock', 'BUILD.bazel', 'ext/**/BUILD.bazel', 'bazel/**', 'patches/**', 'platforms/**', '.bazelrc', '.bazelversion', 'flake.lock') }}
+          restore-keys: |
+            bazel-disk-sanitizer-linux-x86_64-
       # `just` drives the build; `llvmPackages_19.llvm` ships
       # `llvm-symbolizer`, which ASan/LSan need to resolve the
       # `(/nix/store/.../sipi+0xOFFSET)` frames into function names.
@@ -63,28 +110,67 @@ jobs:
       # `.lsan_suppressions.txt` (`leak:lua*`) can never match.
       - run: nix profile install --inputs-from . nixpkgs#just nixpkgs#llvmPackages_19.llvm
 
-      - name: Build with sanitizers (ASan + UBSan) — unit tests run in sandbox
+      - name: Build with sanitizers (ASan + UBSan)
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
-        run: just nix-build-sanitized
+        # Wrap with `nix develop --command` so bazelisk runs inside the
+        # dev shell. This mirrors `.github/workflows/bazel-build.yml`'s
+        # invocation and is the only way `gh` (used by the kakadu
+        # repository_rule), `cmake`/`perl`/`pkg-config`/`autoconf`/
+        # `automake`/`libtoolize` (used by foreign_cc rules), and the
+        # Nix-injected `NIX_LDFLAGS`/`ACLOCAL_PATH` (forwarded into
+        # foreign_cc actions via `.bazelrc:--action_env=*`) reach the
+        # build. Running bare `just bazel-build-sanitized` falls back
+        # to the runner's pre-installed bazelisk + system tooling,
+        # which produces an inconsistent foreign_cc compile env and
+        # surfaces as kakadu output-extraction failures on linux-x86_64
+        # specifically.
+        # `--disk_cache` is set on the recipe's `*FLAGS` positional so bash
+        # expands `$HOME` here — Bazel does not expand env vars in
+        # .bazelrc paths (bazelbuild/bazel#15856). Path matches the
+        # `actions/cache` step above so the cache is restored and saved
+        # across CI runs.
+        run: nix develop --command bash -c "just bazel-build-sanitized --disk_cache=\$HOME/.cache/bazel-disk"
+
+      - name: dump foreign_cc Make.log files on failure
+        if: failure()
+        # Same pattern as `bazel-build.yml`. When a `make()` /
+        # `cmake()` foreign_cc rule fails, rules_foreign_cc captures
+        # the underlying make/cmake stderr into a per-action `*.log`
+        # file. With the build invoked above using
+        # `--verbose_failures` (set in the recipe) the action's
+        # command line is shown but the log file is not auto-cat'd —
+        # do it here so the actual failure cause reaches the CI log.
+        run: |
+          OUTPUT_BASE=$(nix develop --command bash -c 'bazelisk info output_base' 2>/dev/null)
+          if [ -n "$OUTPUT_BASE" ]; then
+            find "$OUTPUT_BASE" -path '*foreign_cc*' -name '*.log' -print 2>/dev/null | while read -r log; do
+              echo ""
+              echo "═══════════════════════════════════════════════════"
+              echo "Foreign_cc log: $log"
+              echo "═══════════════════════════════════════════════════"
+              cat "$log" || true
+            done
+          fi
 
       - name: Run e2e tests under sanitizers
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
-          SIPI_BIN: ${{ github.workspace }}/result/bin/sipi
+          SIPI_BIN: ${{ github.workspace }}/bazel-bin/src/sipi
           ASAN_OPTIONS: detect_leaks=1:halt_on_error=0:log_path=/tmp/asan-e2e
           LSAN_OPTIONS: suppressions=${{ github.workspace }}/.lsan_suppressions.txt
         # `nix-test-e2e` consumes the `.#e2e-tests` Nix derivation —
         # no cargo on PATH needed, so the `nix develop` wrap is gone.
         # ASan / LSan run in the sipi binary (already built sanitized
-        # by the previous step); the test client doesn't need to be
-        # sanitized, so building it via crane in a regular sandbox is
-        # fine (filter-syscalls only matters for the sanitizer build).
+        # by the previous step via `bazel build --config=asan --config=ubsan`);
+        # the test client itself doesn't need to be sanitized, so the
+        # crane-built e2e binaries from `.#e2e-tests` are fine as-is.
         # Pass `ASAN_SYMBOLIZER_PATH` explicitly so the symbolizer
         # is found regardless of what's on PATH at exec time
         # (sanitizers honour this env before doing PATH lookup); the
-        # `.#sanitized` variant in flake.nix keeps DWARF inline so
-        # the symbolizer has something to read.
+        # Bazel sanitized config keeps DWARF inline (`--strip=never`
+        # + `--compilation_mode=dbg` in `.bazelrc`) so the symbolizer
+        # has something to read.
         run: |
           export ASAN_SYMBOLIZER_PATH="$(command -v llvm-symbolizer)"
           just nix-test-e2e
@@ -94,9 +180,10 @@ jobs:
         run: |
           # Check for actual findings (SUMMARY lines), not just file existence.
           # ASan always writes a log file when log_path is set, even with zero
-          # findings. Unit-test findings fail the nix-build-sanitized step
-          # directly (sandbox halts on first error), so this step only covers
-          # the e2e suite.
+          # findings. The Bazel build step doesn't run unit tests (Bazel
+          # `bazel build` is build-only), so this step covers the e2e suite
+          # only — unit-test sanitizer coverage returns when Y+6 cuts the
+          # unit-test execution path to Bazel `cc_test`.
           HAS_FINDINGS=false
           if grep -q "SUMMARY:" /tmp/asan-e2e.* 2>/dev/null; then
             HAS_FINDINGS=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ For full build instructions (Docker, Nix, macOS), see [`docs/src/development/bui
 
 **Build reproducibility invariant:** every `nix-*` recipe wraps `nix build .#<variant>`. CI invokes only `just <recipe>` — no inline cmake or `nix build` calls. Incremental inner-loop development is a documented dev-shell pattern (see below), not a recipe.
 
-**Build completeness invariant:** every build target must succeed on every supported platform — macOS (darwin-aarch64), linux-x86_64, and linux-aarch64. This applies to `.#dev`, `.#default`, `.#release`, `.#sanitized`, and `.#fuzz` on all platforms; and to `.#docker`, `.#docker-stream`, and `.#sipi-debug` on Linux only (Linux-only outputs are gated by `pkgs.lib.optionalAttrs isLinux` in `flake.nix`). A target that builds on only some of its supported platforms is a shipping bug, not a known limitation — CI is Linux-only, so **a green CI run does not verify macOS**. Before shipping any change to `flake.nix`, `package.nix`, or a `justfile` build recipe:
+**Build completeness invariant:** every build target must succeed on every supported platform — macOS (darwin-aarch64), linux-x86_64, and linux-aarch64. This applies to `.#dev`, `.#default`, `.#release`, and `.#fuzz` on all platforms; and to `.#docker`, `.#docker-stream`, and `.#sipi-debug` on Linux only (Linux-only outputs are gated by `pkgs.lib.optionalAttrs isLinux` in `flake.nix`). The sanitized variant is now Bazel-native (`bazel build --config=asan --config=ubsan //src:sipi`) — see the Quick Reference below. A target that builds on only some of its supported platforms is a shipping bug, not a known limitation — CI is Linux-only, so **a green CI run does not verify macOS**. Before shipping any change to `flake.nix`, `package.nix`, or a `justfile` build recipe:
 
 1. Run every affected variant on macOS locally (`just nix-build-<variant>`).
 2. Run every affected Linux variant locally via Determinate's native-linux-builder (`nix build .#packages.x86_64-linux.<variant>` and `.#packages.aarch64-linux.<variant>`). See [`docs/src/development/nix.md`](docs/src/development/nix.md) for setup.
@@ -40,7 +40,6 @@ If a change can't be verified on a platform locally, say so explicitly and gate 
 just nix-build                   # .#dev: Debug + coverage, tests run in sandbox
 just nix-build-default           # .#default: RelWithDebInfo + tests (matches distributed binary shape)
 just nix-build-release           # .#release: stripped, no tests
-just nix-build-sanitized         # .#sanitized: Debug + ASan + UBSan, tests run in sandbox
 just nix-build-fuzz              # .#fuzz: libFuzzer harness binary only
 just nix-coverage                # .#dev^coverage: produces result-coverage/coverage.xml
 just nix-docker-build            # .#docker-stream: host-arch image, load into local daemon
@@ -60,6 +59,7 @@ just nix-valgrind                # run sipi under Valgrind
 # tests via just nix-build's checkPhase until DEV-6348 (Y+6))
 just bazel-test-unit             # bazel test //test/unit/...  (12 of 12 components)
 just bazel-test-approval         # bazel test //test/approval:approvaltests  (24 cases, env-injected SOURCE_DATE_EPOCH)
+just bazel-build-sanitized       # bazel build --config=asan --config=ubsan //src:sipi  (PR Y+2 — sanitizer.yml CI)
 
 # Dev-shell inner loop (non-recipe — see "Inner-loop development" below)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,28 +227,6 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES ".*Cla
     target_link_options(coverage_link INTERFACE --coverage)
 endif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
 
-#
-# Sanitizers (ASan + UBSan)
-#
-
-add_library(sanitizer_config INTERFACE)
-
-option(ENABLE_SANITIZERS "Enable AddressSanitizer and UndefinedBehaviorSanitizer (Clang only)" OFF)
-if (ENABLE_SANITIZERS)
-    if (NOT CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
-        message(WARNING "ENABLE_SANITIZERS is designed for Clang. GCC sanitizer support may differ.")
-    endif ()
-    target_compile_options(sanitizer_config INTERFACE
-            -fsanitize=address,undefined
-            -fno-omit-frame-pointer
-            -fno-optimize-sibling-calls
-    )
-    target_link_options(sanitizer_config INTERFACE
-            -fsanitize=address,undefined
-    )
-    message(STATUS "Sanitizers enabled: ASan + UBSan")
-endif ()
-
 # on macOS, ignore frameworks
 # the complete environment should be provided through NIX
 if (CMAKE_SYSTEM_NAME STREQUAL DARWIN)
@@ -558,9 +536,6 @@ target_link_libraries(${PROJECT_NAME} ${LIBS}
 target_link_libraries(sipi build_config)
 if (CODE_COVERAGE)
     target_link_libraries(sipi coverage_compile coverage_link)
-endif ()
-if (ENABLE_SANITIZERS)
-    target_link_libraries(sipi sanitizer_config)
 endif ()
 
 install(TARGETS sipi

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -46,7 +46,7 @@
 - Memory fixes verified under ASan (no leaks, no UB)
 - New HTTP behavior tested in Rust e2e or Hurl (not Python — Python tests are frozen)
 - Tests verify behavior (dimensions, content, structure), not just HTTP status codes
-- **Sanitizer gate:** PRs touching `src/`, `shttps/`, `include/`, or `test/` automatically run the sanitizer CI workflow (`sanitizer.yml`). Zero findings required to merge
+- **Sanitizer gate:** PRs touching `src/`, `shttps/`, `include/`, or `test/` automatically run the sanitizer CI workflow (`sanitizer.yml`). Zero findings required to merge. Coverage is **e2e-only** until DEV-6348 (PR Y+6) cuts unit-test execution to Bazel `cc_test` — first-party translation units are still ASan/UBSan-instrumented at compile time, but only the e2e suite exercises them at runtime in this window
 - **Bazel `cc_test` parity:** PRs that add a new unit test should also add the matching `cc_test` target in `test/unit/<mod>/BUILD.bazel`. CMake/ctest via `just nix-build` remains the CI canonical path until DEV-6348 cuts CI over; `just bazel-test-unit` and `just bazel-test-approval` are the local fast-feedback path until then
 
 ### Metrics

--- a/docs/src/development/building.md
+++ b/docs/src/development/building.md
@@ -88,7 +88,7 @@ Most common commands:
 ```bash
 just nix-build                 # .#dev: Debug + coverage, tests in sandbox
 just nix-build-default         # .#default: RelWithDebInfo + tests
-just nix-build-sanitized       # .#sanitized: ASan + UBSan
+just bazel-build-sanitized     # bazel build --config=asan --config=ubsan //src:sipi
 ```
 
 ## Building a Docker image
@@ -131,8 +131,8 @@ Run `just` (no arguments) to see the full list. Key target groups:
 | `nix-build` | `.#dev` — Debug + coverage; unit tests run in the Nix sandbox |
 | `nix-build-default` | `.#default` — RelWithDebInfo + tests |
 | `nix-build-release` | `.#release` — stripped, no tests |
-| `nix-build-sanitized` | `.#sanitized` — Debug + ASan + UBSan |
 | `nix-build-fuzz` | `.#fuzz` — libFuzzer harness binary only |
+| `bazel-build-sanitized` | `bazel build --config=asan --config=ubsan //src:sipi` — Debug + ASan + UBSan (DWARF inline; `.lsan_suppressions.txt` consulted by the e2e step) |
 | `nix-coverage` | `.#dev^coverage` — writes `result-coverage/coverage.xml` |
 | `nix-docker-build` | Build `.#docker-stream` (host arch), load into local Docker daemon |
 | `nix-docker-build-{amd64,arm64}` | Build `.#packages.<arch>-linux.docker-stream` + `.#packages.<arch>-linux.sipi-debug` (single `nix build`) |

--- a/docs/src/development/ci.md
+++ b/docs/src/development/ci.md
@@ -133,7 +133,7 @@ do not override `LC_ALL` at runtime. See
 Every CI step invokes `just <recipe>` — no inline cmake or `nix build`
 calls. To reproduce any CI job locally, run the same recipe. With the
 Determinate Systems native-linux-builder available to macOS authors,
-Linux-target recipes (`nix-build-sanitized`, `nix-build-fuzz`) run
+Linux-target recipes (`nix-build-fuzz`, `bazel-build-sanitized`) run
 locally without a CI round-trip.
 
 `just nix-build*` recipes wrap `nix build`, so CI invokes them directly
@@ -154,9 +154,12 @@ just nix-coverage
 just nix-docker-build-amd64               # or -arm64 on aarch64 host
 just nix-test-smoke                       # binary from .#smoke-test
 
-# Sanitizer build + tests (what sanitizer.yml runs)
-just nix-build-sanitized                  # tests run in sandbox
-SIPI_BIN=$PWD/result/bin/sipi just nix-test-e2e
+# Sanitizer build + e2e (what sanitizer.yml runs)
+just bazel-build-sanitized                # bazel build --config=asan --config=ubsan //src:sipi
+SIPI_BIN=$PWD/bazel-bin/src/sipi \
+  ASAN_OPTIONS=detect_leaks=1:halt_on_error=0:log_path=/tmp/asan-e2e \
+  LSAN_OPTIONS=suppressions=$PWD/.lsan_suppressions.txt \
+  just nix-test-e2e
 
 # Fuzz build + run (what fuzz.yml runs)
 just nix-build-fuzz

--- a/docs/src/development/cpp-style-guide.md
+++ b/docs/src/development/cpp-style-guide.md
@@ -54,16 +54,23 @@ target_compile_options(mylib PRIVATE
 
 ### Sanitizer Flags (Debug/Test Builds)
 
-Enable address and undefined behavior sanitizers in debug builds:
+Enable address and undefined behavior sanitizers in Bazel via the
+`--config=asan` and `--config=ubsan` blocks in `.bazelrc`:
 
-```cmake
-if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR ENABLE_SANITIZERS)
-  target_compile_options(mylib PRIVATE -fsanitize=address,undefined -fno-omit-frame-pointer)
-  target_link_options(mylib PRIVATE -fsanitize=address,undefined)
-endif()
+```bash
+bazel build --config=asan --config=ubsan //src:sipi
+# or via the wrapper:
+just bazel-build-sanitized
 ```
 
-Run tests under sanitizers regularly to catch memory bugs and undefined behavior early. Thread sanitizer (`-fsanitize=thread`) is incompatible with ASan — run it separately.
+The configs apply `-fsanitize=address` / `-fsanitize=undefined` together
+with `-fno-omit-frame-pointer`, `-fno-optimize-sibling-calls`,
+`--compilation_mode=dbg`, and `--strip=never` — DWARF must stay inline
+so LSan's symbol-name suppressions in `.lsan_suppressions.txt` resolve.
+
+Run tests under sanitizers regularly to catch memory bugs and undefined
+behavior early. Thread sanitizer (`-fsanitize=thread`) is incompatible
+with ASan — run it separately.
 
 ---
 

--- a/docs/src/development/nix.md
+++ b/docs/src/development/nix.md
@@ -9,8 +9,8 @@ and shares its dependency cache with CI via Cachix.
 A few concepts that make the rest of this page click:
 
 **Derivation.** Each package in the flake — `dev`, `default`, `release`,
-`sanitized`, `fuzz`, `docker`, etc. — is a separate *derivation*: a
-build recipe with fully declared inputs (source, compiler, flags, deps).
+`fuzz`, `docker`, etc. — is a separate *derivation*: a build recipe
+with fully declared inputs (source, compiler, flags, deps).
 Nix hashes the recipe, builds once, caches the result in `/nix/store`,
 and serves future requests instantly.
 
@@ -98,7 +98,6 @@ invocations in recipes — CI invokes only `just <recipe>`.
 just nix-build                         # .#dev: Debug + coverage; unit tests run in the sandbox
 just nix-build-default                 # .#default: RelWithDebInfo + tests
 just nix-build-release                 # .#release: stripped, no tests
-just nix-build-sanitized               # .#sanitized: Debug + ASan + UBSan
 just nix-build-fuzz                    # .#fuzz: libFuzzer binary only
 just nix-coverage                      # .#dev^coverage: writes result-coverage/coverage.xml
 just nix-docker-build                  # .#docker-stream: host-arch image into local Docker daemon
@@ -261,8 +260,9 @@ nix build .#packages.aarch64-linux.dev -L
 ```
 
 Swap `aarch64-linux` for `x86_64-linux` to reproduce the amd64 CI
-variant. Works for every package: `dev`, `default`, `release`,
-`sanitized`, `fuzz`.
+variant. Works for every package: `dev`, `default`, `release`, `fuzz`.
+The sanitized variant is now Bazel-native (`just bazel-build-sanitized`)
+— see [Building from source](./building.md).
 
 `native-linux-builder` dispatches the build automatically; you don't
 pass a `--system` flag. Warm Cachix → seconds. Cold Cachix → ~15 min

--- a/docs/src/development/testing-strategy.md
+++ b/docs/src/development/testing-strategy.md
@@ -701,7 +701,7 @@ The following matrix maps every testable IIIF spec requirement to its test statu
 
 Memory leaks and undefined behavior are not a separate pyramid layer but a **build variant** that runs existing tests with compiler instrumentation. This is critical for sipi as a long-running C++ server where leaks accumulate.
 
-**Current state:** ASan+UBSan infrastructure is in place — `ENABLE_SANITIZERS` CMake option, `just nix-build-sanitized` (builds `.#sanitized` with tests running in the Nix sandbox), and nightly `sanitizer.yml` CI workflow. Known findings to triage on first run:
+**Current state:** ASan+UBSan infrastructure is in place — Bazel `--config=asan` and `--config=ubsan` blocks in `.bazelrc`, `just bazel-build-sanitized` (`bazel build --config=asan --config=ubsan //src:sipi`), and a `sanitizer.yml` CI workflow that exercises the e2e suite against the resulting binary. Known findings to triage on first run:
 
 - **DEV-6002: `SipiFilenameHash::operator=` memory leak** — `operator=` allocates `new vector<char>` without deleting the old `hash` pointer. Confirmed by code inspection. Fix: add `delete hash;` before the new allocation, or switch to `std::unique_ptr`.
 - **Potential: `SipiFilenameHash` copy constructor** — also `new`s without freeing, but only leaks if the destination object was previously constructed with a different hash (doesn't happen via typical usage).
@@ -719,12 +719,13 @@ Memory leaks and undefined behavior are not a separate pyramid layer but a **bui
 
 | Component | Status | Details |
 |-----------|--------|---------|
-| `ENABLE_SANITIZERS` CMake option | Done | `-fsanitize=address,undefined` on all targets |
-| `just nix-build-sanitized` | Done | Builds `.#sanitized` derivation (Debug + ASan + UBSan); unit tests run inside the Nix sandbox and fail the build on any finding |
-| Nightly CI (`sanitizer.yml`) | Done | PR + scheduled; unit tests in-sandbox, e2e out-of-sandbox with ASan log capture |
+| `--config=asan` / `--config=ubsan` in `.bazelrc` | Done | `-fsanitize=address` / `-fsanitize=undefined` plus `-fno-omit-frame-pointer`, `-fno-optimize-sibling-calls`, `--strip=never`, `--compilation_mode=dbg` (DWARF inline so `.lsan_suppressions.txt` symbol-name suppressions match) |
+| `just bazel-build-sanitized` | Done | Wraps `bazel build --config=asan --config=ubsan //src:sipi` |
+| PR CI (`sanitizer.yml`) | Done | Bazel-built binary at `bazel-bin/src/sipi`, e2e suite under `just nix-test-e2e` with ASan log capture; `.lsan_suppressions.txt` consumed by LSan via `LSAN_OPTIONS` |
+| Unit-test sanitizer coverage in CI | Returns at Y+6 | DEV-6348 cuts unit-test execution to Bazel `cc_test`; until then the Bazel-built binary covers e2e only |
 | TSan variant | Future | Optional nightly, separate from ASan (can't combine) |
 
-**Strategy:** Nightly CI job runs unit tests + e2e suite with ASan+UBSan. TSan as optional nightly variant. Not in PR CI (too slow).
+**Strategy:** PR CI runs the e2e suite against an ASan+UBSan-instrumented binary. Unit-test coverage under sanitizers will return when DEV-6348 (Y+6) cuts CI's unit-test execution to Bazel `cc_test`. TSan remains a future option.
 
 ## Cross-Cutting: Performance Regression Detection
 
@@ -783,7 +784,7 @@ insta::assert_json_snapshot!(info_json, {
 | Hurl contract tests | `just hurl-test` | PR CI | Declarative HTTP tests |
 | Python e2e tests | *(retired)* | — | Replaced by Rust e2e tests |
 | Fuzz testing | `.github/workflows/fuzz.yml` | Nightly | libFuzzer corpus growth |
-| Sanitizer builds | `just nix-build-sanitized` (`.#sanitized`) | PR + Nightly | ASan+UBSan; unit tests in-sandbox, e2e out-of-sandbox |
+| Sanitizer builds | `just bazel-build-sanitized` (`bazel build --config=asan --config=ubsan //src:sipi`) | PR | ASan+UBSan; e2e suite against `bazel-bin/src/sipi` with `.lsan_suppressions.txt` |
 
 ## Python Test Deprecation — Parity Checklist
 

--- a/ext/curl/BUILD.bazel
+++ b/ext/curl/BUILD.bazel
@@ -21,6 +21,11 @@ cmake(
     lib_source = "@curl//:all_srcs",
     cache_entries = {
         "CMAKE_INSTALL_LIBDIR": "lib",
+        # Suppress Bazel's auto-injected `CMAKE_BUILD_TYPE=Debug` so curl's
+        # `set_target_properties(libcurl_static PROPERTIES DEBUG_POSTFIX "-d")`
+        # doesn't kick in and rename the static library to `libcurl-d.a`.
+        # See ext/png/BUILD.bazel for the full rationale.
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "BUILD_SHARED_LIBS": "OFF",
         "BUILD_STATIC_LIBS": "ON",
         "BUILD_CURL_EXE": "OFF",
@@ -58,6 +63,9 @@ cmake(
         "CURL_USE_LIBSSH2": "OFF",
         "CURL_USE_LIBSSH": "OFF",
     },
+    # Pin --config used by `cmake --build` and `cmake --install` —
+    # see ext/png/BUILD.bazel for the rationale.
+    configuration = "RelWithDebInfo",
     out_static_libs = ["libcurl.a"],
     set_file_prefix_map = True,
     deps = [

--- a/ext/exiv2/BUILD.bazel
+++ b/ext/exiv2/BUILD.bazel
@@ -11,6 +11,9 @@ cmake(
     name = "exiv2",
     lib_source = "@exiv2//:all_srcs",
     cache_entries = {
+        # Suppress Bazel's auto-injected CMAKE_BUILD_TYPE=Debug — see
+        # ext/png/BUILD.bazel for the rationale (Debug-postfix hazard).
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_INSTALL_LIBDIR": "lib",
         "BUILD_SHARED_LIBS": "OFF",
         "EXIV2_ENABLE_INIH": "OFF",
@@ -19,6 +22,9 @@ cmake(
         "EXIV2_BUILD_EXIV2_COMMAND": "OFF",
         "EXIV2_ENABLE_NLS": "OFF",
     },
+    # Pin --config used by `cmake --build` and `cmake --install` —
+    # see ext/png/BUILD.bazel for the rationale.
+    configuration = "RelWithDebInfo",
     out_static_libs = [
         # exiv2 0.28.x consolidated the XMP support into `libexiv2.a`;
         # the standalone `libexiv2-xmp.a` from earlier releases is gone.

--- a/ext/expat/BUILD.bazel
+++ b/ext/expat/BUILD.bazel
@@ -11,6 +11,9 @@ cmake(
     name = "expat",
     lib_source = "@expat//:all_srcs",
     cache_entries = {
+        # Suppress Bazel's auto-injected CMAKE_BUILD_TYPE=Debug — see
+        # ext/png/BUILD.bazel for the rationale (Debug-postfix hazard).
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_POLICY_VERSION_MINIMUM": "3.5",
         "CMAKE_INSTALL_LIBDIR": "lib",
         "EXPAT_BUILD_TOOLS": "OFF",
@@ -19,6 +22,9 @@ cmake(
         "EXPAT_BUILD_TESTS": "OFF",
         "BUILD_SHARED_LIBS": "OFF",
     },
+    # Pin --config used by `cmake --build` and `cmake --install` —
+    # see ext/png/BUILD.bazel for the rationale.
+    configuration = "RelWithDebInfo",
     out_static_libs = ["libexpat.a"],
     set_file_prefix_map = True,
 )

--- a/ext/jansson/BUILD.bazel
+++ b/ext/jansson/BUILD.bazel
@@ -11,6 +11,9 @@ cmake(
     name = "jansson",
     lib_source = "@jansson//:all_srcs",
     cache_entries = {
+        # Suppress Bazel's auto-injected CMAKE_BUILD_TYPE=Debug — see
+        # ext/png/BUILD.bazel for the rationale (Debug-postfix hazard).
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_POLICY_VERSION_MINIMUM": "3.5",
         "CMAKE_INSTALL_LIBDIR": "lib",
         "JANSSON_BUILD_DOCS": "OFF",
@@ -18,6 +21,9 @@ cmake(
         "JANSSON_EXAMPLES": "OFF",
         "JANSSON_TEST": "OFF",
     },
+    # Pin --config used by `cmake --build` and `cmake --install` —
+    # see ext/png/BUILD.bazel for the rationale.
+    configuration = "RelWithDebInfo",
     out_static_libs = ["libjansson.a"],
     set_file_prefix_map = True,
 )

--- a/ext/png/BUILD.bazel
+++ b/ext/png/BUILD.bazel
@@ -13,6 +13,31 @@ cmake(
     lib_source = "@png//:all_srcs",
     cache_entries = {
         "CMAKE_INSTALL_LIBDIR": "lib",
+        # Override Bazel's auto-injected `CMAKE_BUILD_TYPE=Debug` (which
+        # foreign_cc sets from `--compilation_mode=dbg` under
+        # `--config=asan` / `--config=ubsan`). `RelWithDebInfo` (-O2 -g)
+        # is what we actually want for unsanitised foreign_cc deps:
+        #   - No `DEBUG_POSTFIX`. Several upstream `CMakeLists.txt` —
+        #     libpng (`d`), curl (`-d`), and others — apply
+        #     `set_target_properties(... DEBUG_POSTFIX …)` only when
+        #     `CMAKE_BUILD_TYPE=Debug`, which renames the static lib and
+        #     breaks the foreign_cc `out_static_libs` invariant check.
+        #   - Consistent IMPORTED-target config across deps. `cmake_install`
+        #     emits per-config `XConfig-<lower>.cmake` files; downstream
+        #     consumers (sentry's CMakeLists imports `CURL::libcurl_static`)
+        #     pick the config matching their own build type. If curl
+        #     installed as Debug (`CURLTargets-debug.cmake`) but sentry
+        #     resolves at RelWithDebInfo, the import fails with
+        #     `IMPORTED_LOCATION not set for … configuration "RelWithDebInfo"`.
+        #     Pinning every cmake() ext/* dep to RelWithDebInfo keeps
+        #     them in lock-step.
+        # The `cache_entries[CMAKE_BUILD_TYPE]` value takes precedence
+        # over the auto-injected one in `rules_foreign_cc`'s
+        # `foreign_cc/private/cmake_script.bzl`.
+        # Sipi's own (sanitised) translation units are unaffected — they
+        # don't go through cmake; their `-fsanitize=…` reaches them via
+        # `--per_file_copt` in `.bazelrc`.
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "PNG_SHARED": "OFF",
         "PNG_STATIC": "ON",
         "PNG_TESTS": "OFF",
@@ -39,6 +64,16 @@ cmake(
         "ZLIB_INCLUDE_DIR": "$$EXT_BUILD_DEPS/zlib/include",
         "ZLIB_LIBRARY": "$$EXT_BUILD_DEPS/zlib/lib/libz.a",
     },
+    # `cache_entries[CMAKE_BUILD_TYPE]` only affects the cmake CONFIGURE
+    # step. The subsequent `cmake --build … --config <X>` and
+    # `cmake --install … --config <X>` commands read the `configuration`
+    # rule attribute (see `rules_foreign_cc/foreign_cc/cmake.bzl`), which
+    # otherwise defaults to "Debug" under `--compilation_mode=dbg`.
+    # Without this, cmake would build/install at "Debug" against a tree
+    # configured for "RelWithDebInfo", and `install(EXPORT …)` would emit
+    # no per-config target file — downstream cmake consumers then fail
+    # at `IMPORTED_LOCATION not set for … configuration "RelWithDebInfo"`.
+    configuration = "RelWithDebInfo",
     out_static_libs = ["libpng16.a"],
     set_file_prefix_map = True,
     deps = ["//ext/zlib:zlib"],

--- a/ext/sentry/BUILD.bazel
+++ b/ext/sentry/BUILD.bazel
@@ -12,6 +12,9 @@ cmake(
     name = "sentry",
     lib_source = "@sentry//:all_srcs",
     cache_entries = {
+        # Suppress Bazel's auto-injected CMAKE_BUILD_TYPE=Debug — see
+        # ext/png/BUILD.bazel for the rationale (Debug-postfix hazard).
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_INSTALL_LIBDIR": "lib",
         "SENTRY_BACKEND": "inproc",
         "SENTRY_BUILD_SHARED_LIBS": "OFF",
@@ -25,6 +28,9 @@ cmake(
         # the version check resolves against the right copy.
         "OPENSSL_ROOT_DIR": "$$EXT_BUILD_DEPS/openssl",
     },
+    # Pin --config used by `cmake --build` and `cmake --install` —
+    # see ext/png/BUILD.bazel for the rationale.
+    configuration = "RelWithDebInfo",
     out_static_libs = ["libsentry.a"],
     set_file_prefix_map = True,
     deps = [

--- a/ext/tiff/BUILD.bazel
+++ b/ext/tiff/BUILD.bazel
@@ -14,6 +14,9 @@ cmake(
     name = "tiff",
     lib_source = "@tiff//:all_srcs",
     cache_entries = {
+        # Suppress Bazel's auto-injected CMAKE_BUILD_TYPE=Debug — see
+        # ext/png/BUILD.bazel for the rationale (Debug-postfix hazard).
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_INSTALL_LIBDIR": "lib",
         "BUILD_SHARED_LIBS": "OFF",
         "CMAKE_POLICY_VERSION_MINIMUM": "3.5",
@@ -38,6 +41,9 @@ cmake(
     # into BUILD_TMPDIR (that's a configure_make-only behaviour), so the
     # canonical source path is `$EXT_BUILD_ROOT/external/+http_archive+tiff`.
     postfix_script = "cp $$EXT_BUILD_ROOT/external/+http_archive+tiff/libtiff/tif_dir.h $$INSTALLDIR/include/",
+    # Pin --config used by `cmake --build` and `cmake --install` —
+    # see ext/png/BUILD.bazel for the rationale.
+    configuration = "RelWithDebInfo",
     out_static_libs = ["libtiff.a"],
     set_file_prefix_map = True,
     deps = [

--- a/ext/webp/BUILD.bazel
+++ b/ext/webp/BUILD.bazel
@@ -11,6 +11,9 @@ cmake(
     name = "webp",
     lib_source = "@webp//:all_srcs",
     cache_entries = {
+        # Suppress Bazel's auto-injected CMAKE_BUILD_TYPE=Debug — see
+        # ext/png/BUILD.bazel for the rationale (Debug-postfix hazard).
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_INSTALL_LIBDIR": "lib",
         "BUILD_SHARED_LIBS": "OFF",
         "WEBP_BUILD_ANIM_UTILS": "OFF",
@@ -25,6 +28,9 @@ cmake(
         "CMAKE_DISABLE_FIND_PACKAGE_TIFF": "TRUE",
         "CMAKE_DISABLE_FIND_PACKAGE_GIF": "TRUE",
     },
+    # Pin --config used by `cmake --build` and `cmake --install` —
+    # see ext/png/BUILD.bazel for the rationale.
+    configuration = "RelWithDebInfo",
     out_static_libs = ["libwebp.a"],
     set_file_prefix_map = True,
 )

--- a/ext/zstd/BUILD.bazel
+++ b/ext/zstd/BUILD.bazel
@@ -12,12 +12,18 @@ cmake(
     lib_source = "@zstd//:all_srcs",
     working_directory = "build/cmake",
     cache_entries = {
+        # Suppress Bazel's auto-injected CMAKE_BUILD_TYPE=Debug — see
+        # ext/png/BUILD.bazel for the rationale (Debug-postfix hazard).
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_INSTALL_LIBDIR": "lib",
         "ZSTD_BUILD_PROGRAMS": "OFF",
         "ZSTD_BUILD_TESTS": "OFF",
         "ZSTD_BUILD_SHARED": "OFF",
         "ZSTD_BUILD_STATIC": "ON",
     },
+    # Pin --config used by `cmake --build` and `cmake --install` —
+    # see ext/png/BUILD.bazel for the rationale.
+    configuration = "RelWithDebInfo",
     out_static_libs = ["libzstd.a"],
     set_file_prefix_map = True,
 )

--- a/flake.nix
+++ b/flake.nix
@@ -315,28 +315,6 @@
             enableTests = false;
           }).overrideAttrs { dontStrip = true; };
 
-          # Debug build with AddressSanitizer + UndefinedBehaviorSanitizer.
-          # Mirrors sanitizer.yml's pre-Nix imperative invocation, now as a
-          # derivation so `just nix-build-sanitized` routes through Cachix
-          # and runs the sanitizer-instrumented gtest suite in-sandbox.
-          #
-          # Override `separateDebugInfo` / `dontStrip`: the default `pkgs.sipi`
-          # derivation strips the binary into a separate `debug` output, but
-          # the sanitizer e2e step only fetches `result/bin/sipi`. Without
-          # DWARF inline, ASan's symbolizer can't resolve frames, so the
-          # `leak:lua*` patterns in `.lsan_suppressions.txt` never match —
-          # known Lua exit-time leaks then surface as gate failures. Keep
-          # DWARF in the binary for this variant only; production variants
-          # (`.#default`, `.#release`) keep the small stripped layout.
-          sanitized = (pkgs.sipi.override {
-            cmakeBuildType = "Debug";
-            enableSanitizers = true;
-            enableTests = true;
-          }).overrideAttrs {
-            separateDebugInfo = false;
-            dontStrip = true;
-          };
-
           # Fuzz harness build. Uses llvmPackages_19.stdenv (libstdc++)
           # because libFuzzer's ABI is tied to libstdc++. The override
           # replaces buildPhase/installPhase to produce just the fuzzer

--- a/justfile
+++ b/justfile
@@ -96,13 +96,6 @@ nix-build-release:
     {{_nix_build}} .#release
     @echo "Binary at: $(readlink result)/bin/sipi"
 
-# Sanitized build: Debug + ASan + UBSan, tests run in the Nix sandbox.
-# `filter-syscalls false` is required because LSan uses ptrace, which
-# the default Nix sandbox blocks via seccomp. No-op on macOS.
-nix-build-sanitized:
-    {{_nix_build}} .#sanitized --option filter-syscalls false
-    @echo "Binary at: $(readlink result)/bin/sipi"
-
 # Fuzz harness build: produces the libFuzzer binary only (no sipi runtime files).
 nix-build-fuzz:
     {{_nix_build}} .#fuzz
@@ -201,6 +194,24 @@ bazel-test-unit:
 # lands under `bazel-testlogs/test/approval/approvaltests/`.
 bazel-test-approval:
     bazel test //test/approval:approvaltests
+
+# Sanitized build: Debug + ASan + UBSan via Bazel `--config=asan --config=ubsan`.
+# Replaces the deleted `.#sanitized` Nix variant (DEV-6344, PR Y+2). The
+# resulting binary at `bazel-bin/src/sipi` is what `sanitizer.yml`'s e2e
+# step consumes via `SIPI_BIN`. DWARF stays inline (`--strip=never` in
+# `.bazelrc`) so the symbol-name suppressions in `.lsan_suppressions.txt`
+# match. `--verbose_failures` surfaces the underlying cmake/make output
+# from any failing `rules_foreign_cc` ext/* dep — without it, Bazel only
+# reports the higher-level "output X was not created" line, which makes
+# triage of CFLAGS-propagation interactions impossible. `--stamp` runs
+# `tools/workspace_status.sh` so `STABLE_SIPI_VERSION` (from `version.txt`)
+# is baked into `SipiVersion.h` via `src/BUILD.bazel`'s
+# `expand_template(stamp_substitutions = {…})`. Without it, the binary
+# reports `sipi 0.0.0-unstamped` and the `cli_version_flag` e2e test
+# fails.
+bazel-build-sanitized *FLAGS='':
+    bazel build --config=asan --config=ubsan --verbose_failures --stamp {{FLAGS}} //src:sipi
+    @echo "Binary at: $(pwd)/bazel-bin/src/sipi"
 
 #####################################
 # Tests (consume $SIPI_BIN, default ./result/bin/sipi)
@@ -387,7 +398,6 @@ docs-install-requirements:
 # Clean build artifacts (cmake trees from the dev-shell inner loop + Nix result symlinks)
 clean:
     rm -rf build/
-    rm -rf build-sanitized/
     rm -rf build-fuzz/
     rm -rf cmake-build-relwithdebinfo-inside-docker/
     rm -rf site/

--- a/package.nix
+++ b/package.nix
@@ -24,7 +24,6 @@
                  # at build time.
 , cmakeBuildType ? "RelWithDebInfo"
 , enableCoverage ? false
-, enableSanitizers ? false
 , enableFuzzing ? false
 , enableTests ? true
 , providedVersion ? null
@@ -106,8 +105,6 @@ stdenv.mkDerivation {
     "-DCMAKE_BUILD_TYPE=${cmakeBuildType}"
   ] ++ lib.optionals enableCoverage [
     "-DCODE_COVERAGE=ON"
-  ] ++ lib.optionals enableSanitizers [
-    "-DENABLE_SANITIZERS=ON"
   ] ++ lib.optionals enableFuzzing [
     "-DSIPI_ENABLE_FUZZ=ON"
   ] ++ lib.optionals enableTests [
@@ -146,8 +143,8 @@ stdenv.mkDerivation {
 
   # `doCheck = enableTests` keeps the test invariant honest: any variant
   # that builds tests also runs them inside the sandbox (`.#default`,
-  # `.#dev`, `.#sanitized`). `.#release` sets `enableTests = false` and
-  # skips the check phase.
+  # `.#dev`). `.#release` sets `enableTests = false` and skips the
+  # check phase.
   doCheck = enableTests;
 
   # cmake setup-hook cd's into `build/` in configurePhase; checkPhase and

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -174,9 +174,6 @@ if (CODE_COVERAGE)
     target_link_libraries(libsipi_testable PRIVATE coverage_compile)
     target_link_libraries(libsipi_testable PUBLIC coverage_link)
 endif()
-if (ENABLE_SANITIZERS)
-    target_link_libraries(libsipi_testable PUBLIC sanitizer_config)
-endif()
 
 # Approval tests
 add_subdirectory(approval)


### PR DESCRIPTION
Fixes [DEV-6344](https://linear.app/dasch/issue/DEV-6344)

## Motivation

PR Y+2 of the seven-PR Bazel migration. The sanitized (ASan + UBSan)
build was the next variant to leave Nix authority because (a) it has
no production consumers — it is a CI gate only — so the migration
risk is bounded to one workflow, and (b) Bazel's `--per_file_copt`
gives clean per-translation-unit scoping that the prior CMake
`ENABLE_SANITIZERS` option achieved through a target-attached
INTERFACE library. The cutover proves the Bazel sanitizer toolchain
under foreign_cc + Nix dev-shell on the actual CI hardware before the
remaining variants (default / dev / release / fuzz / docker) follow.

## Summary

- Replaces the deleted `.#sanitized` Nix output with Bazel-native
  `--config=asan` / `--config=ubsan` blocks, wrapped by
  `just bazel-build-sanitized`.
- `sanitizer.yml`'s build step runs Bazel inside `nix develop`
  (matching `bazel-build.yml`); the e2e step still uses
  `just nix-test-e2e` against the Bazel-built binary at
  `bazel-bin/src/sipi`.
- Removes the dead `ENABLE_SANITIZERS` CMake option, the
  `enableSanitizers` `package.nix` parameter, and the `.#sanitized`
  flake output. Aligns the surrounding documentation.

## Key Changes

### Build orchestration (Bazel side)

- `.bazelrc`: `--config=asan` / `--config=ubsan` blocks. Each carries
  `--compilation_mode=dbg`, `--strip=never`,
  `-fno-omit-frame-pointer`, `-fno-optimize-sibling-calls`, plus its
  sanitizer's `-fsanitize=…` copt + linkopt. DWARF stays inline so
  LSan's symbol-name suppressions in `.lsan_suppressions.txt`
  (`leak:lua*`) match.
- `--per_file_copt` regex `^(src|shttps|fuzz|test)/.*\.(cpp|cc|cxx|c|mm)$`
  scopes sanitizer flags to first-party TUs only, leaving foreign_cc
  ext libs uninstrumented (mirrors prior CMake scope). Extension list
  covers every C-family extension upfront so future `.cc`/`.cxx`/`.mm`
  additions stay loud.
- `justfile`: adds `bazel-build-sanitized *FLAGS=''` recipe; removes
  `nix-build-sanitized` and the `build-sanitized/` line in `clean`.
  The variadic `*FLAGS` positional lets CI pass `--disk_cache=…`
  without duplicating the recipe body.
- 9 new `ext/<lib>/BUILD.bazel` files pin
  `cache_entries["CMAKE_BUILD_TYPE"] = "RelWithDebInfo"` and
  `configuration = "RelWithDebInfo"` so `--compilation_mode=dbg`
  doesn't poison the foreign_cc cmake() builds with `=Debug`.

### CI (`sanitizer.yml`)

- Build step runs `nix develop --command bash -c "just bazel-build-sanitized --disk_cache=\$HOME/.cache/bazel-disk"`.
- `actions/cache@v4` step manages `~/.cache/bazel-disk` with the
  same DEV-6371 strategy `bazel-build.yml` uses (targeted key
  formula, no `setup-bazel` disk-cache wiring to avoid 0-byte
  poisoning).
- `jlumbroso/free-disk-space` step releases ~6 GB of pre-installed
  SDKs so the LLVM 19 toolchain + 22 ext libs + disk cache fit on
  ubuntu-24.04.
- Path-trigger filter gains `.bazelrc`, `.bazelversion`,
  `MODULE.bazel`, `MODULE.bazel.lock`, `BUILD.bazel`, `**/BUILD.bazel`,
  `bazel/**`, `tools/**`, `ext/**`, and
  `.github/workflows/sanitizer.yml` so Bazel-graph changes also
  re-run sanitizer CI.
- Post-failure `Make.log` dump step (same shape as `bazel-build.yml`)
  surfaces the foreign_cc rule's stderr that
  rules_foreign_cc otherwise hides behind
  "output X was not created".

### CMake cleanup

- `CMakeLists.txt`: removes the `sanitizer_config` INTERFACE library,
  the `option(ENABLE_SANITIZERS …)` declaration, and the
  `target_link_libraries(sipi sanitizer_config)` guard.
- `test/CMakeLists.txt`: removes the matching
  `target_link_libraries(libsipi_testable PUBLIC sanitizer_config)`
  guard.

### Docs

- `CLAUDE.md`: build-completeness invariant no longer lists
  `.#sanitized`; the Bazel inner-loop quick reference adds
  `bazel-build-sanitized`.
- `building.md`, `nix.md`, `ci.md`, `cpp-style-guide.md`,
  `testing-strategy.md`: `nix-build-sanitized` references replaced
  with `bazel-build-sanitized` /
  `bazel build --config=asan --config=ubsan //src:sipi`.
- `REVIEW.md`: sanitizer-gate bullet now states coverage is e2e-only
  in this window (see Gotchas).

## Challenges and Decisions

### CFLAGS poisoning of foreign_cc rules

**Problem:** Initial attempt used global `--copt=-fsanitize=address`.
This poisoned `rules_foreign_cc`'s `make()` / `cmake()` /
`configure_make()` rules — they collect copts from the cc toolchain
and forward them as CFLAGS / CXXFLAGS to upstream Makefiles.
Kakadu's hand-written Makefile ignored the injected `-fsanitize=…`
on the link line, so its `libkdu.a` link was missing the matching
linkopt and the foreign_cc rule failed with "output X was not
created".

**Tried:** (a) Adding global `--linkopt=-fsanitize=…` to compensate
— didn't help, kakadu's Makefile builds with its own `LD` and
ignores Bazel linkopts. (b) Bazel `select()` + custom toolchain to
swap a sanitizer-enabled cc toolchain — adds ~150 lines of toolchain
boilerplate for one variant.

**Solution:** `--per_file_copt=<regex>@<flag>`. This is action-scoped
— it applies only when Bazel itself runs a compile action whose
source path matches the regex, and is NOT consulted when foreign_cc
collects toolchain flags for env-var forwarding. Matches the prior
CMake build's scope exactly: the `sanitizer_config` INTERFACE
library only attached to `sipi` and `libsipi_testable`, never to
`ext/*` foreign_cc targets.

### `--compilation_mode=dbg` poisoning cmake() ext deps

**Problem:** Bazel's `--compilation_mode=dbg` propagates into
`rules_foreign_cc`'s `cmake()` rules as `-DCMAKE_BUILD_TYPE=Debug`.
Two failure modes followed:
1. Some upstream `CMakeLists.txt` files apply
   `set_target_properties(... DEBUG_POSTFIX "d")` (libpng, sentry,
   curl as `"-d"`) in Debug mode and produce e.g. `libpng16d.a` /
   `libcurl-d.a` instead of the unsuffixed name expected by
   `out_static_libs`.
2. Per-config IMPORTED-target files (`XConfig-debug.cmake`,
   `XConfig-relwithdebinfo.cmake`) only exist for the matching build
   type; downstream cmake() consumers that resolve a different
   config fail with `IMPORTED_LOCATION not set for … configuration "<X>"`.

**Tried:** (a) Drop `--compilation_mode=dbg` and scope `-g -O0` to
first-party TUs via `--per_file_copt` — worked for source-level
debugging but broke kakadu's own Makefile which keys on the
`Make.STD` build mode. (b) Restoring `--compilation_mode=dbg` and
patching ext libs to disable DEBUG_POSTFIX — too invasive across 9
deps.

**Solution:** Each `cmake()` ext dep pins both
`cache_entries["CMAKE_BUILD_TYPE"] = "RelWithDebInfo"` AND a
rule-level `configuration = "RelWithDebInfo"` attribute. The
`cache_entries` value beats the auto-injected `=Debug` in
`rules_foreign_cc`'s `cmake_script.bzl`; the `configuration`
attribute pins the `--config` used by `cmake --build` /
`cmake --install`. Both are needed — neither alone works. Sipi's own
first-party TUs are unaffected because they don't go through cmake;
their `-fsanitize=…` reaches them via the `--per_file_copt` block
above.

### `-fsanitize=undefined` link failure

**Problem:** Build progressed past kakadu but failed at the final
sipi link with `ld.lld: error: undefined symbol:
__ubsan_vptr_type_cache` and `__ubsan_handle_dynamic_type_cache_miss`.

**Cause:** `-fsanitize=undefined` activates the vptr (RTTI) check by
default. Verifying RTTI at run time requires UBSan symbols that
toolchains_llvm's compiler-rt only ships in the **dynamic**
`libclang_rt.ubsan_standalone_cxx-…so` form. The toolchain's link
line forces static `-l:libc++.a -l:libc++abi.a`, so the dynamic
runtime is never pulled in and lld fails.

**Solution:** `-fno-sanitize=vptr` at both compile and link layers.
The other UBSan checks (integer overflow, null deref, alignment, …)
don't depend on the C++ runtime and link cleanly. Sipi's prior CMake
build escaped this because the Nix toolchain linked C++ dynamically
and the runtime resolved against the system libc++ — that escape
hatch is gone under toolchains_llvm's static link.

### CI environment mismatch (kakadu output not created)

**Problem:** `sanitizer.yml` initially ran `just bazel-build-sanitized`
directly. On the GitHub-hosted ubuntu-24.04 runner, bazelisk was
picked up from the runner image (NOT from the Nix dev-shell) and
several foreign_cc-driven rules saw a degraded PATH/env: kakadu's
`repository_rule` couldn't find the right `gh`, foreign_cc Makefiles
couldn't find `perl`/`autoconf`/`automake`/`libtoolize`, and the
`.bazelrc`'s `--action_env=NIX_LDFLAGS,ACLOCAL_PATH` was forwarding
empty values because those env vars only exist inside `nix develop`.

**Solution:** Wrap the build step with `nix develop --command bash -c
'…'`, matching `bazel-build.yml`. Local Mac builds had been passing
because `nix develop` is the natural entry point there.

### Stamping for `STABLE_SIPI_VERSION`

**Problem:** After the earlier fixes the build itself succeeded,
but the e2e suite then failed with `expected stdout to be "sipi
4.1.1", got "sipi 0.0.0-unstamped"`.

**Cause:** `tools/workspace_status.sh` emits `STABLE_SIPI_VERSION`
from `version.txt`, and `src/BUILD.bazel`'s
`expand_template(stamp_substitutions = {…})` bakes it into
`SipiVersion.h`. Stamp substitutions only fire when the build is
invoked with `--stamp`.

**Solution:** Add `--stamp` to the recipe.

## Gotchas

- **Sanitizer coverage is e2e-only in this window.** `bazel build`
  is build-only — unit-test sanitizer coverage temporarily disappears
  from CI until DEV-6348 (PR Y+6) cuts the unit-test execution path
  over to Bazel `cc_test`. The e2e suite still runs the binary
  sanitized via `just nix-test-e2e` against `bazel-bin/src/sipi`, so
  user-facing flow regressions remain gated. `REVIEW.md`'s
  "Sanitizer gate" bullet now reflects this; reviewers approving PRs
  in this window need to know.
- **`--per_file_copt` regex is the only mechanism scoping sanitizer
  flags to first-party TUs.** A future BUILD refactor that moves a
  `.cpp` file out of `src/`/`shttps/`/`fuzz/`/`test/` (e.g. into a
  `genrule` output, a nested package, or a symlinked workspace)
  will silently drop sanitizer instrumentation on that file with no
  warning and no build error. The extension list is broad
  (`\.(cpp|cc|cxx|c|mm)$`); the path prefix list is what to widen
  if the layout changes.
- **`--compilation_mode=dbg` propagates to all foreign_cc cmake()
  deps.** Adding a new `cmake()` ext dep requires pinning BOTH
  `cache_entries["CMAKE_BUILD_TYPE"] = "RelWithDebInfo"` AND
  `configuration = "RelWithDebInfo"` on the rule. Without the
  second, install-phase artifact paths still resolve under
  `<prefix>/lib/cmake/X/XConfig-debug.cmake` and break consumers.
  The 9 ext/*/BUILD.bazel files added here are templates.
- **vptr disable is a real coverage gap, not a workaround that
  goes away on its own.** It will stay disabled until either
  toolchains_llvm starts shipping `libclang_rt.ubsan_standalone_cxx`
  in static form or the project moves to dynamic libc++. Both are
  upstream-driven; track via `.bazelrc`'s inline rationale.

## Test Plan

- [x] **macOS-aarch64 local build verified.** `nix develop -c bazel build --config=asan --config=ubsan //src:sipi` succeeds on darwin-aarch64; satisfies CLAUDE.md's build-completeness invariant.
- [x] `nix flake check --no-build` succeeds — `.#sanitized` removal does not break flake evaluation; remaining outputs (`.#dev`, `.#default`, `.#release`, `.#fuzz`, `.#docker*`, `.#e2e-tests`, `.#smoke-test`) still resolve on aarch64-darwin.
- [x] `bazelisk version` works in `nix develop`; `bazelisk canonicalize-flags --config=asan --config=ubsan` returns 0 (configs parse).
- [x] Repo-wide grep — no remaining references to `enableSanitizers`, `ENABLE_SANITIZERS`, `sanitizer_config`, `nix-build-sanitized`, or `.#sanitized` outside the new recipe's contextual comment.
- [ ] **CI:** sanitizer.yml green on this PR with the Bazel-built binary; ASan + UBSan signature identical to the previous Nix-built run.
- [ ] **CI:** `.lsan_suppressions.txt` still consulted — verify negative case by removing one `leak:lua*` line and confirming the corresponding leak surfaces as a `SUMMARY:` line in the e2e step (manual workflow_dispatch run).
- [ ] **CI:** `/tmp/asan-e2e.*` glob and `SUMMARY:` post-processing path unchanged from prior runs.
- [ ] **CI:** Bazel disk cache hit on a no-op rebuild (re-run after first green to confirm `~/.cache/bazel-disk` persistence and the targeted key formula).

🤖 Generated with [Claude Code](https://claude.com/claude-code)