### PR TITLE
refactor(metadata): move SipiExif assign_val bodies out-of-line (DEV-6407)

### DIFF
--- a/src/metadata/SipiExif.cpp
+++ b/src/metadata/SipiExif.cpp
@@ -47,6 +47,131 @@ SipiExif::SipiExif(const unsigned char *exif, unsigned int len)
 //============================================================================
 
 SipiExif::~SipiExif() { delete[] binaryExif; }
+//============================================================================
+
+// Type-dispatched assignment helpers backing the inline `getValByKey<T>`
+// templates in the header. Moved out-of-line per DEV-6407 to keep
+// `metadata/SipiExif.h` lean.
+
+bool SipiExif::assign_val(Exiv2::Value::UniquePtr &v, std::string &val)
+{
+  val = v->toString();
+  return v->ok();
+}
+
+bool SipiExif::assign_val(Exiv2::Value::UniquePtr &v, std::vector<std::string> &val)
+{
+  for (int i = 0; i < v->count(); i++) { val.push_back(v->toString(i)); }
+  return v->ok();
+}
+
+bool SipiExif::assign_val(Exiv2::Value::UniquePtr &v, char &val)
+{
+  val = static_cast<char>(v->toInt64());
+  return v->ok();
+}
+
+bool SipiExif::assign_val(Exiv2::Value::UniquePtr &v, std::vector<char> &val)
+{
+  for (int i = 0; i < v->count(); i++) { val.push_back(static_cast<char>(v->toInt64(i))); }
+  return v->ok();
+}
+
+bool SipiExif::assign_val(Exiv2::Value::UniquePtr &v, unsigned char &val)
+{
+  val = static_cast<unsigned char>(v->toInt64());
+  return v->ok();
+}
+
+bool SipiExif::assign_val(Exiv2::Value::UniquePtr &v, std::vector<unsigned char> &val)
+{
+  for (int i = 0; i < v->count(); i++) { val.push_back(static_cast<unsigned char>(v->toInt64(i))); }
+  return v->ok();
+}
+
+bool SipiExif::assign_val(Exiv2::Value::UniquePtr &v, short &val)
+{
+  val = static_cast<short>(v->toInt64());
+  return v->ok();
+}
+
+bool SipiExif::assign_val(Exiv2::Value::UniquePtr &v, std::vector<short> &val)
+{
+  for (int i = 0; i < v->count(); i++) { val.push_back(static_cast<short>(v->toInt64(i))); }
+  return v->ok();
+}
+
+bool SipiExif::assign_val(Exiv2::Value::UniquePtr &v, unsigned short &val)
+{
+  val = static_cast<unsigned short>(v->toInt64());
+  return v->ok();
+}
+
+bool SipiExif::assign_val(Exiv2::Value::UniquePtr &v, std::vector<unsigned short> &val)
+{
+  for (int i = 0; i < v->count(); i++) { val.push_back(static_cast<unsigned short>(v->toInt64(i))); }
+  return v->ok();
+}
+
+bool SipiExif::assign_val(Exiv2::Value::UniquePtr &v, int &val)
+{
+  val = static_cast<int>(v->toInt64());
+  return v->ok();
+}
+
+bool SipiExif::assign_val(Exiv2::Value::UniquePtr &v, std::vector<int> &val)
+{
+  for (int i = 0; i < v->count(); i++) { val.push_back(static_cast<int>(v->toInt64(i))); }
+  return v->ok();
+}
+
+bool SipiExif::assign_val(Exiv2::Value::UniquePtr &v, unsigned int &val)
+{
+  val = static_cast<unsigned int>(v->toInt64());
+  return v->ok();
+}
+
+bool SipiExif::assign_val(Exiv2::Value::UniquePtr &v, std::vector<unsigned int> &val)
+{
+  for (int i = 0; i < v->count(); i++) { val.push_back(static_cast<unsigned int>(v->toInt64(i))); }
+  return v->ok();
+}
+
+bool SipiExif::assign_val(Exiv2::Value::UniquePtr &v, float &val)
+{
+  val = static_cast<float>(v->toFloat());
+  return v->ok();
+}
+
+bool SipiExif::assign_val(Exiv2::Value::UniquePtr &v, std::vector<float> &val)
+{
+  for (int i = 0; i < v->count(); i++) { val.push_back(static_cast<float>(v->toFloat(i))); }
+  return v->ok();
+}
+
+bool SipiExif::assign_val(Exiv2::Value::UniquePtr &v, double &val)
+{
+  val = static_cast<double>(v->toFloat());
+  return v->ok();
+}
+
+bool SipiExif::assign_val(Exiv2::Value::UniquePtr &v, std::vector<double> &val)
+{
+  for (int i = 0; i < v->count(); i++) { val.push_back(static_cast<double>(v->toFloat(i))); }
+  return v->ok();
+}
+
+bool SipiExif::assign_val(Exiv2::Value::UniquePtr &v, Exiv2::Rational &val)
+{
+  val = v->toRational();
+  return v->ok();
+}
+
+bool SipiExif::assign_val(Exiv2::Value::UniquePtr &v, std::vector<Exiv2::Rational> &val)
+{
+  for (int i = 0; i < v->count(); i++) { val.push_back(v->toRational(i)); }
+  return v->ok();
+}
 
 std::vector<unsigned char> SipiExif::exifBytes()
 {

--- a/src/metadata/SipiExif.h
+++ b/src/metadata/SipiExif.h
@@ -43,125 +43,29 @@ private:
   Exiv2::ExifData exifData;//!< Private member variable holding the exiv2 EXIF data
   Exiv2::ByteOrder byteorder;//!< Private member holding the byteorder of the EXIF data
 
-  static inline bool assign_val(Exiv2::Value::UniquePtr &v, std::string &val)
-  {
-    val = v->toString();
-    return v->ok();
-  }
-
-  static inline bool assign_val(Exiv2::Value::UniquePtr &v, std::vector<std::string> &val)
-  {
-    for (int i = 0; i < v->count(); i++) { val.push_back(v->toString(i)); }
-    return v->ok();
-  }
-
-  static inline bool assign_val(Exiv2::Value::UniquePtr &v, char &val)
-  {
-    val = static_cast<char>(v->toInt64());
-    return v->ok();
-  }
-
-  static inline bool assign_val(Exiv2::Value::UniquePtr &v, std::vector<char> &val)
-  {
-    for (int i = 0; i < v->count(); i++) { val.push_back(static_cast<char>(v->toInt64(i))); }
-    return v->ok();
-  }
-
-  static inline bool assign_val(Exiv2::Value::UniquePtr &v, unsigned char &val)
-  {
-    val = static_cast<unsigned char>(v->toInt64());
-    return v->ok();
-  }
-
-  static inline bool assign_val(Exiv2::Value::UniquePtr &v, std::vector<unsigned char> &val)
-  {
-    for (int i = 0; i < v->count(); i++) { val.push_back(static_cast<unsigned char>(v->toInt64(i))); }
-    return v->ok();
-  }
-
-  static inline bool assign_val(Exiv2::Value::UniquePtr &v, short &val)
-  {
-    val = static_cast<short>(v->toInt64());
-    return v->ok();
-  }
-
-  static inline bool assign_val(Exiv2::Value::UniquePtr &v, std::vector<short> &val)
-  {
-    for (int i = 0; i < v->count(); i++) { val.push_back(static_cast<short>(v->toInt64(i))); }
-    return v->ok();
-  }
-
-  static inline bool assign_val(Exiv2::Value::UniquePtr &v, unsigned short &val)
-  {
-    val = static_cast<unsigned short>(v->toInt64());
-    return v->ok();
-  }
-
-  static inline bool assign_val(Exiv2::Value::UniquePtr &v, std::vector<unsigned short> &val)
-  {
-    for (int i = 0; i < v->count(); i++) { val.push_back(static_cast<unsigned short>(v->toInt64(i))); }
-    return v->ok();
-  }
-
-  static inline bool assign_val(Exiv2::Value::UniquePtr &v, int &val)
-  {
-    val = static_cast<int>(v->toInt64());
-    return v->ok();
-  }
-
-  static inline bool assign_val(Exiv2::Value::UniquePtr &v, std::vector<int> &val)
-  {
-    for (int i = 0; i < v->count(); i++) { val.push_back(static_cast<int>(v->toInt64(i))); }
-    return v->ok();
-  }
-
-  static inline bool assign_val(Exiv2::Value::UniquePtr &v, unsigned int &val)
-  {
-    val = static_cast<unsigned int>(v->toInt64());
-    return v->ok();
-  }
-
-  static inline bool assign_val(Exiv2::Value::UniquePtr &v, std::vector<unsigned int> &val)
-  {
-    for (int i = 0; i < v->count(); i++) { val.push_back(static_cast<unsigned int>(v->toInt64(i))); }
-    return v->ok();
-  }
-
-  static inline bool assign_val(Exiv2::Value::UniquePtr &v, float &val)
-  {
-    val = static_cast<float>(v->toFloat());
-    return v->ok();
-  }
-
-  static inline bool assign_val(Exiv2::Value::UniquePtr &v, std::vector<float> &val)
-  {
-    for (int i = 0; i < v->count(); i++) { val.push_back(static_cast<float>(v->toFloat(i))); }
-    return v->ok();
-  }
-
-  static inline bool assign_val(Exiv2::Value::UniquePtr &v, double &val)
-  {
-    val = static_cast<double>(v->toFloat());
-    return v->ok();
-  }
-
-  static inline bool assign_val(Exiv2::Value::UniquePtr &v, std::vector<double> &val)
-  {
-    for (int i = 0; i < v->count(); i++) { val.push_back(static_cast<double>(v->toFloat(i))); }
-    return v->ok();
-  }
-
-  static inline bool assign_val(Exiv2::Value::UniquePtr &v, Exiv2::Rational &val)
-  {
-    val = v->toRational();
-    return v->ok();
-  }
-
-  static inline bool assign_val(Exiv2::Value::UniquePtr &v, std::vector<Exiv2::Rational> &val)
-  {
-    for (int i = 0; i < v->count(); i++) { val.push_back(v->toRational(i)); }
-    return v->ok();
-  }
+  // Type-dispatched assignment helpers backing the inline `getValByKey<T>`
+  // templates below. Definitions live in SipiExif.cpp so the 22 inline bodies
+  // don't have to be parsed by every TU that includes this header (DEV-6407).
+  static bool assign_val(Exiv2::Value::UniquePtr &v, std::string &val);
+  static bool assign_val(Exiv2::Value::UniquePtr &v, std::vector<std::string> &val);
+  static bool assign_val(Exiv2::Value::UniquePtr &v, char &val);
+  static bool assign_val(Exiv2::Value::UniquePtr &v, std::vector<char> &val);
+  static bool assign_val(Exiv2::Value::UniquePtr &v, unsigned char &val);
+  static bool assign_val(Exiv2::Value::UniquePtr &v, std::vector<unsigned char> &val);
+  static bool assign_val(Exiv2::Value::UniquePtr &v, short &val);
+  static bool assign_val(Exiv2::Value::UniquePtr &v, std::vector<short> &val);
+  static bool assign_val(Exiv2::Value::UniquePtr &v, unsigned short &val);
+  static bool assign_val(Exiv2::Value::UniquePtr &v, std::vector<unsigned short> &val);
+  static bool assign_val(Exiv2::Value::UniquePtr &v, int &val);
+  static bool assign_val(Exiv2::Value::UniquePtr &v, std::vector<int> &val);
+  static bool assign_val(Exiv2::Value::UniquePtr &v, unsigned int &val);
+  static bool assign_val(Exiv2::Value::UniquePtr &v, std::vector<unsigned int> &val);
+  static bool assign_val(Exiv2::Value::UniquePtr &v, float &val);
+  static bool assign_val(Exiv2::Value::UniquePtr &v, std::vector<float> &val);
+  static bool assign_val(Exiv2::Value::UniquePtr &v, double &val);
+  static bool assign_val(Exiv2::Value::UniquePtr &v, std::vector<double> &val);
+  static bool assign_val(Exiv2::Value::UniquePtr &v, Exiv2::Rational &val);
+  static bool assign_val(Exiv2::Value::UniquePtr &v, std::vector<Exiv2::Rational> &val);
 
 public:
   /*!


### PR DESCRIPTION
[DEV-6407](https://linear.app/dasch/issue/DEV-6407) — stacked on #634 → #633 → #632 → #631 → #630

> ⚠️ Stacked PR. Base = \`feature/dev-6408-essentials-interface-refactor\` (PR #634). Merge order: #630 → #631 → #632 → #633 → #634 → this PR.

## Summary

\`SipiExif.h\` carried **22 inline \`assign_val\` overload definitions** (one per type: \`std::string\`, \`vector<std::string>\`, \`char\`, …, \`Exiv2::Rational\`, \`vector<Exiv2::Rational>\`) feeding the inline \`getValByKey<T>\` template. Every TU that \`#include\`d \`metadata/SipiExif.h\` had to parse 100+ lines of identical body code on every translation — exactly the \"header bloat\" Probe 2 flagged.

This PR moves all 22 bodies out-of-line to \`SipiExif.cpp\` as static-member function definitions. The header now carries one-line declarations only, dropping **~85 lines** from the public surface.

## Scope discipline

Deliberately conservative compared to the issue's full spec:

- **Templates stay inline.** \`getValByKey<T>\` and \`addKeyVal<T>\` remain in the header — moving them to \`.cpp\` with explicit instantiations would require enumerating every \`T\` used at every call site across \`SipiLua.cpp\`, the format handlers, and \`sipi.cpp\`. A missed \`T\` becomes a linker error in a specific build configuration. The reward (header-bloat reduction beyond what \`assign_val\` provides) isn't worth the enumeration risk for this PR. Filed as follow-up in DEV-6398's broader scope.
- **\`typeid\`-dispatched \`addKeyVal\` untouched.** Same reasoning: a C++20 concepts replacement is a meaningful refactor on its own and doesn't belong on this PR's surface.
- **\`Exiv2::Rational\` not hidden behind \`std::pair<int32_t, int32_t>\`.** The issue called this out as \"if it doesn't break call sites materially\" — and it does: \`SipiIOTiff.cpp\` passes \`Exiv2::Rational\` instances by value into \`addKeyVal\`, so swapping the public-API alias to \`std::pair\` would touch every caller.

## Test Plan

- [x] \`bazel test //src/... //test/unit/... //test/approval:approvaltests\` — all 13 test targets pass, including the approval tests that exercise the EXIF round-trip through every format handler.
- [ ] CI: full matrix green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)