### PR TITLE
refactor(observability): split SipiSentry into header + .cpp (DEV-6491)

### DIFF
--- a/include/SipiSentry.h
+++ b/include/SipiSentry.h
@@ -7,15 +7,14 @@
 #define SIPISENTRY_H
 
 #include <string>
-#include <sys/stat.h>
 
 #include <sentry.h>
 
-#include "SipiImage.hpp"
 #include "iiifparser/SipiQualityFormat.h"
-#include "metadata/SipiIcc.h"
 
 namespace Sipi {
+
+class SipiImage;
 
 /*!
  * Operating mode for Sentry flush behavior.
@@ -49,88 +48,18 @@ struct ImageContext
  * \param[in] path File path
  * \return File size in bytes, or 0 on failure
  */
-inline size_t get_file_size(const std::string &path)
-{
-  struct stat st{};
-  if (stat(path.c_str(), &st) == 0) {
-    return static_cast<size_t>(st.st_size);
-  }
-  return 0;
-}
-
-/*!
- * Convert a PredefinedProfiles enum value to a human-readable string.
- */
-inline std::string predefined_profile_to_string(PredefinedProfiles p)
-{
-  switch (p) {
-  case icc_undefined: return "undefined";
-  case icc_unknown: return "unknown/embedded";
-  case icc_sRGB: return "sRGB";
-  case icc_AdobeRGB: return "AdobeRGB";
-  case icc_RGB: return "RGB (custom)";
-  case icc_CMYK_standard: return "CMYK (USWebCoatedSWOP)";
-  case icc_GRAY_D50: return "Gray D50";
-  case icc_LUM_D65: return "Luminance D65";
-  case icc_ROMM_GRAY: return "ROMM Gray";
-  case icc_LAB: return "L*a*b*";
-  default: return "unknown";
-  }
-}
-
-/*!
- * Convert an Orientation enum value to a human-readable string.
- */
-inline std::string orientation_to_string(Orientation o)
-{
-  switch (o) {
-  case TOPLEFT: return "TOPLEFT";
-  case TOPRIGHT: return "TOPRIGHT";
-  case BOTRIGHT: return "BOTRIGHT";
-  case BOTLEFT: return "BOTLEFT";
-  case LEFTTOP: return "LEFTTOP";
-  case RIGHTTOP: return "RIGHTTOP";
-  case RIGHTBOT: return "RIGHTBOT";
-  case LEFTBOT: return "LEFTBOT";
-  default: return "unknown";
-  }
-}
+size_t get_file_size(const std::string &path);
 
 /*!
  * Convert a SipiQualityFormat::FormatType enum value to a human-readable string.
  */
-inline std::string format_type_to_string(SipiQualityFormat::FormatType f)
-{
-  switch (f) {
-  case SipiQualityFormat::JPG: return "jpg";
-  case SipiQualityFormat::TIF: return "tif";
-  case SipiQualityFormat::PNG: return "png";
-  case SipiQualityFormat::JP2: return "jp2";
-  case SipiQualityFormat::GIF: return "gif";
-  case SipiQualityFormat::PDF: return "pdf";
-  case SipiQualityFormat::WEBP: return "webp";
-  default: return "unsupported";
-  }
-}
+std::string format_type_to_string(SipiQualityFormat::FormatType f);
 
 /*!
  * Populate an ImageContext from a SipiImage.
  * Safe to call on partially-initialized images — getters return defaults (0) for unset fields.
  */
-inline void populate_from_image(ImageContext &ctx, const SipiImage &img)
-{
-  ctx.width = img.getNx();
-  ctx.height = img.getNy();
-  ctx.channels = img.getNc();
-  ctx.bps = img.getBps();
-  ctx.colorspace = to_string(img.getPhoto());
-  ctx.orientation = orientation_to_string(img.getOrientation());
-
-  auto icc = img.getIcc();
-  if (icc) {
-    ctx.icc_profile_type = predefined_profile_to_string(icc->getProfileType());
-  }
-}
+void populate_from_image(ImageContext &ctx, const SipiImage &img);
 
 /*!
  * Capture an image processing error to Sentry with rich context.
@@ -147,96 +76,11 @@ inline void populate_from_image(ImageContext &ctx, const SipiImage &img)
  * \param[in] mode Operating mode (default: CLI)
  * \param[in] level Sentry event level (default: SENTRY_LEVEL_ERROR)
  */
-inline void capture_image_error(const std::string &error_message,
+void capture_image_error(const std::string &error_message,
   const std::string &phase,
   const ImageContext &ctx,
   SipiMode mode = SipiMode::CLI,
-  sentry_level_e level = SENTRY_LEVEL_ERROR)
-{
-  const char *mode_str = (mode == SipiMode::CLI) ? "cli" : "server";
-
-  sentry_value_t event = sentry_value_new_event();
-  sentry_value_set_by_key(event, "level", sentry_value_new_string(
-    level == SENTRY_LEVEL_ERROR ? "error" :
-    level == SENTRY_LEVEL_WARNING ? "warning" : "fatal"));
-
-  // Set the message
-  sentry_value_t message = sentry_value_new_object();
-  sentry_value_set_by_key(message, "formatted", sentry_value_new_string(error_message.c_str()));
-  sentry_value_set_by_key(event, "message", message);
-
-  // Set searchable tags directly on the event (not the global scope) for thread safety.
-  sentry_value_t tags = sentry_value_new_object();
-  sentry_value_set_by_key(tags, "sipi.mode", sentry_value_new_string(mode_str));
-  sentry_value_set_by_key(tags, "sipi.phase", sentry_value_new_string(phase.c_str()));
-  if (!ctx.output_format.empty()) {
-    sentry_value_set_by_key(tags, "sipi.output_format", sentry_value_new_string(ctx.output_format.c_str()));
-  }
-  if (!ctx.colorspace.empty()) {
-    sentry_value_set_by_key(tags, "sipi.colorspace", sentry_value_new_string(ctx.colorspace.c_str()));
-  }
-  if (ctx.bps > 0) {
-    sentry_value_set_by_key(tags, "sipi.bps", sentry_value_new_string(std::to_string(ctx.bps).c_str()));
-  }
-  if (!ctx.request_uri.empty()) {
-    sentry_value_set_by_key(tags, "sipi.request_uri", sentry_value_new_string(ctx.request_uri.c_str()));
-  }
-  sentry_value_set_by_key(event, "tags", tags);
-
-  // Build "Image" context with full details
-  sentry_value_t image_ctx = sentry_value_new_object();
-  sentry_value_set_by_key(image_ctx, "type", sentry_value_new_string("image"));
-
-  sentry_value_t image_data = sentry_value_new_object();
-  if (!ctx.input_file.empty()) {
-    sentry_value_set_by_key(image_data, "input_file", sentry_value_new_string(ctx.input_file.c_str()));
-  }
-  if (!ctx.output_file.empty()) {
-    sentry_value_set_by_key(image_data, "output_file", sentry_value_new_string(ctx.output_file.c_str()));
-  }
-  if (!ctx.output_format.empty()) {
-    sentry_value_set_by_key(image_data, "output_format", sentry_value_new_string(ctx.output_format.c_str()));
-  }
-  if (ctx.width > 0 || ctx.height > 0) {
-    sentry_value_set_by_key(image_data, "width", sentry_value_new_int32(static_cast<int32_t>(ctx.width)));
-    sentry_value_set_by_key(image_data, "height", sentry_value_new_int32(static_cast<int32_t>(ctx.height)));
-  }
-  if (ctx.channels > 0) {
-    sentry_value_set_by_key(image_data, "channels", sentry_value_new_int32(static_cast<int32_t>(ctx.channels)));
-  }
-  if (ctx.bps > 0) {
-    sentry_value_set_by_key(image_data, "bps", sentry_value_new_int32(static_cast<int32_t>(ctx.bps)));
-  }
-  if (!ctx.colorspace.empty()) {
-    sentry_value_set_by_key(image_data, "colorspace", sentry_value_new_string(ctx.colorspace.c_str()));
-  }
-  if (!ctx.icc_profile_type.empty()) {
-    sentry_value_set_by_key(image_data, "icc_profile_type", sentry_value_new_string(ctx.icc_profile_type.c_str()));
-  }
-  if (!ctx.orientation.empty()) {
-    sentry_value_set_by_key(image_data, "orientation", sentry_value_new_string(ctx.orientation.c_str()));
-  }
-  if (ctx.file_size_bytes > 0) {
-    sentry_value_set_by_key(image_data, "file_size_bytes",
-      sentry_value_new_double(static_cast<double>(ctx.file_size_bytes)));
-  }
-  if (!ctx.request_uri.empty()) {
-    sentry_value_set_by_key(image_data, "request_uri", sentry_value_new_string(ctx.request_uri.c_str()));
-  }
-
-  sentry_value_set_by_key(image_ctx, "data", image_data);
-
-  // Add the Image context to the event
-  sentry_value_t contexts = sentry_value_new_object();
-  sentry_value_set_by_key(contexts, "Image", image_ctx);
-  sentry_value_set_by_key(event, "contexts", contexts);
-
-  sentry_capture_event(event);
-
-  // In CLI mode, block briefly to ensure the event is sent before process exit.
-  // In server mode, use non-blocking flush to avoid stalling request threads.
-  sentry_flush(mode == SipiMode::CLI ? 2000 : 0);
-}
+  sentry_level_e level = SENTRY_LEVEL_ERROR);
 
 }// namespace Sipi
 

