### PR TITLE
refactor(metadata): drop raw-pointer overloads on byte getters (DEV-6409)

### DIFF
--- a/src/formats/SipiIOJ2k.cpp
+++ b/src/formats/SipiIOJ2k.cpp
@@ -997,17 +997,13 @@ void SipiIOJ2k::write(SipiImage *img, const std::string &filepath, const SipiCom
       try {
         switch (icc_type) {
         case icc_undefined: {
-          unsigned int icc_len;
-          kdu_byte *icc_bytes = (kdu_byte *)img->icc->iccBytes(icc_len);
-          jp2_family_colour.init(icc_bytes);
-          delete[] icc_bytes;
+          std::vector<unsigned char> icc_buf = img->icc->iccBytes();
+          jp2_family_colour.init(reinterpret_cast<kdu_byte *>(icc_buf.data()));
           break;
         }
         case icc_unknown: {
-          unsigned int icc_len;
-          kdu_byte *icc_bytes = (kdu_byte *)img->icc->iccBytes(icc_len);
-          jp2_family_colour.init(icc_bytes);
-          delete[] icc_bytes;
+          std::vector<unsigned char> icc_buf = img->icc->iccBytes();
+          jp2_family_colour.init(reinterpret_cast<kdu_byte *>(icc_buf.data()));
           break;
         }
         case icc_sRGB: {
@@ -1020,17 +1016,13 @@ void SipiIOJ2k::write(SipiImage *img, const std::string &filepath, const SipiCom
           break;
         }
         case icc_AdobeRGB: {
-          unsigned int icc_len;
-          kdu_byte *icc_bytes = (kdu_byte *)img->icc->iccBytes(icc_len);
-          jp2_family_colour.init(icc_bytes);
-          delete[] icc_bytes;
+          std::vector<unsigned char> icc_buf = img->icc->iccBytes();
+          jp2_family_colour.init(reinterpret_cast<kdu_byte *>(icc_buf.data()));
           break;
         }
         case icc_RGB: {// TODO: DOES NOT WORK AS EXPECTED!!!!! Fallback below
-          unsigned int icc_len;
-          kdu_byte *icc_bytes = (kdu_byte *)img->icc->iccBytes(icc_len);
-          jp2_family_colour.init(icc_bytes);
-          delete[] icc_bytes;
+          std::vector<unsigned char> icc_buf = img->icc->iccBytes();
+          jp2_family_colour.init(reinterpret_cast<kdu_byte *>(icc_buf.data()));
           break;
         }
         case icc_CMYK_standard: {
@@ -1038,10 +1030,8 @@ void SipiIOJ2k::write(SipiImage *img, const std::string &filepath, const SipiCom
           break;
         }
         case icc_GRAY_D50: {
-          unsigned int icc_len;
-          kdu_byte *icc_bytes = (kdu_byte *)img->icc->iccBytes(icc_len);
-          jp2_family_colour.init(icc_bytes);// TODO: DOES NOT WORK AS EXPECTED!!!!! Fallback below
-          delete[] icc_bytes;
+          std::vector<unsigned char> icc_buf = img->icc->iccBytes();
+          jp2_family_colour.init(reinterpret_cast<kdu_byte *>(icc_buf.data()));// TODO: DOES NOT WORK AS EXPECTED!!!!! Fallback below
           break;
         }
         case icc_LUM_D65: {
@@ -1066,10 +1056,8 @@ void SipiIOJ2k::write(SipiImage *img, const std::string &filepath, const SipiCom
           break;
         };
         default: {
-          unsigned int icc_len;
-          kdu_byte *icc_bytes = (kdu_byte *)img->icc->iccBytes(icc_len);
-          jp2_family_colour.init(icc_bytes);
-          delete[] icc_bytes;
+          std::vector<unsigned char> icc_buf = img->icc->iccBytes();
+          jp2_family_colour.init(reinterpret_cast<kdu_byte *>(icc_buf.data()));
         }
         }
       } catch (kdu_exception e) {

--- a/src/metadata/SipiEssentials.cpp
+++ b/src/metadata/SipiEssentials.cpp
@@ -143,17 +143,7 @@ void SipiEssentials::hash_type(const std::string &hash_type_p)
     _hash_type = shttps::HashType::none;
 }
 
-std::vector<unsigned char> SipiEssentials::icc_profile(void) { return base64Decode(_icc_profile); }
-
-unsigned char *SipiEssentials::icc_profile(unsigned int &len)
-{
-  std::vector<unsigned char> tmp = base64Decode(_icc_profile);
-  len = tmp.size();
-
-  unsigned char *buf = new unsigned char[len];
-  memcpy(buf, tmp.data(), len);
-  return buf;
-}
+std::vector<unsigned char> SipiEssentials::icc_profile() { return base64Decode(_icc_profile); }
 
 void SipiEssentials::icc_profile(const std::vector<unsigned char> &icc_profile_p)
 {

--- a/src/metadata/SipiEssentials.h
+++ b/src/metadata/SipiEssentials.h
@@ -149,9 +149,8 @@ public:
    *
    * @return ICC profile binary data as std::vector
    */
-  std::vector<unsigned char> icc_profile(void);
+  std::vector<unsigned char> icc_profile();
 
-  unsigned char *icc_profile(unsigned int &len);
   /*!
    * Setter for ICC profile
    *

--- a/src/metadata/SipiExif.cpp
+++ b/src/metadata/SipiExif.cpp
@@ -48,30 +48,19 @@ SipiExif::SipiExif(const unsigned char *exif, unsigned int len)
 
 SipiExif::~SipiExif() { delete[] binaryExif; }
 
-unsigned char *SipiExif::exifBytes(unsigned int &len)
+std::vector<unsigned char> SipiExif::exifBytes()
 {
   Exiv2::Blob blob;
   Exiv2::WriteMethod wm = Exiv2::ExifParser::encode(blob, binaryExif, binary_size, byteorder, exifData);
-  unsigned char *tmpbuf = nullptr;
   if (wm == Exiv2::wmIntrusive) {
-    // we use blob
+    // Refresh the cached binary blob so subsequent reads see the encoded form.
     binary_size = blob.size();
-    tmpbuf = new unsigned char[binary_size];
+    unsigned char *tmpbuf = new unsigned char[binary_size];
     if (binary_size > 0) memcpy(tmpbuf, blob.data(), binary_size);
-    delete[] binaryExif;// cleanup tmpbuf!
+    delete[] binaryExif;
     binaryExif = tmpbuf;
   }
-  len = binary_size;
-  return binaryExif;
-}
-//============================================================================
-
-std::vector<unsigned char> SipiExif::exifBytes()
-{
-  unsigned int len = 0;
-  unsigned char *buf = exifBytes(len);
-  std::vector<unsigned char> data(buf, buf + len);
-  return data;
+  return std::vector<unsigned char>(binaryExif, binaryExif + binary_size);
 }
 //============================================================================
 

--- a/src/metadata/SipiExif.h
+++ b/src/metadata/SipiExif.h
@@ -182,15 +182,7 @@ public:
   ~SipiExif();
 
   /*!
-   * Returns the bytes of the EXIF data
-   *
-   * \param[out] len Length of buffer returned
-   * \returns Buffer with EXIF data
-   */
-  unsigned char *exifBytes(unsigned int &len);
-
-  /*!
-   * Returns the bytes of the EXIF data as vector
+   * Returns the bytes of the EXIF data as a vector.
    *
    * @return Vector with EXIF data
    */

--- a/src/metadata/SipiIcc.cpp
+++ b/src/metadata/SipiIcc.cpp
@@ -235,35 +235,21 @@ SipiIcc &SipiIcc::operator=(const SipiIcc &rhs)
   return *this;
 }
 
-unsigned char *SipiIcc::iccBytes(unsigned int &len)
-{
-  unsigned char *buf = nullptr;
-  len = 0;
-  if (icc_profile != nullptr) {
-    if (!cmsSaveProfileToMem(icc_profile, nullptr, &len))
-      throw SipiError("cmsSaveProfileToMem failed");
-    buf = new unsigned char[len];
-    if (!cmsSaveProfileToMem(icc_profile, buf, &len)) {
-      delete[] buf;
-      throw SipiError("cmsSaveProfileToMem failed");
-    }
-    // ICC normalization for reproducibility — no-op unless SOURCE_DATE_EPOCH
-    // is set in the environment. Production never sets it.
-    detail::apply_icc_header_normalization(buf, len, read_source_date_epoch());
-  }
-  return buf;
-}
-
 std::vector<unsigned char> SipiIcc::iccBytes()
 {
-  unsigned int len = 0;
-  unsigned char *buf = iccBytes(len);
-  std::vector<unsigned char> data;
-  if (buf != nullptr) {
-    data.reserve(len);
-    for (size_t i = 0; i < len; i++) data.push_back(buf[i]);
-    delete[] buf;
-  }
+  if (icc_profile == nullptr) return {};
+
+  cmsUInt32Number len = 0;
+  if (!cmsSaveProfileToMem(icc_profile, nullptr, &len))
+    throw SipiError("cmsSaveProfileToMem failed");
+
+  std::vector<unsigned char> data(len);
+  if (!cmsSaveProfileToMem(icc_profile, data.data(), &len))
+    throw SipiError("cmsSaveProfileToMem failed");
+
+  // ICC normalization for reproducibility — no-op unless SOURCE_DATE_EPOCH
+  // is set in the environment. Production never sets it.
+  detail::apply_icc_header_normalization(data.data(), data.size(), read_source_date_epoch());
   return data;
 }
 

--- a/src/metadata/SipiIcc.h
+++ b/src/metadata/SipiIcc.h
@@ -122,17 +122,7 @@ public:
    * See test/approval/CHANGELOG.approval.md and docs/adr/0002-icc-
    * profile-determinism-test-only.md for the rationale.
    *
-   * @param[out] len Length of the buffer returned
-   * @returns Buffer containing the binary ICC profile (caller owns; `delete[]` it)
-   */
-  [[nodiscard]] unsigned char *iccBytes(unsigned int &len);
-
-  /*!
-   * Get the blob containing the ICC profile as std::vector. Calls the
-   * raw-buffer overload, so the same SOURCE_DATE_EPOCH normalization
-   * applies.
-   *
-   * @return std::vector containing the binary ICC profile
+   * @return std::vector containing the binary ICC profile (empty if no profile is set)
    */
   [[nodiscard]] std::vector<unsigned char> iccBytes();
 

--- a/src/metadata/SipiIptc.cpp
+++ b/src/metadata/SipiIptc.cpp
@@ -19,27 +19,11 @@ SipiIptc::SipiIptc(const unsigned char *iptc, unsigned int len)
 SipiIptc::~SipiIptc() {}
 
 
-unsigned char *SipiIptc::iptcBytes(unsigned int &len)
+std::vector<unsigned char> SipiIptc::iptcBytes()
 {
   Exiv2::DataBuf databuf = Exiv2::IptcParser::encode(iptcData);
-  unsigned char *buf = new unsigned char[databuf.size()];
-  if (databuf.size() > 0) memcpy(buf, databuf.data(), databuf.size());
-  len = databuf.size();
-  return buf;
-}
-//============================================================================
-
-std::vector<unsigned char> SipiIptc::iptcBytes(void)
-{
-  unsigned int len = 0;
-  unsigned char *buf = iptcBytes(len);
-  std::vector<unsigned char> data;
-  if (buf != nullptr) {
-    data.reserve(len);
-    for (int i = 0; i < len; i++) data.push_back(buf[i]);
-    delete[] buf;
-  }
-  return data;
+  if (databuf.size() == 0) return {};
+  return std::vector<unsigned char>(databuf.data(), databuf.data() + databuf.size());
 }
 //============================================================================
 

--- a/src/metadata/SipiIptc.h
+++ b/src/metadata/SipiIptc.h
@@ -38,18 +38,10 @@ public:
   ~SipiIptc();
 
   /*!
-   * Returns the bytes of the IPTC data. The buffer must be
-   * deleted by the caller after it is no longer used!
-   * \param[out] len Length of the data in bytes
-   * \returns Chunk of chars holding the IPTC data
-   */
-  unsigned char *iptcBytes(unsigned int &len);
-
-  /*!
-   * Returns the bytes of the IPTC data as std::vector
+   * Returns the bytes of the IPTC data as a std::vector.
    * @return IPTC bytes as std::vector
    */
-  std::vector<unsigned char> iptcBytes(void);
+  std::vector<unsigned char> iptcBytes();
 
   /*!
    * The overloaded << operator which is used to write the IPTC data formatted to the outstream

--- a/src/metadata/SipiXmp.cpp
+++ b/src/metadata/SipiXmp.cpp
@@ -98,48 +98,12 @@ SipiXmp::~SipiXmp()
 //============================================================================
 
 
-char *SipiXmp::xmpBytes(unsigned int &len)
-{
-  char *__buf = new char[__xmpstr.length() + 1];
-  memcpy(__buf, __xmpstr.c_str(), __xmpstr.length());
-  __buf[__xmpstr.length()] = '\0';
-  len = __xmpstr.length();
-  return __buf;// provisional code until Exiv2::Xmp is threadsafe
-  // TODO: Testing required if now Exiv2::Xmp is thread save
-
-  /*
-  std::string xmpPacket;
-  try {
-      if (0 != Exiv2::XmpParser::encode(xmpPacket, xmpData, Exiv2::XmpParser::useCompactFormat)) {
-          throw SipiError(thisSourceFile, __LINE__, "Failed to serialize XMP data!");
-      }
-  }
-  catch(Exiv2::Error &err) {
-      throw SipiError(thisSourceFile, __LINE__, err.what());
-  }
-  Exiv2::XmpParser::terminate();
-
-  len = xmpPacket.size();
-  char *buf = new char[len + 1];
-  memcpy (buf, xmpPacket.c_str(), len);
-  buf[len] = '\0';
-  return buf;
-   */
-}
-//============================================================================
-
-std::string SipiXmp::xmpBytes(void)
-{
-  unsigned int len = 0;
-  char *buf = xmpBytes(len);
-  std::string data;
-  if (buf != nullptr) {
-    data.reserve(len);
-    for (int i = 0; i < len; i++) data.push_back(buf[i]);
-    delete[] buf;
-  }
-  return data;
-}
+// Provisional implementation: returns the cached RDF/XML packet directly.
+// The Exiv2::XmpParser::encode path remains the long-term replacement, but
+// it is not thread-safe in the Exiv2 version we depend on. Once Exiv2's
+// XMP encoder becomes thread-safe, swap in the parser-driven path here
+// without touching call sites.
+std::string SipiXmp::xmpBytes() { return __xmpstr; }
 //============================================================================
 
 std::ostream &operator<<(std::ostream &outstr, const SipiXmp &rhs)

--- a/src/metadata/SipiXmp.h
+++ b/src/metadata/SipiXmp.h
@@ -65,18 +65,11 @@ public:
 
 
   /*!
-   * Returns the bytes of the RDF/XML data
-   * \param[out] len Length of the data on bytes
-   * \returns Chunk of chars holding the xmp data
-   */
-  char *xmpBytes(unsigned int &len);
-
-  /*!
-   * Returns the bytes of the RDF/XML data as std::string
+   * Returns the bytes of the RDF/XML data as a std::string.
    *
    * @return String holding the xmp data
    */
-  std::string xmpBytes(void);
+  std::string xmpBytes();
 
   /*!
    * The overloaded << operator which is used to write the xmp formatted to the outstream


### PR DESCRIPTION
[DEV-6409](https://linear.app/dasch/issue/DEV-6409) — stacked on #632 → #631 → #630

> ⚠️ Stacked PR. Base = \`feature/dev-6406-icc-internal-test-seam\` (PR #632). Merge order: #630 → #631 → #632 → this PR. Rebase onto \`main\` once predecessors land.

## Summary

Per \`cpp-style-guide.md\`'s \"no raw owning new/delete\" rule and the Y+8 plan for SIPI's transitional C++ to Rust roadmap, replace the dual-overload pattern on metadata byte getters with the single \`std::vector<unsigned char>\` form (or \`std::string\` for XMP).

## Header drops

- \`SipiExif::exifBytes(unsigned int &len)\` — caller-owns raw pointer
- \`SipiIcc::iccBytes(unsigned int &len)\` — caller-owns raw pointer
- \`SipiIptc::iptcBytes(unsigned int &len)\` — caller-owns raw pointer
- \`SipiXmp::xmpBytes(unsigned int &len)\` — caller-owns char buffer
- \`SipiEssentials::icc_profile(unsigned int &len)\` — caller-owns raw pointer; had zero call sites (already unused dead code)

All five raw-pointer overloads previously returned heap-allocated buffers the caller had to \`delete[]\`. Each was paired with a vector/string overload that delegated to the raw form and copied. Now there's only the vector/string form, owned by the value type itself.

## Implementation cleanup

- \`SipiIcc::iccBytes()\` and \`SipiIptc::iptcBytes()\` reshaped to use \`std::vector<unsigned char>\` end-to-end — no more \`new[]\`, \`memcpy\`, \`delete[]\` between two overloads of the same function.
- \`SipiExif::exifBytes()\` keeps the internal \`binaryExif\`/\`binary_size\` cache (a separate \`new unsigned char[]\` allocation tracked by the class's destructor). Modernising that to \`std::unique_ptr\` is a separate concern under DEV-6398's broader scope, not this issue.
- \`SipiXmp::xmpBytes()\` collapses to \`return __xmpstr;\` — the function was only doing a \`new char[]\` + \`memcpy\` + null-terminate dance to round-trip a \`std::string\` member through a raw buffer. Thread-safety story unchanged (still provisional, pending Exiv2::XmpParser::encode thread-safety upstream).

## Caller updates

\`src/formats/SipiIOJ2k.cpp\` had the only consumers of the raw-pointer overloads — six identical sites under the \`icc_type\` switch that did:

\`\`\`cpp
unsigned int icc_len;
kdu_byte *icc_bytes = (kdu_byte *)img->icc->iccBytes(icc_len);
jp2_family_colour.init(icc_bytes);
delete[] icc_bytes;
\`\`\`

Updated to:

\`\`\`cpp
std::vector<unsigned char> icc_buf = img->icc->iccBytes();
jp2_family_colour.init(reinterpret_cast<kdu_byte *>(icc_buf.data()));
\`\`\`

The local vector lives through the \`init()\` call (Kakadu doesn't retain the pointer past the call — proved by the original \`delete[]\` happening on the next line). RAII destruction at scope exit replaces the explicit \`delete[]\`.

## Test Plan

- [x] \`bazel test //src/... //test/unit/... //test/approval:approvaltests\` — all 13 test targets pass, including the approval tests that exercise the JPEG2000 encoder + ICC roundtrip path.
- [ ] CI: full matrix green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)