### PR TITLE
ci: publish Bazel build events to BuildBuddy (BES)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -414,6 +414,24 @@ build --remote_local_fallback
 build --remote_timeout=30s
 build --remote_max_connections=100
 
+# ── Build Event Service (BuildBuddy) ───────────────────────────────────────
+# BES is a publish-only build-event stream to https://dasch.buildbuddy.io for
+# build/test observability (invocation timeline, action graph, failure
+# stderr). Like --remote_cache, the flags are injected by each CI workflow
+# step:
+#   --bes_backend=grpcs://dasch.buildbuddy.io
+#   --bes_results_url=https://dasch.buildbuddy.io/invocation/
+#   --bes_header=x-buildbuddy-api-key=$BUILDBUDDY_ORG_API_KEY
+#   --build_metadata=ROLE=CI
+# Bazel does not expand env vars in .bazelrc, so the API-key-bearing flag
+# can't live here; splitting the static URLs into .bazelrc and the secret
+# into the workflow would silently break local dev (publishing attempts
+# with no auth), so we keep all three together inline. `--bes_header`
+# (scoped to BES traffic) is preferred over `common --remote_header` so
+# the BuildBuddy key doesn't bleed into our bazel-remote / cache-downloader
+# gRPC streams, which authenticate via a different mechanism
+# (tools/bazel-cred-helper.sh).
+
 # ── User overrides ─────────────────────────────────────────────────────────
 # Local-machine-only flags (e.g. --disk_cache=...) belong in user.bazelrc;
 # the file is gitignored.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
           BAZEL_CACHE_PASSWORD: ${{ secrets.BAZEL_CACHE_PASSWORD }}
+          BUILDBUDDY_ORG_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
         run: |
           if [ -n "$BAZEL_CACHE_PASSWORD" ]; then
             CACHE_HOST=bazel-cache-proxy-pbjdzenira-uc.a.run.app
@@ -153,7 +154,12 @@ jobs:
           else
             REMOTE=""
           fi
-          nix develop --command bash -c "just bazel-test $REMOTE --sandbox_debug"
+          if [ -n "$BUILDBUDDY_ORG_API_KEY" ]; then
+            BES="--bes_backend=grpcs://dasch.buildbuddy.io --bes_results_url=https://dasch.buildbuddy.io/invocation/ --bes_header=x-buildbuddy-api-key=$BUILDBUDDY_ORG_API_KEY --build_metadata=ROLE=CI"
+          else
+            BES=""
+          fi
+          nix develop --command bash -c "just bazel-test $REMOTE $BES --sandbox_debug"
 
       # On any bazel failure above, locate and dump every foreign_cc
       # Make.log under the bazel output base. rules_foreign_cc writes
@@ -196,6 +202,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
           BAZEL_CACHE_PASSWORD: ${{ secrets.BAZEL_CACHE_PASSWORD }}
+          BUILDBUDDY_ORG_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
         run: |
           if [ -n "$BAZEL_CACHE_PASSWORD" ]; then
             CACHE_HOST=bazel-cache-proxy-pbjdzenira-uc.a.run.app
@@ -203,7 +210,12 @@ jobs:
           else
             REMOTE=""
           fi
-          nix develop --command bash -c "just bazel-test-smoke $REMOTE"
+          if [ -n "$BUILDBUDDY_ORG_API_KEY" ]; then
+            BES="--bes_backend=grpcs://dasch.buildbuddy.io --bes_results_url=https://dasch.buildbuddy.io/invocation/ --bes_header=x-buildbuddy-api-key=$BUILDBUDDY_ORG_API_KEY --build_metadata=ROLE=CI"
+          else
+            BES=""
+          fi
+          nix develop --command bash -c "just bazel-test-smoke $REMOTE $BES"
 
       - name: Docker Scout — compare to production
         if: runner.os == 'Linux' && github.event_name == 'pull_request'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -85,6 +85,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
           BAZEL_CACHE_PASSWORD: ${{ secrets.BAZEL_CACHE_PASSWORD }}
+          BUILDBUDDY_ORG_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
         run: |
           if [ -n "$BAZEL_CACHE_PASSWORD" ]; then
             CACHE_HOST=bazel-cache-proxy-pbjdzenira-uc.a.run.app
