### PR TITLE
refactor(metadata): SipiEssentials struct-of-accessors (DEV-6408)

### DIFF
--- a/src/SipiImage.cpp
+++ b/src/SipiImage.cpp
@@ -323,13 +323,20 @@ bool SipiImage::readOriginal(const std::string &filepath,
     std::string mimetype = shttps::Parsing::getFileMimetype(filepath).first;
     std::vector<unsigned char> iccprofile;
     if (icc != nullptr) { iccprofile = icc->iccBytes(); }
-    SipiEssentials emdata2(origname, mimetype, shttps::HashType::sha256, checksum, iccprofile);
+    SipiEssentials emdata2(EssentialsFields{
+      .origname = origname,
+      .mimetype = mimetype,
+      .hash_type = shttps::HashType::sha256,
+      .data_chksum = checksum,
+      .use_icc = !iccprofile.empty(),
+      .icc_profile = std::move(iccprofile),
+    });
     essential_metadata(emdata2);
   } else {
-    shttps::Hash internal_hash(emdata.hash_type());
+    shttps::Hash internal_hash(emdata.fields().hash_type);
     internal_hash.add_data(pixels, nx * ny * nc * bps / 8);
     std::string checksum = internal_hash.hash();
-    if (checksum != emdata.data_chksum()) { return false; }
+    if (checksum != emdata.fields().data_chksum) { return false; }
   }
 
   return true;
@@ -351,13 +358,18 @@ bool SipiImage::readOriginal(const std::string &filepath,
     internal_hash.add_data(pixels, nx * ny * nc * bps / 8);
     std::string checksum = internal_hash.hash();
     std::string mimetype = shttps::Parsing::getFileMimetype(filepath).first;
-    SipiEssentials emdata2(origname, mimetype, shttps::HashType::sha256, checksum);
+    SipiEssentials emdata2(EssentialsFields{
+      .origname = origname,
+      .mimetype = mimetype,
+      .hash_type = shttps::HashType::sha256,
+      .data_chksum = checksum,
+    });
     essential_metadata(emdata2);
   } else {
-    shttps::Hash internal_hash(emdata.hash_type());
+    shttps::Hash internal_hash(emdata.fields().hash_type);
     internal_hash.add_data(pixels, nx * ny * nc * bps / 8);
     std::string checksum = internal_hash.hash();
-    if (checksum != emdata.data_chksum()) { return false; }
+    if (checksum != emdata.fields().data_chksum) { return false; }
   }
 
   return true;

--- a/src/formats/SipiIOJ2k.cpp
+++ b/src/formats/SipiIOJ2k.cpp
@@ -704,8 +704,8 @@ SipiImgInfo SipiIOJ2k::getDim(const std::string &filepath)
     const char *cstr = comment.get_text();
     if (strncmp(cstr, "SIPI:", 5) == 0) {
       SipiEssentials se(cstr + 5);
-      info.origmimetype = se.mimetype();
-      info.origname = se.origname();
+      info.origmimetype = se.fields().mimetype;
+      info.origname = se.fields().origname;
       info.success = SipiImgInfo::ALL;
       break;
     }
@@ -1035,12 +1035,12 @@ void SipiIOJ2k::write(SipiImage *img, const std::string &filepath, const SipiCom
           break;
         }
         case icc_LUM_D65: {
-          if (es.is_set()) es.use_icc(true);
+          if (es.is_set()) es.fields_mut().use_icc = true;
           jp2_family_colour.init(JP2_sLUM_SPACE);// TODO: just a fallback
           break;
         }
         case icc_ROMM_GRAY: {
-          if (es.is_set()) es.use_icc(true);
+          if (es.is_set()) es.fields_mut().use_icc = true;
           jp2_family_colour.init(JP2_sLUM_SPACE);// TODO: just a fallback
           break;
         }
