### PR TITLE
refactor(metadata): relocate SipiIccDetail to internal/ (DEV-6406, canonical Test seam)

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -4,9 +4,11 @@ Two targets:
 
   //src:sipi_lib  — `cc_library` containing every Sipi translation unit
                     *except* the executable's `main`. Headers come via
-                    `//include:headers` (which exposes private internal
-                    headers like `metadata/SipiIccDetail.h` so per-component
-                    unit tests in Y+1 can link against private symbols).
+                    `//include:headers` for the legacy include/ tree.
+                    Per-module Bazel packages under `//src/<mod>/` (e.g.
+                    `//src/metadata`, `//src/observability`) own their
+                    own headers — including internal/ subpackages with
+                    restricted visibility for Test seam helpers.
   //src:sipi      — thin `cc_binary` (`srcs = ["sipi.cpp"]`) deps-only on
                     `:sipi_lib`. `linkopts = ["-Wl,--build-id=sha1"]`
                     content-addresses the build-id for Y+4 debug-info

--- a/src/metadata/BUILD.bazel
+++ b/src/metadata/BUILD.bazel
@@ -7,11 +7,12 @@ Houses SIPI's EXIF (`SipiExif`), IPTC (`SipiIptc`), XMP (`SipiXmp`), and ICC
 `include/metadata/` per ADR-0003 so `.cpp`, `.h`, and `*_test.cpp` live
 co-located.
 
-`SipiIccDetail.h` is still exposed in `hdrs` here so the co-located
-`icc_normalize_test.cpp` (moved from `test/unit/sipiicc/`) can exercise
-the byte-mutation helper directly. DEV-6406 relocates it to
-`metadata/internal/icc_normalization.h` with a tighter visibility, replacing
-today's comment-as-policy with a build-graph invariant.
+The byte-mutation helper `apply_icc_header_normalization` lives in
+`//src/metadata/internal:icc_normalization` per DEV-6406 — the canonical
+Test seam pattern. Its visibility is restricted to `//src/metadata:__pkg__`
+at the Bazel analysis level, replacing today's comment-as-policy header
+with a build-graph invariant. The co-located `icc_normalize_test`
+exercises the helper through the same restricted edge.
 
 `layering_check` and `parse_headers` are **deferred** for the same reason as
 //src/observability: every `.cpp` here `#include`s `SipiImage.hpp` (and
@@ -40,7 +41,6 @@ cc_library(
         "SipiEssentials.h",
         "SipiExif.h",
         "SipiIcc.h",
-        "SipiIccDetail.h",
         "SipiIptc.h",
         "SipiXmp.h",
     ],
@@ -57,6 +57,7 @@ cc_library(
         "//shttps:shttps",
         "//src:sipi_generated_hdrs",
         "//src:sipi_top",
+        "//src/metadata/internal:icc_normalization",
     ],
 )
 
@@ -71,7 +72,7 @@ cc_test(
         "test_main.cpp",
     ],
     deps = [
-        ":metadata",
+        "//src/metadata/internal:icc_normalization",
         "@googletest//:gtest_main",
     ],
 )

--- a/src/metadata/SipiIcc.cpp
+++ b/src/metadata/SipiIcc.cpp
@@ -4,12 +4,10 @@
  */
 
 #include "metadata/SipiIcc.h"
-#include "metadata/SipiIccDetail.h"
+#include "metadata/internal/icc_normalization.h"
 
 #include <cerrno>
-#include <cstdint>
 #include <cstdlib>
-#include <cstring>
 #include <ctime>
 #include <optional>
 