@@ -92,7 +93,12 @@ jobs:
           else
             REMOTE=""
           fi
-          nix develop .#llvm-tools --command bash -c "just bazel-coverage $REMOTE --sandbox_debug"
+          if [ -n "$BUILDBUDDY_ORG_API_KEY" ]; then
+            BES="--bes_backend=grpcs://dasch.buildbuddy.io --bes_results_url=https://dasch.buildbuddy.io/invocation/ --bes_header=x-buildbuddy-api-key=$BUILDBUDDY_ORG_API_KEY --build_metadata=ROLE=CI"
+          else
+            BES=""
+          fi
+          nix develop .#llvm-tools --command bash -c "just bazel-coverage $REMOTE $BES --sandbox_debug"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6.0.0

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -90,6 +90,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
           BAZEL_CACHE_PASSWORD: ${{ secrets.BAZEL_CACHE_PASSWORD }}
+          BUILDBUDDY_ORG_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
         # `nix develop --command` mirrors `sanitizer.yml`'s wrapper — it
         # activates the dev shell so bazelisk + `gh` (used by the kakadu
         # repository_rule) + the foreign_cc host tools (`cmake`, `perl`,
@@ -102,7 +103,12 @@ jobs:
           else
             REMOTE=""
           fi
-          nix develop --command bash -c "just bazel-build-fuzz $REMOTE"
+          if [ -n "$BUILDBUDDY_ORG_API_KEY" ]; then
+            BES="--bes_backend=grpcs://dasch.buildbuddy.io --bes_results_url=https://dasch.buildbuddy.io/invocation/ --bes_header=x-buildbuddy-api-key=$BUILDBUDDY_ORG_API_KEY --build_metadata=ROLE=CI"
+          else
+            BES=""
+          fi
+          nix develop --command bash -c "just bazel-build-fuzz $REMOTE $BES"
 
       - name: Prepare live corpus (merge previous-run findings)
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,6 +52,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
           BAZEL_CACHE_PASSWORD: ${{ secrets.BAZEL_CACHE_PASSWORD }}
+          BUILDBUDDY_ORG_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
         # See ci.yml for the `nix develop --command` rationale (foreign_cc
         # host-tool PATH).
         run: |
@@ -61,7 +62,12 @@ jobs:
           else
             REMOTE=""
           fi
-          nix develop --command bash -c "just bazel-docker-build-${{ matrix.arch }} $REMOTE"
+          if [ -n "$BUILDBUDDY_ORG_API_KEY" ]; then
+            BES="--bes_backend=grpcs://dasch.buildbuddy.io --bes_results_url=https://dasch.buildbuddy.io/invocation/ --bes_header=x-buildbuddy-api-key=$BUILDBUDDY_ORG_API_KEY --build_metadata=ROLE=CI"
+          else
+            BES=""
+          fi
+          nix develop --command bash -c "just bazel-docker-build-${{ matrix.arch }} $REMOTE $BES"
       # `:docker_smoke` rust_test loads the OCI tarball produced by
       # `//src:image_load` and runs the smoke suite against it. The Docker
       # image already loaded by the build step above is left alone.
@@ -69,6 +75,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
           BAZEL_CACHE_PASSWORD: ${{ secrets.BAZEL_CACHE_PASSWORD }}
+          BUILDBUDDY_ORG_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
         run: |
           if [ -n "$BAZEL_CACHE_PASSWORD" ]; then
             CACHE_HOST=bazel-cache-proxy-pbjdzenira-uc.a.run.app
@@ -76,7 +83,12 @@ jobs:
           else
             REMOTE=""
           fi
-          nix develop --command bash -c "just bazel-test-smoke $REMOTE"
+          if [ -n "$BUILDBUDDY_ORG_API_KEY" ]; then
+            BES="--bes_backend=grpcs://dasch.buildbuddy.io --bes_results_url=https://dasch.buildbuddy.io/invocation/ --bes_header=x-buildbuddy-api-key=$BUILDBUDDY_ORG_API_KEY --build_metadata=ROLE=CI"
+          else
+            BES=""
+          fi
+          nix develop --command bash -c "just bazel-test-smoke $REMOTE $BES"
 
   release-gate:
     runs-on: ubuntu-latest