@@ -1061,7 +1061,7 @@ void SipiIOJ2k::write(SipiImage *img, const std::string &filepath, const SipiCom
         }
         }
       } catch (kdu_exception e) {
-        if (es.is_set()) es.use_icc(true);
+        if (es.is_set()) es.fields_mut().use_icc = true;
         switch (img->nc - img->es.size()) {
         case 1: {
           jp2_family_colour.init(JP2_sLUM_SPACE);
@@ -1098,7 +1098,7 @@ void SipiIOJ2k::write(SipiImage *img, const std::string &filepath, const SipiCom
     // Custom tag for SipiEssential metadata
     //
     if (es.is_set()) {
-      std::string esstr = es;
+      std::string esstr = es.serialize();
       std::string emdata = "SIPI:" + esstr;
       kdu_codestream_comment comment = codestream.add_comment();
       comment.put_text(emdata.c_str());

--- a/src/formats/SipiIOJpeg.cpp
+++ b/src/formats/SipiIOJpeg.cpp
@@ -1225,11 +1225,11 @@ void SipiIOJpeg::write(SipiImage *img, const std::string &filepath, const SipiCo
 
   SipiEssentials es = img->essential_metadata();
 
-  if ((img->icc != nullptr) || es.use_icc()) {
+  if ((img->icc != nullptr) || es.fields().use_icc) {
     std::vector<unsigned char> buf;
     try {
-      if (es.use_icc()) {
-        buf = es.icc_profile();
+      if (es.fields().use_icc) {
+        buf = es.fields().icc_profile;
       } else {
         buf = img->icc->iccBytes();
       }
@@ -1280,7 +1280,7 @@ void SipiIOJpeg::write(SipiImage *img, const std::string &filepath, const SipiCo
   }
 
   if (es.is_set()) {
-    std::string esstr = es;
+    std::string esstr = es.serialize();
     unsigned int len = esstr.length();
     char sipi_buf[512 + 1];
     strncpy(sipi_buf, esstr.c_str(), 512);

--- a/src/formats/SipiIOPng.cpp
+++ b/src/formats/SipiIOPng.cpp
@@ -546,14 +546,14 @@ void SipiIOPng::write(SipiImage *img, const std::string &filepath, const SipiCom
   // ICC profile handfling is special...
   //
   SipiEssentials es = img->essential_metadata();
-  if ((img->icc != nullptr) || es.use_icc()) {
+  if ((img->icc != nullptr) || es.fields().use_icc) {
     if ((img->icc != nullptr) && (img->icc->getProfileType() == icc_LAB)) {
       img->convertToIcc(SipiIcc(Sipi::PredefinedProfiles::icc_sRGB), img->bps);
     }
     std::vector<unsigned char> icc_buf;
     try {
-      if (es.use_icc()) {
-        icc_buf = es.icc_profile();
+      if (es.fields().use_icc) {
+        icc_buf = es.fields().icc_profile;
       } else {
         icc_buf = img->icc->iccBytes();
       }
@@ -591,7 +591,7 @@ void SipiIOPng::write(SipiImage *img, const std::string &filepath, const SipiCom
   // to avoid stack-use-after-scope when png_set_text reads the pointer.
   char sipi_buf[512 + 1] = {};
   if (es.is_set()) {
-    std::string esstr = es;
+    std::string esstr = es.serialize();
     unsigned int len = esstr.length();
     strncpy(sipi_buf, esstr.c_str(), 512);
     sipi_buf[512] = '\0';

--- a/src/formats/SipiIOTiff.cpp
+++ b/src/formats/SipiIOTiff.cpp
@@ -1465,8 +1465,8 @@ SipiImgInfo SipiIOTiff::getDim(const std::string &filepath)
     char *emdatastr;
     if (1 == TIFFGetField(tif.get(), TIFFTAG_SIPIMETA, &emdatastr)) {
       SipiEssentials se(emdatastr);
-      info.origmimetype = se.mimetype();
-      info.origname = se.origname();
+      info.origmimetype = se.fields().mimetype;
+      info.origname = se.fields().origname;
       info.success = SipiImgInfo::ALL;
     }
 
@@ -1650,11 +1650,11 @@ void SipiIOTiff::write(SipiImage *img, const std::string &filepath, const SipiCo
     if (img->exif->getValByKey("Exif.Image.ResolutionUnit", s)) { TIFFSetField(tif, TIFFTAG_RESOLUTIONUNIT, s); }
   }
   SipiEssentials es = img->essential_metadata();
-  if (((img->icc != nullptr) || es.use_icc()) & (!(img->skip_metadata & SKIP_ICC))) {
+  if (((img->icc != nullptr) || es.fields().use_icc) & (!(img->skip_metadata & SKIP_ICC))) {
     std::vector<unsigned char> buf;
     try {
-      if (es.use_icc()) {
-        buf = es.icc_profile();
+      if (es.fields().use_icc) {
+        buf = es.fields().icc_profile;
       } else {
         buf = img->icc->iccBytes();
       }
@@ -1691,7 +1691,7 @@ void SipiIOTiff::write(SipiImage *img, const std::string &filepath, const SipiCo
   // Custom tag for SipiEssential metadata
   //
   if (es.is_set()) {
-    std::string emdata = es;
+    std::string emdata = es.serialize();
     TIFFSetField(tif, TIFFTAG_SIPIMETA, emdata.c_str());
   }
   // TIFFCheckpointDirectory(tif);

--- a/src/metadata/SipiEssentials.cpp
+++ b/src/metadata/SipiEssentials.cpp
@@ -3,40 +3,42 @@
  * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <math.h>
+#include <cerrno>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
 #include <openssl/bio.h>
 #include <openssl/buffer.h>
 #include <openssl/evp.h>
-#include <stdlib.h>
-#include <string.h>
-#include <vector>
 
 #include "metadata/SipiEssentials.h"
 #include "shttps/Error.h"
-#include "shttps/Global.h"
 
-static int calcDecodeLength(const std::string &b64input)
+namespace {
+
+int calcDecodeLength(const std::string &b64input)
 {
   int padding = 0;
-
-  // Check for trailing '=''s as padding
-  if (b64input[b64input.length() - 1] == '=' && b64input[b64input.length() - 2] == '=')
+  if (b64input.length() >= 2 && b64input[b64input.length() - 1] == '=' && b64input[b64input.length() - 2] == '=')
     padding = 2;
-  else if (b64input[b64input.length() - 1] == '=')
+  else if (!b64input.empty() && b64input[b64input.length() - 1] == '=')
     padding = 1;
-
-  return (int)b64input.length() * 0.75 - padding;
+  return static_cast<int>(b64input.length() * 0.75) - padding;
 }
 
 std::string base64Encode(const std::vector<unsigned char> &message)
 {
+  if (message.empty()) return {};
+
   BIO *bio;
   BIO *b64;
   FILE *stream;
 
-  size_t encodedSize = 4 * ceil((double)message.size() / 3);
+  std::size_t encodedSize = 4 * static_cast<std::size_t>(std::ceil(static_cast<double>(message.size()) / 3));
 
-  char *buffer = (char *)malloc(encodedSize + 1);
+  char *buffer = static_cast<char *>(std::malloc(encodedSize + 1));
   if (buffer == nullptr) { throw shttps::Error("Failed to allocate memory", errno); }
 
   stream = fmemopen(buffer, encodedSize + 1, "w");
@@ -44,160 +46,128 @@ std::string base64Encode(const std::vector<unsigned char> &message)
   bio = BIO_new_fp(stream, BIO_NOCLOSE);
   bio = BIO_push(b64, bio);
   BIO_set_flags(bio, BIO_FLAGS_BASE64_NO_NL);
-  BIO_write(bio, message.data(), message.size());
+  BIO_write(bio, message.data(), static_cast<int>(message.size()));
   (void)BIO_flush(bio);
   BIO_free_all(bio);
-  fclose(stream);
+  std::fclose(stream);
 
   std::string res(buffer);
-  free(buffer);
+  std::free(buffer);
   return res;
 }
 
 std::vector<unsigned char> base64Decode(const std::string &b64message)
 {
+  if (b64message.empty()) return {};
+
   BIO *bio;
   BIO *b64;
-  size_t decodedLength = calcDecodeLength(b64message);
+  std::size_t decodedLength = calcDecodeLength(b64message);
 
-  unsigned char *buffer = (unsigned char *)malloc(decodedLength + 1);
-  if (buffer == NULL) { throw shttps::Error("Failed to allocate memory", errno); }
-  FILE *stream = fmemopen((char *)b64message.c_str(), b64message.size(), "r");
+  auto *buffer = static_cast<unsigned char *>(std::malloc(decodedLength + 1));
+  if (buffer == nullptr) { throw shttps::Error("Failed to allocate memory", errno); }
+  FILE *stream = fmemopen(const_cast<char *>(b64message.c_str()), b64message.size(), "r");
 
   b64 = BIO_new(BIO_f_base64());
   bio = BIO_new_fp(stream, BIO_NOCLOSE);
   bio = BIO_push(b64, bio);
   BIO_set_flags(bio, BIO_FLAGS_BASE64_NO_NL);
-  decodedLength = BIO_read(bio, buffer, b64message.size());
+  decodedLength = BIO_read(bio, buffer, static_cast<int>(b64message.size()));
   buffer[decodedLength] = '\0';
 
   BIO_free_all(bio);
-  fclose(stream);
+  std::fclose(stream);
 
-  std::vector<unsigned char> data;
-  data.reserve(decodedLength);
-  for (int i = 0; i < decodedLength; i++) data.push_back(buffer[i]);
-
-  free(buffer);
+  std::vector<unsigned char> data(buffer, buffer + decodedLength);
+  std::free(buffer);
   return data;
 }
 
-namespace Sipi {
-
-SipiEssentials::SipiEssentials(const std::string &origname_p,
-  const std::string &mimetype_p,
-  shttps::HashType hash_type_p,
-  const std::string &data_chksum_p,
-  const std::vector<unsigned char> &icc_profile_p)
-  : _origname(origname_p), _mimetype(mimetype_p), _hash_type(hash_type_p), _data_chksum(data_chksum_p)
+std::vector<std::string> split(const std::string &s, const std::string &delimiter)
 {
-  _is_set = true;
-  _use_icc = false;
-  if (!_icc_profile.empty()) {
-    _icc_profile = base64Encode(icc_profile_p);
-    _use_icc = true;
-  }
-}
-
-std::string SipiEssentials::hash_type_string(void) const
-{
-  std::string hash_type_str;
-  switch (_hash_type) {
-  case shttps::HashType::none:
-    hash_type_str = "none";
-    break;
-  case shttps::HashType::md5:
-    hash_type_str = "md5";
-    break;
-  case shttps::HashType::sha1:
-    hash_type_str = "sha1";
-    break;
-  case shttps::HashType::sha256:
-    hash_type_str = "sha256";
-    break;
-  case shttps::HashType::sha384:
-    hash_type_str = "sha384";
-    break;
-  case shttps::HashType::sha512:
-    hash_type_str = "sha512";
-    break;
-  }
-  return hash_type_str;
-}
-
-void SipiEssentials::hash_type(const std::string &hash_type_p)
-{
-  if (hash_type_p == "none")
-    _hash_type = shttps::HashType::none;
-  else if (hash_type_p == "md5")
-    _hash_type = shttps::HashType::md5;
-  else if (hash_type_p == "sha1")
-    _hash_type = shttps::HashType::sha1;
-  else if (hash_type_p == "sha256")
-    _hash_type = shttps::HashType::sha256;
-  else if (hash_type_p == "sha384")
-    _hash_type = shttps::HashType::sha384;
-  else if (hash_type_p == "sha512")
-    _hash_type = shttps::HashType::sha512;
-  else
-    _hash_type = shttps::HashType::none;
-}
-
-std::vector<unsigned char> SipiEssentials::icc_profile() { return base64Decode(_icc_profile); }
-
-void SipiEssentials::icc_profile(const std::vector<unsigned char> &icc_profile_p)
-{
-  _icc_profile = base64Encode(icc_profile_p);
-}
-
-// for string delimiter
-std::vector<std::string> split(std::string s, std::string delimiter)
-{
-  size_t pos_start = 0, pos_end, delim_len = delimiter.length();
-  std::string token;
+  std::size_t pos_start = 0;
+  std::size_t pos_end;
+  std::size_t delim_len = delimiter.length();
   std::vector<std::string> res;
 
   while ((pos_end = s.find(delimiter, pos_start)) != std::string::npos) {
-    token = s.substr(pos_start, pos_end - pos_start);
+    res.emplace_back(s.substr(pos_start, pos_end - pos_start));
     pos_start = pos_end + delim_len;
-    res.push_back(token);
   }
-
-  res.push_back(s.substr(pos_start));
+  res.emplace_back(s.substr(pos_start));
   return res;
 }
 
-void SipiEssentials::parse(const std::string &str)
+std::string hash_type_to_string(shttps::HashType ht)
 {
-  std::vector<std::string> result = split(str, "|");
-  _origname = result[0];
-  _mimetype = result[1];
-  std::string _hash_type_str = result[2];
-  if (_hash_type_str == "none")
-    _hash_type = shttps::HashType::none;
-  else if (_hash_type_str == "md5")
-    _hash_type = shttps::HashType::md5;
-  else if (_hash_type_str == "sha1")
-    _hash_type = shttps::HashType::sha1;
-  else if (_hash_type_str == "sha256")
-    _hash_type = shttps::HashType::sha256;
-  else if (_hash_type_str == "sha384")
-    _hash_type = shttps::HashType::sha384;
-  else if (_hash_type_str == "sha512")
-    _hash_type = shttps::HashType::sha512;
-  else
-    _hash_type = shttps::HashType::none;
-  _data_chksum = result[3];
+  switch (ht) {
+  case shttps::HashType::none:
+    return "none";
+  case shttps::HashType::md5:
+    return "md5";
+  case shttps::HashType::sha1:
+    return "sha1";
+  case shttps::HashType::sha256:
+    return "sha256";
+  case shttps::HashType::sha384:
+    return "sha384";
+  case shttps::HashType::sha512:
+    return "sha512";
+  }
+  return "none";
+}
+
+shttps::HashType hash_type_from_string(const std::string &s)
+{
+  if (s == "md5") return shttps::HashType::md5;
+  if (s == "sha1") return shttps::HashType::sha1;
+  if (s == "sha256") return shttps::HashType::sha256;
+  if (s == "sha384") return shttps::HashType::sha384;
+  if (s == "sha512") return shttps::HashType::sha512;
+  return shttps::HashType::none;
+}
+
+}// namespace
+
+namespace Sipi {
+
+SipiEssentials::SipiEssentials(const std::string &serialized)
+{
+  std::vector<std::string> result = split(serialized, "|");
+  if (result.size() < 4) return;// Malformed packet — leave _is_set = false.
+
+  _fields.origname = result[0];
+  _fields.mimetype = result[1];
+  _fields.hash_type = hash_type_from_string(result[2]);
+  _fields.data_chksum = result[3];
 
   if (result.size() > 5) {
-    std::string tmp_use_icc = result[4];
-    _use_icc = (tmp_use_icc == "USE_ICC");
-    if (_use_icc) {
-      _icc_profile = result[5];
-    } else {
-      _icc_profile = std::string();
-    }
+    _fields.use_icc = (result[4] == "USE_ICC");
+    if (_fields.use_icc && result[5] != "NULL") { _fields.icc_profile = base64Decode(result[5]); }
   }
   _is_set = true;
 }
+
+std::string SipiEssentials::serialize() const
+{
+  std::string out;
+  out.reserve(_fields.origname.size() + _fields.mimetype.size() + _fields.data_chksum.size() + 64);
+  out += _fields.origname;
+  out += '|';
+  out += _fields.mimetype;
+  out += '|';
+  out += hash_type_to_string(_fields.hash_type);
+  out += '|';
+  out += _fields.data_chksum;
+  out += '|';
+  out += _fields.use_icc ? "USE_ICC" : "IGNORE_ICC";
+  out += '|';
+  if (!_fields.icc_profile.empty()) {
+    out += base64Encode(_fields.icc_profile);
+  } else {
+    out += "NULL";
+  }
+  return out;
+}
+
 }// namespace Sipi

--- a/src/metadata/SipiEssentials.h
+++ b/src/metadata/SipiEssentials.h
@@ -3,206 +3,83 @@
  * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#ifndef __defined_essentials_h
-#define __defined_essentials_h
+#ifndef SIPI_METADATA_SIPI_ESSENTIALS_H
+#define SIPI_METADATA_SIPI_ESSENTIALS_H
 
-#include <cstdlib>
-#include <sstream>
+#include <ostream>
 #include <string>
-#include <utility>
 #include <vector>
-
 
 #include "shttps/Hash.h"
 
 namespace Sipi {
 
 /*!
- * Small class to create a small essential metadata packet that can be embedded
- * within an image header. It contains
- * - original file name
- * - original mime type
- * - checksum method
- * - checksum of uncompressed pixel values
- * The class contains methods to set the fields, to serialize and deserialize
- * the data.
+ * Plain value type holding the six fields embedded in SIPI's image-header
+ * "essentials" packet. Per DEV-6408 (Probe 2): the public API is a struct
+ * of accessors, not 17 getter/setter pairs.
+ */
+struct EssentialsFields
+{
+  std::string origname;//!< original filename
+  std::string mimetype;//!< original mime type
+  shttps::HashType hash_type = shttps::HashType::none;//!< type of checksum
+  std::string data_chksum;//!< the checksum of pixel data
+  bool use_icc = false;//!< apply this ICC profile when converting from JPEG2000
+  std::vector<unsigned char> icc_profile;//!< decoded ICC profile bytes (empty if none)
+};
+
+/*!
+ * Small class that creates a packet of essentials metadata embedded in an
+ * image header (containing original filename, original mime type, checksum
+ * method, pixel-data checksum, and optionally an ICC profile).
+ *
+ * The pipe-delimited wire format is retained indefinitely for reading legacy
+ * packets per DEV-6398 scope; DEV-6410 (ADR-0005) adds CBOR for new emissions.
  */
 class SipiEssentials
 {
 private:
-  bool _is_set;
-  std::string _origname;//!< original filename
-  std::string _mimetype;//!< original mime type
-  shttps::HashType _hash_type;//!< type of checksum
-  std::string _data_chksum;//!< the checksum of pixel data
-  bool _use_icc;//!< use this ICC profile when converting from JPEG200 to other format
-  std::string _icc_profile;//!< ICC profile if JPEG2000 can not deal with it directly
+  bool _is_set = false;
+  EssentialsFields _fields{};
 
 public:
+  SipiEssentials() = default;
+
   /*!
-   * Constructor for empty packet
+   * Construct from fully-populated fields. Marks the packet as set.
    */
-  inline SipiEssentials()
+  explicit SipiEssentials(EssentialsFields fields) : _is_set(true), _fields(std::move(fields)) {}
+
+  /*!
+   * Parse a serialized (pipe-delimited) packet. Marks the packet as set on
+   * successful parse.
+   */
+  explicit SipiEssentials(const std::string &serialized);
+
+  [[nodiscard]] bool is_set() const { return _is_set; }
+
+  [[nodiscard]] const EssentialsFields &fields() const { return _fields; }
+
+  /*!
+   * Mutable field access. Reaching for this implicitly marks the packet as set.
+   */
+  EssentialsFields &fields_mut()
   {
-    _hash_type = shttps::HashType::none;
-    _is_set = false;
-    _use_icc = false;
-  }
-
-  /*!
-   * Constructor where all fields are passed
-   *
-   * \param[in] origname_p Original filename
-   * \param[in] mimetype_p Original mimetype as string
-   * \param[in] hash_type_p Checksumtype as defined in Hash.h (shttps::HashType)
-   * \param[in] data_chksum_p The actual checksum of the internal image data
-   * \param[in] icc_profile_p ICC profile data
-   */
-  SipiEssentials(const std::string &origname_p,
-    const std::string &mimetype_p,
-    shttps::HashType hash_type_p,
-    const std::string &data_chksum_p,
-    const std::vector<unsigned char> &icc_profile_p = std::vector<unsigned char>());
-
-  /*!
-   * Constructor taking a serialized packet (as string)
-   *
-   * \param[in] datastr Serialzed metadata packet
-   */
-  inline SipiEssentials(const std::string &datastr) { parse(datastr); }
-
-  /*!
-   * Getter for original name
-   */
-  inline std::string origname(void) { return _origname; }
-
-  /*!
-   * Setter for original name
-   */
-  inline void origname(const std::string &origname_p)
-  {
-    _origname = origname_p;
     _is_set = true;
+    return _fields;
   }
 
   /*!
-   * Getter for mimetype
+   * Serialize the packet to the pipe-delimited wire form used by SIPI's
+   * format handlers (TIFF SIPIMETA tag, JPEG COM marker, JP2 codestream
+   * comment, PNG text chunk).
    */
-  inline std::string mimetype(void) { return _mimetype; }
+  [[nodiscard]] std::string serialize() const;
 
-  /*!
-   * Setter for original name
-   */
-  inline void mimetype(const std::string &mimetype_p) { _mimetype = mimetype_p; }
-
-  /*!
-   * Getter for checksum type as shttps::HashType
-   */
-  inline shttps::HashType hash_type(void) { return _hash_type; }
-
-  /*!
-   * Getter for checksum type as string
-   */
-  std::string hash_type_string(void) const;
-
-  /*!
-   * Setter for checksum type
-   *
-   * \param[in] hash_type_p checksum type
-   */
-  inline void hash_type(shttps::HashType hash_type_p) { _hash_type = hash_type_p; }
-
-  /*!
-   * Setter for checksum type
-   *
-   * \param[in] hash_type_p checksum type
-   */
-  void hash_type(const std::string &hash_type_p);
-
-  /*!
-   * Getter for checksum
-   *
-   * @return Chekcsum as std::string
-   */
-  inline std::string data_chksum(void) { return _data_chksum; }
-
-  /*!
-   * Setter for checksum
-   */
-  inline void data_chksum(const std::string &data_chksum_p) { _data_chksum = data_chksum_p; }
-
-  /*!
-   * Do I have to use this ICC profile? (only when converting from JPEG2000
-   * @return Bool if this ICC profile should be used....
-   */
-  inline bool use_icc(void) { return _use_icc; }
-
-  /*!
-   * Setter for boolean flag for the usage of the essential's ICC profile
-   * @param use_icc_p
-   */
-  inline void use_icc(bool use_icc_p) { _use_icc = use_icc_p; }
-
-
-  /*!
-   * Getter for ICC profile
-   *
-   * @return ICC profile binary data as std::vector
-   */
-  std::vector<unsigned char> icc_profile();
-
-  /*!
-   * Setter for ICC profile
-   *
-   * \param[in] icc_profile_p ICC profile binary data as std::vector
-   */
-  void icc_profile(const std::vector<unsigned char> &icc_profile_p);
-
-  /*!
-   * Parse a string containing a serialized metadata packet
-   */
-  void parse(const std::string &str);
-
-  /*!
-   * Check if essential metadata has been set.
-   */
-  inline bool is_set(void) { return _is_set; }
-
-  /*!
-   * String conversion operator
-   */
-  inline operator std::string() const
-  {
-    std::string tmpstr = _origname + "|" + _mimetype + "|" + hash_type_string() + "|" + _data_chksum;
-    if (_use_icc)
-      tmpstr += "|USE_ICC|";
-    else
-      tmpstr += "|IGNORE_ICC|";
-    if (!_icc_profile.empty())
-      tmpstr += _icc_profile;
-    else
-      tmpstr += "NULL";
-    return tmpstr;
-  }
-
-  /*!
-   * Stream output operator
-   */
-  inline friend std::ostream &operator<<(std::ostream &ostr, const SipiEssentials &rhs)
-  {
-    ostr << rhs._origname << "|" << rhs._mimetype << "|" << rhs.hash_type_string() << "|" << rhs._data_chksum;
-    if (rhs._use_icc)
-      ostr << "|USE_ICC|";
-    else
-      ostr << "|IGNORE_ICC|";
-    if (!rhs._icc_profile.empty())
-      ostr << rhs._icc_profile;
-    else
-      ostr << "NULL";
-    return ostr;
-  }
+  friend std::ostream &operator<<(std::ostream &os, const SipiEssentials &rhs) { return os << rhs.serialize(); }
 };
-}// namespace Sipi
 
+}// namespace Sipi
 
 #endif


### PR DESCRIPTION
[DEV-6408](https://linear.app/dasch/issue/DEV-6408) — stacked on #633 → #632 → #631 → #630

> ⚠️ Stacked PR. Base = \`feature/dev-6409-metadata-pointer-ownership\` (PR #633). Merge order: #630 → #631 → #632 → #633 → this PR.

## Summary

\`SipiEssentials.h\` was 209 lines for what's essentially a 6-field struct + pipe-delimited serialization. Per the Probe-2 analysis, this PR collapses the bloat to the shape DEV-6408 specifies: one \`EssentialsFields\` value struct + one parse-from-string ctor + one \`serialize()\`.

## New API

\`\`\`cpp
struct EssentialsFields {
  std::string origname;
  std::string mimetype;
  shttps::HashType hash_type = shttps::HashType::none;
  std::string data_chksum;
  bool use_icc = false;
  std::vector<unsigned char> icc_profile;  // decoded; empty if none
};

class SipiEssentials {
public:
  SipiEssentials() = default;
  explicit SipiEssentials(EssentialsFields fields);
  explicit SipiEssentials(const std::string &serialized);  // legacy pipe-delimited reader
  bool is_set() const;
  const EssentialsFields &fields() const;
  EssentialsFields &fields_mut();
  std::string serialize() const;
  friend std::ostream &operator<<(std::ostream &, const SipiEssentials &);
};
\`\`\`

## Removes

- **17 individual getter/setter methods** replaced by struct access.
- Inline \`operator std::string()\` and \`operator<<\` removed in favour of the single \`serialize()\` method (and an out-of-line \`operator<<\` that delegates to it).
- The multi-arg \`(origname, mimetype, hash_type, data_chksum, icc_profile)\` constructor replaced by \`EssentialsFields{}\` aggregate init in the one call site (\`SipiImage::readOriginal\`).
- The \`hash_type_to_string\` / \`hash_type_from_string\` helpers move from member methods to anonymous-namespace functions (pure conversions; no \`this\` dep).
- Implementation-detail base64 helpers, the \`split\` helper, and \`calcDecodeLength\` move to anonymous namespace — no longer leak at file scope.

## Fixes a latent bug

The old multi-arg constructor's \`_use_icc\` flag was always \`false\` — the guard \`if (!_icc_profile.empty())\` tested the (default-initialised empty) member, never the parameter, so the encoded buffer was discarded and the flag stayed off. The new \`SipiImage::readOriginal\` path sets \`use_icc = !iccprofile.empty()\` explicitly, restoring the intended behaviour.

## Wire format

The pipe-delimited serialization is **unchanged**. DEV-6398 explicitly retains the legacy reader indefinitely; DEV-6410 adds CBOR for new emissions on top of this refactor.

## Caller updates

6 files, ~30 sites:

- \`src/SipiImage.cpp\` — 2 \`readOriginal\` overloads switch to \`EssentialsFields{}\` aggregate init; field reads via \`fields()\`.
- \`src/formats/SipiIOTiff.cpp\` — 3 sites (read mimetype/origname, write SIPIMETA tag, ICC write path).
- \`src/formats/SipiIOPng.cpp\` — 2 sites (ICC write path, SIPI text chunk emission).
- \`src/formats/SipiIOJpeg.cpp\` — 2 sites (ICC write path, JPEG_COM marker emission).
- \`src/formats/SipiIOJ2k.cpp\` — 4 sites (read mimetype/origname, \`use_icc(true)\` setter → \`fields_mut().use_icc = true\`, codestream comment emission).

## Test Plan

- [x] \`bazel test //src/... //test/unit/... //test/approval:approvaltests\` — all 13 test targets pass, including the approval tests that exercise the SIPIMETA-embedded-then-read round-trip across every format handler.
- [ ] CI: full matrix green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)