### PR TITLE
ci(dependabot): add Bazel ecosystem and unify grouping policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,34 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "nix" # See documentation for possible values
-    directory: "/" # Location of package manifests
+    commit-message:
+      prefix: "build"
+      include: "scope"
+    groups:
+      github-actions-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "nix"
+    directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "build"
+      include: "scope"
+    groups:
+      nix-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
   - package-ecosystem: "cargo"
     directory: "/test/e2e-rust"
     schedule:
@@ -21,14 +45,33 @@ updates:
       prefix: "build"
       include: "scope"
     groups:
-       backend-dependencies:
-          applies-to: version-updates
-          patterns:
-            - "*"
+      backend-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
     ignore:
       # These are peer deps of Cargo and should not be automatically bumped
       - dependency-name: "semver"
       - dependency-name: "crates-io"
       # Ignore major updates for all dependencies
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "bazel"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "build"
+      include: "scope"
+    groups:
+      bazel-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
+    ignore:
+      # Majors require manual review against MODULE.bazel's override comments
+      # (prometheus-cpp patch, rules_go / rules_android floors driven by
+      # protobuf 34.1, BCR repacks).
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Motivation

`.github/dependabot.yml` watches `github-actions`, `nix`, and `cargo` but not Bazel — even though `MODULE.bazel` pins ~14 `bazel_dep` entries resolved from the Bazel Central Registry (`platforms`, `rules_cc`, `aspect_bazel_lib`, `rules_foreign_cc`, `prometheus-cpp`, `protobuf`, `rules_go`, `rules_android`, `toolchains_llvm`, `rules_oci`, `rules_distroless`, `tar.bzl`, `rules_rust`, `googletest`).

GitHub's Dependabot landed a production-ready `bazel` ecosystem in late 2025 (dependabot-core PRs #13265 / #13286 / #13370 / #13467; epic #2196 closed 2025-12-01). It reads `MODULE.bazel` + `MODULE.bazel.lock` and opens PRs for `bazel_dep` bumps. This PR turns it on for SIPI and normalises the three pre-existing entries to the same shape `cargo` already uses, so every ecosystem behaves consistently.

## Summary

- New `bazel` ecosystem entry pointing at the repo root.
- `github-actions` and `nix` gain the same `commit-message`, `groups`, and major-update `ignore` policy that `cargo` already has.
- One grouped weekly PR per ecosystem with `build(deps): ...` subjects.

## Key Changes

### New `bazel` ecosystem
- `directory: "/"`, weekly schedule.
- Single grouped PR via `bazel-dependencies.patterns: ["*"]`.
- Majors ignored — they need manual review against the override comments in `MODULE.bazel` (the `single_version_override` patch on `prometheus-cpp`, the `rules_go` / `rules_android` floors driven by protobuf 34.1, BCR repacks).

### Unified policy for the other ecosystems
- `github-actions` and `nix` now carry `commit-message: { prefix: build, include: scope }`, a `*-dependencies` group, and the same `version-update:semver-major` ignore.
- `cargo` block is unchanged semantically; its `backend-dependencies` indentation was incidentally normalised from 7/10/12-space to 6/8/10-space (the prior file was syntactically valid but visually misleading).

### Out of scope (intentional)
`http_archive` entries in `MODULE.bazel` are not covered by Dependabot's `bazel` ecosystem and stay as manual bumps — the inline comments in `MODULE.bazel` document the bump procedure for each (ext/* libs, FFmpeg static, Chromium sysroots, distroless digest, ApprovalTests.cpp, Kakadu).

## Challenges and Decisions

### Scope of the new ecosystem
**Problem:** Dependabot's `bazel` ecosystem only handles BCR-resolved `bazel_dep` entries, not `http_archive` pins. SIPI uses both.
**Decision:** Add the `bazel` ecosystem for BCR coverage and leave `http_archive` pins manual. The pins are already documented inline in `MODULE.bazel` with per-block bump procedures (URL refresh + sha256). A future evaluation of Renovate (which supports `http_archive` via custom managers) is a separate workstream.

### Whether to ignore specific overrides individually
**Problem:** Three deps carry deliberate override floors (`prometheus-cpp` via `single_version_override` + patch, `rules_go` and `rules_android` pinned to dodge protobuf 34.1's transitive bring-in).
**Decision:** Don't add per-dep ignores. CI failure on a broken patch or override-floor regression is the load-bearing signal the comments already describe ("Drop this override when …" / "Drop this single_version_override when …"). Adding per-dep ignores would mute the signal.

### Commit-message uniformity
**Problem:** Three of four entries lacked `commit-message`, producing inconsistent subjects.
**Decision:** Apply `build(deps): …` to all ecosystems. `build` is in the project's Conventional Commit prefix list (per `CLAUDE.md`) and release-please treats it as non-release-triggering.

## Gotchas

- The first Dependabot run after merge will likely produce **four** grouped PRs (one per ecosystem) since the grouping window resets. Subsequent weeks settle into a single PR per ecosystem only when there's something to bump.
- If a `bazel-dependencies` PR ever lists `prometheus-cpp`, `rules_go`, or `rules_android`, re-read the corresponding override block in `MODULE.bazel` before merging — the override may now be droppable.
- `MODULE.bazel.lock` is updated automatically by Dependabot when bumping `bazel_dep` entries; CI must pass `just bazel-build` + `just bazel-coverage` on the bumped lockfile.

## Test Plan

- [x] `yq-go` round-trips the file and reports the expected four ecosystems with the expected groups and commit-prefix.
- [ ] Post-merge: GitHub's `dependabot.yml` parser shows green in **Insights → Dependency graph → Dependabot**.
- [ ] Post-merge: first weekly tick produces grouped PRs titled `build(deps): bump <ecosystem>-dependencies group with N updates`.
- [ ] First Bazel-group PR: CI green (`just bazel-build` + `just bazel-coverage` exercise the bumped versions and refreshed `MODULE.bazel.lock`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)