@@ -136,6 +148,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
           BAZEL_CACHE_PASSWORD: ${{ secrets.BAZEL_CACHE_PASSWORD }}
+          BUILDBUDDY_ORG_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
         # Binary version + OCI image tag come from version.txt, which
         # release-please updates before cutting the tag — no extra
         # plumbing required to keep them in sync with `${github.ref_name}`.
@@ -147,10 +160,16 @@ jobs:
           else
             REMOTE=""
           fi
-          nix develop --command bash -c "just bazel-docker-build-${{ matrix.arch }} $REMOTE"
+          if [ -n "$BUILDBUDDY_ORG_API_KEY" ]; then
+            BES="--bes_backend=grpcs://dasch.buildbuddy.io --bes_results_url=https://dasch.buildbuddy.io/invocation/ --bes_header=x-buildbuddy-api-key=$BUILDBUDDY_ORG_API_KEY --build_metadata=ROLE=CI"
+          else
+            BES=""
+          fi
+          nix develop --command bash -c "just bazel-docker-build-${{ matrix.arch }} $REMOTE $BES"
       - name: Extract debug symbols for Sentry upload
         env:
           BAZEL_CACHE_PASSWORD: ${{ secrets.BAZEL_CACHE_PASSWORD }}
+          BUILDBUDDY_ORG_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
         # The genrule depends on `:sipi`, already built and in the
         # remote cache from the build step just above.
         run: |
@@ -160,11 +179,17 @@ jobs:
           else
             REMOTE=""
           fi
-          nix develop --command bash -c "just bazel-docker-extract-debug ${{ matrix.arch }} $REMOTE"
+          if [ -n "$BUILDBUDDY_ORG_API_KEY" ]; then
+            BES="--bes_backend=grpcs://dasch.buildbuddy.io --bes_results_url=https://dasch.buildbuddy.io/invocation/ --bes_header=x-buildbuddy-api-key=$BUILDBUDDY_ORG_API_KEY --build_metadata=ROLE=CI"
+          else
+            BES=""
+          fi
+          nix develop --command bash -c "just bazel-docker-extract-debug ${{ matrix.arch }} $REMOTE $BES"
       - name: Run Docker smoke tests
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
           BAZEL_CACHE_PASSWORD: ${{ secrets.BAZEL_CACHE_PASSWORD }}
+          BUILDBUDDY_ORG_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
         run: |
           if [ -n "$BAZEL_CACHE_PASSWORD" ]; then
             CACHE_HOST=bazel-cache-proxy-pbjdzenira-uc.a.run.app
@@ -172,10 +197,16 @@ jobs:
           else
             REMOTE=""
           fi
-          nix develop --command bash -c "just bazel-test-smoke $REMOTE"
+          if [ -n "$BUILDBUDDY_ORG_API_KEY" ]; then
+            BES="--bes_backend=grpcs://dasch.buildbuddy.io --bes_results_url=https://dasch.buildbuddy.io/invocation/ --bes_header=x-buildbuddy-api-key=$BUILDBUDDY_ORG_API_KEY --build_metadata=ROLE=CI"
+          else
+            BES=""
+          fi
+          nix develop --command bash -c "just bazel-test-smoke $REMOTE $BES"
       - name: Push image to Docker Hub
         env:
           BAZEL_CACHE_PASSWORD: ${{ secrets.BAZEL_CACHE_PASSWORD }}
+          BUILDBUDDY_ORG_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
         run: |
           if [ -n "$BAZEL_CACHE_PASSWORD" ]; then
             CACHE_HOST=bazel-cache-proxy-pbjdzenira-uc.a.run.app
@@ -183,7 +214,12 @@ jobs:
           else
             REMOTE=""
           fi