--- a/src/SipiSentry.cpp
+++ b/src/SipiSentry.cpp
@@ -1,0 +1,181 @@
+/*
+ * Copyright © 2016 - 2024 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+ * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "SipiSentry.h"
+
+#include <sys/stat.h>
+
+#include "SipiImage.hpp"
+#include "metadata/SipiIcc.h"
+
+namespace Sipi {
+
+namespace {
+
+std::string predefined_profile_to_string(PredefinedProfiles p)
+{
+  switch (p) {
+  case icc_undefined: return "undefined";
+  case icc_unknown: return "unknown/embedded";
+  case icc_sRGB: return "sRGB";
+  case icc_AdobeRGB: return "AdobeRGB";
+  case icc_RGB: return "RGB (custom)";
+  case icc_CMYK_standard: return "CMYK (USWebCoatedSWOP)";
+  case icc_GRAY_D50: return "Gray D50";
+  case icc_LUM_D65: return "Luminance D65";
+  case icc_ROMM_GRAY: return "ROMM Gray";
+  case icc_LAB: return "L*a*b*";
+  default: return "unknown";
+  }
+}
+
+std::string orientation_to_string(Orientation o)
+{
+  switch (o) {
+  case TOPLEFT: return "TOPLEFT";
+  case TOPRIGHT: return "TOPRIGHT";
+  case BOTRIGHT: return "BOTRIGHT";
+  case BOTLEFT: return "BOTLEFT";
+  case LEFTTOP: return "LEFTTOP";
+  case RIGHTTOP: return "RIGHTTOP";
+  case RIGHTBOT: return "RIGHTBOT";
+  case LEFTBOT: return "LEFTBOT";
+  default: return "unknown";
+  }
+}
+
+}// namespace
+
+size_t get_file_size(const std::string &path)
+{
+  struct stat st{};
+  if (stat(path.c_str(), &st) == 0) {
+    return static_cast<size_t>(st.st_size);
+  }
+  return 0;
+}
+
+std::string format_type_to_string(SipiQualityFormat::FormatType f)
+{
+  switch (f) {
+  case SipiQualityFormat::JPG: return "jpg";
+  case SipiQualityFormat::TIF: return "tif";
+  case SipiQualityFormat::PNG: return "png";
+  case SipiQualityFormat::JP2: return "jp2";
+  case SipiQualityFormat::GIF: return "gif";
+  case SipiQualityFormat::PDF: return "pdf";
+  case SipiQualityFormat::WEBP: return "webp";
+  default: return "unsupported";
+  }
+}
+
+void populate_from_image(ImageContext &ctx, const SipiImage &img)
+{
+  ctx.width = img.getNx();
+  ctx.height = img.getNy();
+  ctx.channels = img.getNc();
+  ctx.bps = img.getBps();
+  ctx.colorspace = to_string(img.getPhoto());
+  ctx.orientation = orientation_to_string(img.getOrientation());
+
+  auto icc = img.getIcc();
+  if (icc) {
+    ctx.icc_profile_type = predefined_profile_to_string(icc->getProfileType());
+  }
+}
+
+void capture_image_error(const std::string &error_message,
+  const std::string &phase,
+  const ImageContext &ctx,
+  SipiMode mode,
+  sentry_level_e level)
+{
+  const char *mode_str = (mode == SipiMode::CLI) ? "cli" : "server";
+
+  sentry_value_t event = sentry_value_new_event();
+  sentry_value_set_by_key(event,
+    "level",
+    sentry_value_new_string(level == SENTRY_LEVEL_ERROR  ? "error"
+                            : level == SENTRY_LEVEL_WARNING ? "warning"
+                                                            : "fatal"));
+
+  sentry_value_t message = sentry_value_new_object();
+  sentry_value_set_by_key(message, "formatted", sentry_value_new_string(error_message.c_str()));
+  sentry_value_set_by_key(event, "message", message);
+
+  // Set searchable tags directly on the event (not the global scope) for thread safety.
+  sentry_value_t tags = sentry_value_new_object();
+  sentry_value_set_by_key(tags, "sipi.mode", sentry_value_new_string(mode_str));
+  sentry_value_set_by_key(tags, "sipi.phase", sentry_value_new_string(phase.c_str()));
+  if (!ctx.output_format.empty()) {
+    sentry_value_set_by_key(tags, "sipi.output_format", sentry_value_new_string(ctx.output_format.c_str()));
+  }
+  if (!ctx.colorspace.empty()) {
+    sentry_value_set_by_key(tags, "sipi.colorspace", sentry_value_new_string(ctx.colorspace.c_str()));
+  }
+  if (ctx.bps > 0) {
+    sentry_value_set_by_key(tags, "sipi.bps", sentry_value_new_string(std::to_string(ctx.bps).c_str()));
+  }
+  if (!ctx.request_uri.empty()) {
+    sentry_value_set_by_key(tags, "sipi.request_uri", sentry_value_new_string(ctx.request_uri.c_str()));
+  }
+  sentry_value_set_by_key(event, "tags", tags);
+
+  // Build "Image" context with full details
+  sentry_value_t image_ctx = sentry_value_new_object();
+  sentry_value_set_by_key(image_ctx, "type", sentry_value_new_string("image"));
+
+  sentry_value_t image_data = sentry_value_new_object();
+  if (!ctx.input_file.empty()) {
+    sentry_value_set_by_key(image_data, "input_file", sentry_value_new_string(ctx.input_file.c_str()));
+  }
+  if (!ctx.output_file.empty()) {
+    sentry_value_set_by_key(image_data, "output_file", sentry_value_new_string(ctx.output_file.c_str()));
+  }
+  if (!ctx.output_format.empty()) {
+    sentry_value_set_by_key(image_data, "output_format", sentry_value_new_string(ctx.output_format.c_str()));
+  }
+  if (ctx.width > 0 || ctx.height > 0) {
+    sentry_value_set_by_key(image_data, "width", sentry_value_new_int32(static_cast<int32_t>(ctx.width)));
+    sentry_value_set_by_key(image_data, "height", sentry_value_new_int32(static_cast<int32_t>(ctx.height)));
+  }
+  if (ctx.channels > 0) {
+    sentry_value_set_by_key(image_data, "channels", sentry_value_new_int32(static_cast<int32_t>(ctx.channels)));
+  }
+  if (ctx.bps > 0) {
+    sentry_value_set_by_key(image_data, "bps", sentry_value_new_int32(static_cast<int32_t>(ctx.bps)));
+  }
+  if (!ctx.colorspace.empty()) {
+    sentry_value_set_by_key(image_data, "colorspace", sentry_value_new_string(ctx.colorspace.c_str()));
+  }
+  if (!ctx.icc_profile_type.empty()) {
+    sentry_value_set_by_key(image_data, "icc_profile_type", sentry_value_new_string(ctx.icc_profile_type.c_str()));
+  }
+  if (!ctx.orientation.empty()) {
+    sentry_value_set_by_key(image_data, "orientation", sentry_value_new_string(ctx.orientation.c_str()));
+  }
+  if (ctx.file_size_bytes > 0) {
+    sentry_value_set_by_key(
+      image_data, "file_size_bytes", sentry_value_new_double(static_cast<double>(ctx.file_size_bytes)));
+  }
+  if (!ctx.request_uri.empty()) {
+    sentry_value_set_by_key(image_data, "request_uri", sentry_value_new_string(ctx.request_uri.c_str()));
+  }
+
+  sentry_value_set_by_key(image_ctx, "data", image_data);
+
+  // Add the Image context to the event
+  sentry_value_t contexts = sentry_value_new_object();
+  sentry_value_set_by_key(contexts, "Image", image_ctx);
+  sentry_value_set_by_key(event, "contexts", contexts);
+
+  sentry_capture_event(event);
+
+  // In CLI mode, block briefly to ensure the event is sent before process exit.
+  // In server mode, use non-blocking flush to avoid stalling request threads.
+  sentry_flush(mode == SipiMode::CLI ? 2000 : 0);
+}
+
+}// namespace Sipi


### PR DESCRIPTION
Fixes DEV-6491

## Motivation

`include/SipiSentry.h` was a 244-line fully-`inline` header that pulled `SipiImage.hpp` (and its transitive `metadata/SipiIcc.h` → exiv2 → lcms2 chain) into every translation unit calling `capture_image_error`. Each consumer paid the full include cost at compile time and re-instantiated the function bodies. First of three PRs in the Probe-9a observability/ refactor (parent: [DEV-6489](https://linear.app/dasch/issue/DEV-6489)).

## Summary

- Split `include/SipiSentry.h` (244 lines) into thin declarations (~80 lines) plus a new `src/SipiSentry.cpp` with the previously-inline impls.
- Drop `SipiImage.hpp`, `metadata/SipiIcc.h`, and `<sys/stat.h>` from the public header; consumers now see only `<string>`, `<sentry.h>`, and the lightweight `iiifparser/SipiQualityFormat.h`.
- Demote two helpers (`predefined_profile_to_string`, `orientation_to_string`) to file-static (anonymous namespace) — neither had external callers.

## Key Changes

### Header surgery
- `Sipi::SipiImage` becomes a forward declaration in the public header; the full type is brought in by `src/SipiSentry.cpp` alone.
- All six public symbols keep their signatures and namespace (`Sipi::`) — no caller-side change required: `ImageContext`, `SipiMode`, `get_file_size`, `format_type_to_string`, `populate_from_image`, `capture_image_error`.

### Call sites
Both consumers (`src/sipi.cpp`, `src/SipiHttpServer.cpp`) already `#include "SipiImage.hpp"` directly, so the dropped transitive includes do not break anything.

## Challenges and Decisions

### Why three PRs (not four) for Probe 9a
**Problem:** The parent issue [DEV-6489](https://linear.app/dasch/issue/DEV-6489) initially specced four sub-PRs — (a) header surgery, (b) move metrics + adapter, (c) extract sentry_init, (d) Bazel package promotion. Four PRs for ~600 LOC of mechanical work felt over-fragmented.

**Tried:** Bundling all four into one PR. Rejected because step (a) is the only one with standalone compile-time-speedup value (no directory move) and ships cleanly on its own.

**Solution:** Three PRs — (a) alone for early build-time benefit; (b)+(c) bundled as cohesive directory establishment; (d) as the Bazel package promotion. Documented in DEV-6489's PR plan table.

## Gotchas

- The two demoted helpers are now file-static in `src/SipiSentry.cpp`. If a future refactor re-exposes either, restore them to the `Sipi::` namespace in the header rather than the .cpp.

## Test Plan

- [x] \`just bazel-build\` (macOS-aarch64): green
- [x] \`just bazel-test-unit\`: 12/12 pass
- [x] \`just bazel-test-approval\`: 1/1 pass
- [x] CI green on linux-x86_64, linux-aarch64, darwin-arm64, asan-ubsan, docker-scout, docs