@@ -36,9 +34,10 @@ namespace {
 // test-only — a SIPI binary aborting because someone in the shell exported a
 // bogus SOURCE_DATE_EPOCH would be a regression.
 //
-// Not exposed via SipiIccDetail.h because unit tests inject epochs directly
-// into apply_icc_header_normalization(); the env-var parser is implicitly
-// covered by the nullopt-equivalent branch.
+// The byte-mutation helper apply_icc_header_normalization lives in
+// //src/metadata/internal:icc_normalization (see ADR-0002, DEV-6406). Unit
+// tests inject epochs directly there, so the env-var parser above is
+// implicitly covered by the nullopt-equivalent branch.
 std::optional<std::time_t> read_source_date_epoch() noexcept
 {
   static const std::optional<std::time_t> cached = []() -> std::optional<std::time_t> {
@@ -53,47 +52,7 @@ std::optional<std::time_t> read_source_date_epoch() noexcept
   return cached;
 }
 
-void put_be16(unsigned char *p, std::uint16_t v) noexcept
-{
-  p[0] = static_cast<unsigned char>(v >> 8);
-  p[1] = static_cast<unsigned char>(v & 0xff);
-}
-
 }// namespace
-
-namespace detail {
-
-// Why zero the Profile ID: lcms2 may round-trip a non-zero ID from an
-// externally-authored input profile (Little-CMS issue #181); a non-zero ID
-// baked over a scrubbed date is meaningless. Production is unaffected because
-// production never sets SOURCE_DATE_EPOCH.
-void apply_icc_header_normalization(unsigned char *buf, std::size_t len, std::optional<std::time_t> epoch) noexcept
-{
-  if (!epoch.has_value()) return;
-  if (len < kIccProfileIdOffset + kIccProfileIdLength) return;
-
-  // POSIX gmtime_r returns NULL when the year doesn't fit `int tm_year`
-  // (e.g., 32-bit time_t platforms with a post-2038 epoch). A bogus
-  // SOURCE_DATE_EPOCH must not silently emit a 1900-stamped profile, so
-  // we no-op rather than write garbage. Bail also if the year is outside
-  // the ICC dateTimeNumber range (uInt16, [0, 65535]).
-  std::tm tm{};
-  if (gmtime_r(&*epoch, &tm) == nullptr) return;
-  const long year = static_cast<long>(tm.tm_year) + 1900;
-  if (year < 0 || year > 65535) return;
-
-  unsigned char *p = buf + kIccDateTimeOffset;
-  put_be16(p + 0, static_cast<std::uint16_t>(year));
-  put_be16(p + 2, static_cast<std::uint16_t>(tm.tm_mon + 1));
-  put_be16(p + 4, static_cast<std::uint16_t>(tm.tm_mday));
-  put_be16(p + 6, static_cast<std::uint16_t>(tm.tm_hour));
-  put_be16(p + 8, static_cast<std::uint16_t>(tm.tm_min));
-  put_be16(p + 10, static_cast<std::uint16_t>(tm.tm_sec));
-
-  std::memset(buf + kIccProfileIdOffset, 0, kIccProfileIdLength);
-}
-
-}// namespace detail
 
 void icc_error_logger(cmsContext ContextID, cmsUInt32Number ErrorCode, const char *Text)
 {

--- a/src/metadata/icc_normalize_test.cpp
+++ b/src/metadata/icc_normalize_test.cpp
@@ -10,7 +10,7 @@
 // have to fight with the production magic-static cache that backs
 // read_source_date_epoch().
 
-#include "metadata/SipiIccDetail.h"
+#include "metadata/internal/icc_normalization.h"
 
 #include "gtest/gtest.h"
 

--- a/src/metadata/internal/BUILD.bazel
+++ b/src/metadata/internal/BUILD.bazel
@@ -1,0 +1,36 @@
+"""//src/metadata/internal — canonical Test seam package (DEV-6406).
+
+Houses the pure byte-mutation helper that backs SipiIcc::iccBytes()'s
+SOURCE_DATE_EPOCH reproducibility hook (ADR-0002). Exists as a separate
+Bazel package solely to encode "this header is internal to the metadata
+module" as a build-graph invariant instead of comment-as-policy.
+
+Visibility is restricted to //src/metadata:__pkg__ — every production
+TU outside `src/metadata/` that tries to `#include
+"metadata/internal/icc_normalization.h"` fails the Bazel analysis phase.
+The co-located icc_normalize_test in `//src/metadata` is on the
+visibility list by virtue of living in `//src/metadata:__pkg__`.
+
+This is the **canonical Test seam pattern** for SIPI per the Probe 2
+glossary delta: any future module that needs to expose internal symbols
+to its co-located test should follow this `internal/` + restricted-
+visibility recipe rather than commenting "do not include me from
+elsewhere" in a `*Detail.h` header.
+"""
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//src/metadata:__pkg__"])
+
+cc_library(
+    name = "icc_normalization",
+    srcs = ["icc_normalization.cpp"],
+    hdrs = ["icc_normalization.h"],
+    # `strip_include_prefix = "/src"` re-roots the header at the
+    # repo-relative `src/` prefix so consumers can `#include
+    # "metadata/internal/icc_normalization.h"` — the canonical
+    # path-prefixed form per ADR-0003 — without needing to pull in
+    # `:sipi_top` (or any other library) just to put `src/` on the
+    # include path. The internal package becomes self-sufficient.
+    strip_include_prefix = "/src",
+)

--- a/src/metadata/internal/icc_normalization.cpp
+++ b/src/metadata/internal/icc_normalization.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2026 Swiss National Data and Service Center for the Humanities
+ * and/or DaSCH Service Platform contributors. SPDX-License-Identifier:
+ * AGPL-3.0-or-later
+ */
+
+#include "icc_normalization.h"
+
+#include <cstdint>
+#include <cstring>
+#include <ctime>
+
+namespace Sipi::detail {
+
+namespace {
+
+void put_be16(unsigned char *p, std::uint16_t v) noexcept
+{
+  p[0] = static_cast<unsigned char>(v >> 8);
+  p[1] = static_cast<unsigned char>(v & 0xff);
+}
+
+}// namespace
+
+// Why zero the Profile ID: lcms2 may round-trip a non-zero ID from an
+// externally-authored input profile (Little-CMS issue #181); a non-zero ID
+// baked over a scrubbed date is meaningless. Production is unaffected because
+// production never sets SOURCE_DATE_EPOCH.
+void apply_icc_header_normalization(unsigned char *buf, std::size_t len, std::optional<std::time_t> epoch) noexcept
+{
+  if (!epoch.has_value()) return;
+  if (len < kIccProfileIdOffset + kIccProfileIdLength) return;
+
+  // POSIX gmtime_r returns NULL when the year doesn't fit `int tm_year`
+  // (e.g., 32-bit time_t platforms with a post-2038 epoch). A bogus
+  // SOURCE_DATE_EPOCH must not silently emit a 1900-stamped profile, so
+  // we no-op rather than write garbage. Bail also if the year is outside
+  // the ICC dateTimeNumber range (uInt16, [0, 65535]).
+  std::tm tm{};
+  if (gmtime_r(&*epoch, &tm) == nullptr) return;
+  const long year = static_cast<long>(tm.tm_year) + 1900;
+  if (year < 0 || year > 65535) return;
+
+  unsigned char *p = buf + kIccDateTimeOffset;
+  put_be16(p + 0, static_cast<std::uint16_t>(year));
+  put_be16(p + 2, static_cast<std::uint16_t>(tm.tm_mon + 1));
+  put_be16(p + 4, static_cast<std::uint16_t>(tm.tm_mday));
+  put_be16(p + 6, static_cast<std::uint16_t>(tm.tm_hour));
+  put_be16(p + 8, static_cast<std::uint16_t>(tm.tm_min));
+  put_be16(p + 10, static_cast<std::uint16_t>(tm.tm_sec));
+
+  std::memset(buf + kIccProfileIdOffset, 0, kIccProfileIdLength);
+}
+
+}// namespace Sipi::detail

--- a/src/metadata/internal/icc_normalization.h
+++ b/src/metadata/internal/icc_normalization.h
@@ -4,13 +4,14 @@
  * AGPL-3.0-or-later
  */
 
-// Internal helpers for SipiIcc — exposed in a header solely so the unit tests
-// in test/unit/sipiicc/ can exercise them with explicit epoch values, side-
-// stepping the magic-static cache that drives production reads of
-// SOURCE_DATE_EPOCH. No production code outside src/metadata/SipiIcc.cpp
-// should include this header.
-#ifndef SIPI_METADATA_SIPI_ICC_DETAIL_H
-#define SIPI_METADATA_SIPI_ICC_DETAIL_H
+// Internal helpers for SipiIcc::iccBytes()'s SOURCE_DATE_EPOCH
+// reproducibility hook (per ADR-0002). Visibility is restricted at the
+// build-graph level to //src/metadata:__pkg__ — replacing the prior
+// comment-as-policy in SipiIccDetail.h with an analysis-time invariant.
+// Any #include outside the metadata package fails the Bazel analysis
+// phase.
+#ifndef SIPI_METADATA_INTERNAL_ICC_NORMALIZATION_H
+#define SIPI_METADATA_INTERNAL_ICC_NORMALIZATION_H
 
 #include <cstddef>
 #include <ctime>


### PR DESCRIPTION
[DEV-6406](https://linear.app/dasch/issue/DEV-6406) — stacked on #631 → #630

> ⚠️ Stacked PR. Base = `feature/dev-6405-metadata-bazel-package` (PR #631). Merge order: #630 → #631 → this PR. Rebase onto `main` once predecessors land.

## Summary

- Replace the comment-as-policy in `SipiIccDetail.h` (\"No production code outside `src/metadata/SipiIcc.cpp` should include this header\") with a **build-graph invariant**: a new `//src/metadata/internal:icc_normalization` Bazel sub-package with `visibility = [\"//src/metadata:__pkg__\"]`.
- Any rogue include from outside the metadata module now fails Bazel analysis, not code review.
- This is the **canonical Test seam pattern** (Probe 2 glossary delta) — future test-seam relocations should follow the same `internal/` + restricted-visibility recipe.

## Changes

**New `src/metadata/internal/` package:**
- `icc_normalization.h` — verbatim move of the former `SipiIccDetail.h` (constants + `apply_icc_header_normalization` declaration in `Sipi::detail`).
- `icc_normalization.cpp` — extracts the `apply_icc_header_normalization` definition + its `put_be16` helper from `SipiIcc.cpp`. Untouched semantics.
- `BUILD.bazel` — `cc_library icc_normalization` with `strip_include_prefix = \"/src\"` so consumers can use the canonical path-prefixed include form (`#include \"metadata/internal/icc_normalization.h\"`) per ADR-0003 without pulling `:sipi_top` in just for the include path. `default_visibility = [\"//src/metadata:__pkg__\"]`.

**`src/metadata/`:**
- `SipiIccDetail.h` deleted.
- `SipiIcc.cpp` — include switched to `metadata/internal/icc_normalization.h`; in-file `apply_icc_header_normalization` and `put_be16` definitions removed. The `read_source_date_epoch` magic-static cache stays in `SipiIcc.cpp` because production reads of `SOURCE_DATE_EPOCH` belong with the icc-bytes call site, not the byte-mutation helper.
- `icc_normalize_test.cpp` — include switched; the test now deps directly on `//src/metadata/internal:icc_normalization` (not `:metadata`), tightening the test surface to exactly the helper it exercises.
- `BUILD.bazel` — `:metadata` gains the new internal pkg in `deps`; `SipiIccDetail.h` removed from `hdrs`. Docstring updated.

**`src/BUILD.bazel`** docstring updated to mention `internal/` subpackages with restricted visibility for Test seam helpers (replacing the stale `metadata/SipiIccDetail.h` reference).

## Why `strip_include_prefix = \"/src\"`

The internal package needs consumers to write `#include \"metadata/internal/icc_normalization.h\"` (canonical path-prefixed form per ADR-0003). Two options:

1. **Add `:sipi_top` as a transitive dep** of the test target — pulls in `Logger.cpp` + `SipiError.cpp` purely to inherit `includes = [\".\"]`. Couples the test to the foundational layer for no semantic reason.
2. **`strip_include_prefix = \"/src\"`** on the internal package — re-roots the header at the repo-relative `src/` prefix. Consumers get the canonical include path automatically, no extra deps.

Chose option 2 — internal package becomes self-sufficient for include resolution.

## Test Plan

- [x] `bazel test //src/metadata:sipi_icc_normalize_test` — green
- [x] `bazel test //src/... //test/unit/... //test/approval:approvaltests` — all 13 test targets pass
- [x] Visibility restriction set at `[\"//src/metadata:__pkg__\"]` — any include from outside the metadata package (e.g. `shttps/Server.cpp` or a future `src/handlers/*.cpp`) would fail Bazel analysis with a visibility-violation error
- [ ] CI: full matrix green

🤖 Generated with [Claude Code](https://claude.com/claude-code)