-          nix develop --command bash -c "just bazel-docker-push-${{ matrix.arch }} $REMOTE"
+          if [ -n "$BUILDBUDDY_ORG_API_KEY" ]; then
+            BES="--bes_backend=grpcs://dasch.buildbuddy.io --bes_results_url=https://dasch.buildbuddy.io/invocation/ --bes_header=x-buildbuddy-api-key=$BUILDBUDDY_ORG_API_KEY --build_metadata=ROLE=CI"
+          else
+            BES=""
+          fi
+          nix develop --command bash -c "just bazel-docker-push-${{ matrix.arch }} $REMOTE $BES"
 
       - name: Docker Scout — record production
         uses: docker/scout-action@v1

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -134,12 +134,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
           BAZEL_CACHE_PASSWORD: ${{ secrets.BAZEL_CACHE_PASSWORD }}
+          BUILDBUDDY_ORG_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
         run: |
           if [ -n "$BAZEL_CACHE_PASSWORD" ]; then
             CACHE_HOST=bazel-cache-proxy-pbjdzenira-uc.a.run.app
             REMOTE="--remote_cache=grpcs://$CACHE_HOST:443 --experimental_remote_downloader=grpcs://$CACHE_HOST:443 --experimental_remote_downloader_local_fallback --credential_helper=$CACHE_HOST=$GITHUB_WORKSPACE/tools/bazel-cred-helper.sh --remote_upload_local_results=true"
           else
             REMOTE=""
+          fi
+          if [ -n "$BUILDBUDDY_ORG_API_KEY" ]; then
+            BES="--bes_backend=grpcs://dasch.buildbuddy.io --bes_results_url=https://dasch.buildbuddy.io/invocation/ --bes_header=x-buildbuddy-api-key=$BUILDBUDDY_ORG_API_KEY --build_metadata=ROLE=CI"
+          else
+            BES=""
           fi
           nix develop .#llvm-tools --command bash -c "
             export ASAN_SYMBOLIZER_PATH=\$(command -v llvm-symbolizer)
@@ -148,7 +154,7 @@ jobs:
               --flaky_test_attempts=//test/e2e-rust:latency@3 \
               --flaky_test_attempts=//test/e2e-rust:iiif_compliance@3 \
               --flaky_test_attempts=//test/e2e-rust:resource_limits@3 \
-              $REMOTE"
+              $REMOTE $BES"
 
       - name: dump foreign_cc Make.log files on failure
         if: failure()

--- a/docs/src/development/ci.md
+++ b/docs/src/development/ci.md
@@ -274,6 +274,50 @@ gcloud storage du gs://dasch-bazel-cache --readable-sizes
 gcloud storage ls gs://dasch-bazel-cache --recursive | head
 ```
 
+## Build Event Service (BuildBuddy)
+
+CI publishes a Bazel **Build Event Service (BES)** stream to
+`dasch.buildbuddy.io` for every invocation. BES is read-only build-event
+mirroring (invocation timeline, action graph, per-test logs, failure
+stderr); it does not affect caching or build execution.
+
+Each Bazel-running workflow step appends a `$BES` flag string to its
+`just bazel-*` invocation when the repo secret `BUILDBUDDY_ORG_API_KEY`
+is set:
+
+```
+--bes_backend=grpcs://dasch.buildbuddy.io
+--bes_results_url=https://dasch.buildbuddy.io/invocation/
+--bes_header=x-buildbuddy-api-key=$BUILDBUDDY_ORG_API_KEY
+--build_metadata=ROLE=CI
+```
+
+Bazel prints `Streaming build results to:
+https://dasch.buildbuddy.io/invocation/<uuid>` near the start of the
+build; that URL renders the action graph, target timings, and per-test
+output for that invocation.
+
+**Fork PRs.** GitHub does not expose secrets to forked-PR runs, so
+`BUILDBUDDY_ORG_API_KEY` is empty and `$BES=""` — Bazel runs without
+publishing. Mirrors the existing `$REMOTE` fork-safety gate.
+
+**Why not in `.bazelrc`.** Bazel does not expand env vars in
+`.bazelrc`, so the API-key-bearing flag cannot live there. Splitting
+the static URLs into `.bazelrc` and the API key into the workflow
+would leave `.bazelrc` in a half-configured state where local builds
+attempt to publish to BuildBuddy without credentials. Keeping all
+three flags together in the workflow keeps the convention consistent
+with the cache wiring above. `--bes_header` (BES-scoped) is used in
+preference to `common --remote_header` so the BuildBuddy key does not
+attach to bazel-remote / downloader gRPC streams, which authenticate
+through `tools/bazel-cred-helper.sh`.
+
+**Out of scope here.** Caching stays on bazel-remote on Cloud Run; RBE
+is not used. Future workstreams may collapse cache + BES + RBE under a
+single BuildBuddy endpoint, at which point a single `common
+--remote_header=x-buildbuddy-api-key=…` line replaces all three
+auth paths.
+
 ## Local reproduction
 
 Every CI step invokes `just <recipe>` — there are no inline


### PR DESCRIPTION
## Motivation

We want to evaluate BuildBuddy as a build observability layer for SIPI's Bazel pipeline. Today CI surfaces build/test results only through GitHub Actions logs — adequate for green runs, but inverted action graphs, target-level timing, and per-test stderr require scrolling through monolithic log files. This PR wires the **publish-only** first step: stream Bazel Build Event Service events to `dasch.buildbuddy.io` so every CI invocation produces a clickable invocation URL with timeline, action graph, and per-target test output. Caching and execution stay on the existing `bazel-remote` on Cloud Run path; no behaviour change to PR latency or cost.

If BES output proves valuable, follow-up workstreams will (a) migrate caching from `bazel-remote` to BuildBuddy and (b) trial RBE.

## Summary

- Every Bazel-running CI step now publishes to `https://dasch.buildbuddy.io/invocation/<uuid>` when the repo secret `BUILDBUDDY_ORG_API_KEY` is present.
- Fork PRs are unaffected (no secret → no BES publishing, matching the existing `$REMOTE` cold-run gate).
- No changes to cache, build-graph, or `just` recipes.

## Key Changes

### Workflows — `$BES` injection, parallel to `$REMOTE`
Each Bazel-running step gains a `BUILDBUDDY_ORG_API_KEY` env var and a sibling shell-variable block:

```bash
if [ -n "$BUILDBUDDY_ORG_API_KEY" ]; then
  BES="--bes_backend=grpcs://dasch.buildbuddy.io --bes_results_url=https://dasch.buildbuddy.io/invocation/ --bes_header=x-buildbuddy-api-key=$BUILDBUDDY_ORG_API_KEY --build_metadata=ROLE=CI"
else
  BES=""
fi
```

Then `$BES` is appended to the `just bazel-*` invocation alongside `$REMOTE`. Touches:

- `ci.yml` — "Build + run all tests", "Run Docker smoke tests" (2 steps)
- `coverage.yml` — "Build + run all tests under coverage" (1 step)
- `sanitizer.yml` — "Run e2e tests under ASan + UBSan" (1 step)
- `fuzz.yml` — "Build fuzz target" only; "Run fuzzer" deliberately skipped (long libFuzzer execution, no `$REMOTE` today)
- `publish.yml` — 5 steps across `validate-docker` + `publish-docker`

The `just` recipes already forward `*FLAGS` verbatim to `bazel`, so no recipe changes are required.

### `.bazelrc`
Comment-only addition: a sibling block to the existing remote-cache convention explaining why BES flags live in workflow env rather than `.bazelrc`. No flag lines added or changed.

### `docs/src/development/ci.md`
New top-level "Build Event Service (BuildBuddy)" section between the cache topology and "Local reproduction". Documents the publishing model, the secret name, fork-PR behaviour, and the why-not-in-`.bazelrc` rationale.

## Challenges and Decisions

### Where the flags live: `.bazelrc` vs. workflow env
**Problem:** BuildBuddy's quickstart recommends three lines in `.bazelrc` (`build --bes_backend=…`, `build --bes_results_url=…`, `common --remote_header=x-buildbuddy-api-key=API_KEY`). Bazel does not expand environment variables inside `.bazelrc`, so the API-key-bearing line cannot live there literally.

**Tried:** Splitting the two static lines into `.bazelrc` and the secret-bearing line into the workflow. This would leave `.bazelrc` half-configured: any local Bazel invocation would attempt to stream events to BuildBuddy without credentials, producing auth-failed warnings on every developer build.

**Solution:** Keep all three flags together in the workflow env, parallel to the existing `$REMOTE` cache pattern. This matches the convention already documented in `.bazelrc` lines 382–396 (and extended in this PR) and keeps `.bazelrc` cache- and BES-backend-agnostic for local builds. If we later move caching to BuildBuddy too, a single `common --remote_header=…` line can replace both auth paths.

### Header scope: `--bes_header` vs. `common --remote_header`
**Problem:** `common --remote_header` (the quickstart form) attaches the BuildBuddy API key to every gRPC stream — BES, remote_cache, and `experimental_remote_downloader`. Our remote_cache and downloader run through `bazel-cache-proxy` on Cloud Run with a different auth scheme (Basic via `tools/bazel-cred-helper.sh`).

**Solution:** Use `--bes_header=x-buildbuddy-api-key=…` (BES-scoped) so the BuildBuddy key never appears on cache or downloader traffic. The cache backend would ignore it today, but keeping the streams separated avoids surprising header-handling interactions and keeps the seam clean for the future caching migration.

### Rollout scope
**Considered:** Trial on `ci.yml` only first, expand later. **Chose:** All 5 workflows at once. The diff is repetitive but small (~10 lines per step), `$BES` defaults to empty when the secret is absent so the change is fork-safe, and partial coverage would obscure invocations from coverage / sanitizer / fuzz / release builds — exactly the runs where BES observability is most valuable.

## Gotchas

- **`tools/bazel-cred-helper.sh` is unchanged.** It still authenticates only the bazel-remote cache stream. If a future change migrates caching to BuildBuddy, the helper goes away — do not extend it to handle BuildBuddy's `x-buildbuddy-api-key` header; use `common --remote_header` instead at that point.
- **`--build_metadata=ROLE=CI`** is set on every invocation. If we later add a separate metadata channel for the GitHub run URL, branch, or actor, append additional `--build_metadata=KEY=VALUE` flags rather than overwriting `ROLE`.
- **Fuzz "Run fuzzer" step has no `$BES`.** It runs `bazel run` on a pre-built libFuzzer binary for the full fuzz duration; publishing an invocation that's mostly idle execution time would be misleading. Revisit if we ever want fuzz-run timelines surfaced in BuildBuddy.
- **The `$BES` quoting depends on the `bash -c "…"` wrapper.** The current `nix develop --command bash -c "just bazel-* $REMOTE $BES …"` pattern is safe because `--bes_header=x-buildbuddy-api-key=<key>` contains no spaces and `--build_metadata=ROLE=CI` contains no shell-special characters. Any future addition that adds a space (e.g. `--build_metadata="SOURCE=GitHub Actions"`) will need explicit re-quoting, like the existing cache-auth flow's workaround for `--remote_header=Authorization=Basic <b64>` documented in `docs/src/development/ci.md`.

## Test Plan

- [x] `bazelisk info` — `.bazelrc` parses; no unknown-flag warnings
- [x] `bazelisk build --nobuild //src/cli:sipi` — full target graph (31060 targets) analyses cleanly
- [x] `yq eval .` on all 5 edited workflows — all valid YAML
- [x] Shell-expansion dry-run — `$BES` populates when secret is present, empty otherwise
- [x] PR CI run — confirm "Build + run all tests" log shows `--bes_backend=grpcs://dasch.buildbuddy.io …` appended after the existing `--remote_cache=…` flags
- [x] Bazel prints `Streaming build results to: https://dasch.buildbuddy.io/invocation/<uuid>` on stderr; URL loads with action graph + test results
- [ ] Fork-PR safety — confirm a forked PR or branch with empty `BUILDBUDDY_ORG_API_KEY` runs cleanly with `$BES=""`, no `--bes_header` validation error
- [ ] Cache untouched — `bazel-cache-proxy` Cloud Run request counts unchanged from baseline
- [ ] Failure-mode payoff — trigger a deliberate test failure; confirm failing test stderr is visible inside the BuildBuddy invocation page

🤖 Generated with [Claude Code](https://claude.com/claude-code)