### PR TITLE
build(bazel): re-enable compiler/linker hardening

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -85,21 +85,46 @@ build:linux --dynamic_mode=off
 # link actions where neither side of the alias is yet linked, producing
 # `--defsym:1: symbol not found: strtol`.
 
-# ── Hardening neutralization ───────────────────────────────────────────────
-# Mirrors the historic flake.nix `hardeningDisable = [ "all" ]` for the
-# subset that doesn't conflict with Bazel's default link mode. PIE/PIC
-# *are* enabled — `cc_test` on Linux defaults to dynamic linking, which
-# requires PIC code to link transitive cc_library `.so` outputs (e.g.
-# `prometheus-cpp+//core:libcore.so`). Disabling PIE on linux-aarch64
-# specifically broke the link because toolchains_llvm's static `libc++.a`
-# carries non-PIC relocations.
-build --copt=-U_FORTIFY_SOURCE
-build --copt=-fno-stack-protector
-build --host_copt=-U_FORTIFY_SOURCE
-build --host_copt=-fno-stack-protector
+# ── Hardening (production target binary) ───────────────────────────────────
+# Re-enables stack-protector-strong, fortify-source, stack-clash protection,
+# and BindNow for the publicly-deployed sipi binary (DEV-6282). PIE/PIC are
+# already on by toolchain default since DEV-6348.
+#
+# Host config is deliberately left unhardened — host-built tools (e.g.
+# libmagic's `file` bootstrap that generates magic.mgc, protoc, etc.) are
+# never deployment artifacts, and `-D_FORTIFY_SOURCE=2` conflicts with
+# libmagic 5.47's `file.h:666` (glibc's `__dprintf_chk` fortified macro vs
+# libmagic's own dprintf-related declaration). Hardening host tools adds
+# no security value, so the simpler course is to keep host config clean.
+#
+# Sanitizer (`--config=asan`/`--config=ubsan`) and fuzz (`--config=fuzz`)
+# builds keep target hardening off — `_FORTIFY_SOURCE=2` intercepts the
+# same libc functions ASan does (memcpy/memmove/etc.), and the
+# instrumentation already subsumes the stack canary's intent. The
+# per-config overrides further down ensure those compile lines do NOT
+# carry the new hardening flags.
+build --copt=-fstack-protector-strong
+build --copt=-D_FORTIFY_SOURCE=2
 
-build:linux --copt=-fno-stack-clash-protection
-build:linux --host_copt=-fno-stack-clash-protection
+# Target build of libmagic 5.47 hits the same glibc fortify-header
+# conflict that breaks host config. Undef FORTIFY for libmagic source
+# files only; stack-protector is fine — the conflict is fortify-specific.
+# This is the per-dep narrowing escape hatch the DEV-6282 plan called out:
+# narrow per-dep rather than rolling back hardening globally.
+#
+# Substring `libmagic` (no anchor / regex escapes) is used deliberately —
+# Bazel's `.bazelrc` parser treats `\+` in anchored forms like
+# `^external/libmagic\+/...$` as a literal that fails to match the source
+# path (verified via aquery), while the same anchored form works when
+# passed via shell-quoted command-line `--per_file_copt='…'`. The
+# substring is unambiguous: no other source path in the build graph
+# contains the string "libmagic".
+build --per_file_copt=libmagic@-U_FORTIFY_SOURCE
+
+# Linux-only: stack-clash-protection is a clang-on-Linux feature (warns on
+# darwin); `-Wl,-z,now` is ELF/GNU-ld syntax not understood by ld64.
+build:linux --copt=-fstack-clash-protection
+build:linux --linkopt=-Wl,-z,now
 
 # ── macOS ──────────────────────────────────────────────────────────────────
 # Pin the deployment target so Bazel-built binaries are portable across
@@ -256,6 +281,19 @@ common --repo_env=ANDROID_HOME=
 # unaffected — they don't go through cmake; their `-fsanitize=…`
 # reaches them via the `--per_file_copt` block above.
 
+# Neutralize the production hardening flags (`build --copt=…` block above)
+# for sanitizer builds. `_FORTIFY_SOURCE=2` intercepts the same libc
+# functions ASan does (memcpy/memmove/etc.), causing duplicate-symbol or
+# poisoned-memory conflicts; stack-protector is subsumed by ASan's
+# stack-frame redzones. The `--copt` flags below are appended AFTER the
+# global `build --copt=…` block, and the compiler's "last wins" precedence
+# (for `-U_FORTIFY_SOURCE` after `-D_FORTIFY_SOURCE=2`, and
+# `-fno-stack-protector` after `-fstack-protector-strong`) yields a clean
+# un-hardened compile line. Verified via
+#   bazel aquery --config=asan 'mnemonic("CppCompile", //src/cli:sipi)'
+# 2026-05-26.
+build:asan --copt=-U_FORTIFY_SOURCE
+build:asan --copt=-fno-stack-protector
 build:asan --compilation_mode=dbg
 build:asan --strip=never
 build:asan --copt=-fno-omit-frame-pointer
@@ -274,6 +312,9 @@ build:asan --linkopt=-fsanitize=address
 # every leak in one report rather than needing N reruns.
 test:asan --test_env=ASAN_OPTIONS=detect_leaks=1:halt_on_error=0:log_path=$TEST_UNDECLARED_OUTPUTS_DIR/asan-e2e
 
+# Neutralize production hardening for UBSan — same rationale as `build:asan`.
+build:ubsan --copt=-U_FORTIFY_SOURCE
+build:ubsan --copt=-fno-stack-protector
 build:ubsan --compilation_mode=dbg
 build:ubsan --strip=never
 build:ubsan --copt=-fno-omit-frame-pointer
@@ -370,6 +411,10 @@ build:ubsan --linkopt=-fno-sanitize=vptr
 # `--platforms` is set by the justfile recipe (per-host; see above), not
 # here — `.bazelrc` cannot pick a platform based on `uname`, but the
 # recipe can.
+# Neutralize production hardening for fuzz — same rationale as `build:asan`
+# (fuzz inherits ASan instrumentation; fortify conflict is identical).
+build:fuzz --copt=-U_FORTIFY_SOURCE
+build:fuzz --copt=-fno-stack-protector
 build:fuzz --per_file_copt=^(src|shttps|fuzz|test)/.*\.(cpp|cc|cxx|c|mm)$@-fsanitize=fuzzer-no-link
 build:fuzz --per_file_copt=^(src|shttps|fuzz|test)/.*\.(cpp|cc|cxx|c|mm)$@-fsanitize-coverage=trace-cmp
 build:fuzz --per_file_copt=^(src|shttps|fuzz|test)/.*\.(cpp|cc|cxx|c|mm)$@-fsanitize=address

--- a/bazel/kakadu.BUILD.bazel
+++ b/bazel/kakadu.BUILD.bazel
@@ -129,19 +129,35 @@ make(
         #      adds the lib search path, but explicit LIBRARY_PATH ensures
         #      it survives any wrapper post-processing.
         "LIBCXX_DIR=$$(printf '%s\\n' \"$${NIX_LDFLAGS:-}\" | tr ' ' '\\n' | grep -E '^-L.*libcxx[^/]*/lib$$' | head -1 | sed 's/^-L//' || true) && " +
+        # Hardening flags for kakadu (DEV-6282). Bazel's `--copt` flow
+        # never reaches kakadu's compile lines — its hand-written
+        # `Makefile-*-gcc` files use their own `CXXFLAGS_ADD` and ignore
+        # foreign_cc-forwarded CFLAGS/CXXFLAGS. The wrapper synthesized
+        # below intercepts `$(CC)`/`$(CXX)` invocations so we can inject
+        # hardening flags one level above the Makefile.
+        #
+        # `-fstack-clash-protection` is clang-on-Linux only (warns on
+        # darwin's clang), so it is gated by `uname -s`. `-fstack-protector-strong`
+        # and `-D_FORTIFY_SOURCE=2` apply uniformly across both platforms.
+        # Sanitizer/fuzz Bazel configs do not propagate here (kakadu is
+        # never sanitized — first-party --per_file_copt scoping leaves it
+        # alone), so kakadu carries hardening unconditionally; the ASan
+        # runtime's libc interposition handles `__*_chk` symbols cleanly.
         "case \"$$(uname -s)\" in " +
         "  Linux) SYSROOT_DIR=$$(find $$EXT_BUILD_ROOT/external -maxdepth 1 -type d -name '+sysroot+sysroot_linux_*' 2>/dev/null | head -1); " +
-        "          [ -n \"$$SYSROOT_DIR\" ] && SYSROOT_FLAG=\"--sysroot=$$SYSROOT_DIR/sysroot\" || SYSROOT_FLAG=\"\" ;; " +
-        "  *)     SYSROOT_FLAG=\"\" ;; " +
+        "          [ -n \"$$SYSROOT_DIR\" ] && SYSROOT_FLAG=\"--sysroot=$$SYSROOT_DIR/sysroot\" || SYSROOT_FLAG=\"\"; " +
+        "          HARDENING_FLAGS=\"-fstack-protector-strong -D_FORTIFY_SOURCE=2 -fstack-clash-protection\" ;; " +
+        "  *)     SYSROOT_FLAG=\"\"; " +
+        "          HARDENING_FLAGS=\"-fstack-protector-strong -D_FORTIFY_SOURCE=2\" ;; " +
         "esac && " +
-        "echo \"kakadu: LIBCXX_DIR=$$LIBCXX_DIR SYSROOT_FLAG=$$SYSROOT_FLAG\" && " +
+        "echo \"kakadu: LIBCXX_DIR=$$LIBCXX_DIR SYSROOT_FLAG=$$SYSROOT_FLAG HARDENING_FLAGS=$$HARDENING_FLAGS\" && " +
         "export LIBRARY_PATH=\"$$LIBCXX_DIR$${LIBRARY_PATH:+:$$LIBRARY_PATH}\" && " +
-        # Synthesize a wrapper that prepends the sysroot flag so kakadu's
-        # `$(CC) -c file.cpp` lines pick it up. Make CLI vars must be a
-        # single token, so `make CC=\"clang++ --sysroot=…\"` won't work —
-        # make would split on whitespace.
+        # Synthesize a wrapper that prepends the sysroot + hardening flags
+        # so kakadu's `$(CC) -c file.cpp` lines pick them up. Make CLI
+        # vars must be a single token, so `make CC=\"clang++ --sysroot=…\"`
+        # won't work — make would split on whitespace.
         "WRAPPER=$$BUILD_TMPDIR/bazel_cxx_wrapper.sh && " +
-        "printf '%s\\n' '#!/bin/bash' \"exec clang++ $$SYSROOT_FLAG \\\"\\$$@\\\"\" > \"$$WRAPPER\" && " +
+        "printf '%s\\n' '#!/bin/bash' \"exec clang++ $$SYSROOT_FLAG $$HARDENING_FLAGS \\\"\\$$@\\\"\" > \"$$WRAPPER\" && " +
         "chmod +x \"$$WRAPPER\" && " +
         "make -j1 -f " + _KDU_MAKE + " EXEC_PLATFORM=" + _KDU_EXEC_PLATFORM + " CC=\"$$WRAPPER\" CXX=\"$$WRAPPER\" all_but_jni && " +
         "mkdir -p $$INSTALLDIR/lib $$INSTALLDIR/include && " +

--- a/docs/src/development/bazel.md
+++ b/docs/src/development/bazel.md
@@ -179,7 +179,9 @@ For Linux-target builds from a macOS host, see
 - [`MODULE.bazel`](https://github.com/dasch-swiss/sipi/blob/main/MODULE.bazel)
   — module manifest + every third-party `http_archive` pin
 - [`.bazelrc`](https://github.com/dasch-swiss/sipi/blob/main/.bazelrc)
-  — flag defaults, sanitizer/fuzz configs, hardening neutralization
+  — flag defaults, sanitizer/fuzz configs, production hardening
+  (stack-protector-strong, _FORTIFY_SOURCE=2, stack-clash-protection,
+  BindNow) with per-config exemptions for asan/ubsan/fuzz
 - [`tools/workspace_status.sh`](https://github.com/dasch-swiss/sipi/blob/main/tools/workspace_status.sh)
   — emits `STABLE_*` keys consumed by `expand_template` and
   `oci_image`'s stamping

--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,17 @@
             }:
             pkgs.mkShell.override { inherit stdenv; } {
               inherit name;
+              # `hardeningDisable` applies only to nixpkgs' wrapper around the
+              # dev-shell's compiler. It does NOT affect Bazel actions, which
+              # run under toolchains_llvm with their own compile flags
+              # (production hardening: -fstack-protector-strong,
+              # -D_FORTIFY_SOURCE=2, -fstack-clash-protection on Linux,
+              # -Wl,-z,now; see `.bazelrc` "Hardening (production target
+              # binary)" block). The disable here remains for the dev shell
+              # itself: ad-hoc `nix develop`-driven compiles, shell hooks,
+              # and tools that link via Nix's wrapped clang. Keeping it off
+              # matches the historical setting and avoids surprising
+              # interactions for one-off builds done outside Bazel.
               hardeningDisable = [ "all" ];
               packages = commonPackages ++ extraPackages;
               shellHook = ''export PS1="\\u@\\h | ${name}> "'' + commonShellHook;


### PR DESCRIPTION
Fixes DEV-6282

## Motivation

The Nix→Bazel migration (DEV-6341 / DEV-6348) restored PIE/PIC but explicitly deferred re-enabling the rest of the production hardening — stack-protector-strong, fortify-source, stack-clash-protection, and BindNow — because the cutover's success criterion was byte-for-byte parity with the deleted Nix build, not security progress.

SIPI is a publicly-exposed IIIF media server that parses attacker-controlled images and metadata. Stack canaries, fortified libc wrappers, stack-clash probes, and full RELRO are standard production-hardening flags for C/C++ binaries and reduce the impact of unmitigated memory-safety bugs in our image-format parsers (kakadu, libtiff, libpng, libjpeg, libwebp) and libmagic (file-type detection on uploads).

## Summary

- Production sipi binary now ships with `-fstack-protector-strong`, `-D_FORTIFY_SOURCE=2`, `-fstack-clash-protection` (Linux), and `-Wl,-z,now` (Linux Full RELRO).
- Hardening reaches every dep statically linked into the binary, including kakadu (JP2 decoder) which uses an unusual hand-written-Makefile build path that does not consume foreign_cc-forwarded CFLAGS.
- Sanitizer (`--config=asan`/`--config=ubsan`) and fuzz (`--config=fuzz`) builds keep hardening off so instrumentation does not conflict with fortify's libc-symbol interception.

## Key Changes

### `.bazelrc`
- Global `build --copt=-fstack-protector-strong` and `--copt=-D_FORTIFY_SOURCE=2`.
- Linux-only `build:linux --copt=-fstack-clash-protection` and `--linkopt=-Wl,-z,now`.
- `build:asan`, `build:ubsan`, `build:fuzz` each get `-U_FORTIFY_SOURCE` + `-fno-stack-protector` exemptions via compiler last-wins precedence.
- Per-file libmagic exemption: `build --per_file_copt=libmagic@-U_FORTIFY_SOURCE`.

### `bazel/kakadu.BUILD.bazel`
- The kakadu Makefile wrapper synthesised in `postfix_script` now injects hardening flags into the `clang++` exec line. `-fstack-clash-protection` is gated by `uname -s` because clang-on-darwin warns on the flag.

### `flake.nix`
- Comment clarifies that `hardeningDisable = ["all"]` is scoped to dev-shell ad-hoc compiles only; it does not affect Bazel actions.

### `docs/src/development/bazel.md`
- Refreshed the `.bazelrc` one-line description from "hardening neutralization" to the new production-hardening posture.

## Challenges and Decisions

### libmagic 5.47 conflicts with glibc `_FORTIFY_SOURCE=2`

**Problem:** Initial commit enabled hardening globally and broke all three Linux CI jobs identically with:
```
external/libmagic+/src/file.h:666:5: error: conflicting types for '__dprintf_chk'
```
The failing action was host-config (`[for tool]`) — libmagic's `file_bootstrap` runs at build time to generate `magic.mgc`.

**Tried:** Dropping fortify globally would lose security across the entire deployment binary. Patching the BCR libmagic module would block on upstream coordination.

**Solution:** Two narrowings. First, drop host-config hardening entirely — host tools never ship, so hardening them adds no security value while triggering the libmagic conflict. Second, target build of libmagic hits the same conflict (glibc is on the target sysroot too); a `--per_file_copt=libmagic@-U_FORTIFY_SOURCE` rule narrows the exemption to libmagic source files only via compiler last-wins precedence. Captured in [dasch-specs learnings/build-errors/bazel-fortify-source-libmagic-glibc-conflict.md](https://github.com/dasch-swiss/dasch-specs/blob/main/learnings/build-errors/bazel-fortify-source-libmagic-glibc-conflict.md).

### Bazel `.bazelrc` silently drops anchored-regex `--per_file_copt` rules

**Problem:** The first attempt at the libmagic exemption used an anchored regex (`^external/libmagic\+/.*\.c$@-U_FORTIFY_SOURCE`) by analogy with the existing first-party scoping rule. `bazel aquery` revealed the rule was silently dropped — no warning, no error, just no effect.

**Tried:** Four candidate filter forms tested side-by-side via shell-quoted command-line `--per_file_copt='…'`. Three out of four worked, including the anchored `\+` form. The same anchored form failed only when placed in `.bazelrc`.

**Solution:** Bazel 9.0.2's `.bazelrc` parser handles `\+` in anchored regex filters differently than shell argument parsing. Using a substring filter (`libmagic`) without anchors or escapes works in both contexts. Captured in [dasch-specs learnings/best-practices/bazel-per-file-copt-bazelrc-parsing.md](https://github.com/dasch-swiss/dasch-specs/blob/main/learnings/best-practices/bazel-per-file-copt-bazelrc-parsing.md).

### kakadu's wrapper-based build path silently excludes Bazel `--copt` flags

**Problem:** Review surfaced that kakadu's hand-written `Makefile-*-gcc` files use their own `CXXFLAGS_ADD` and do not consume foreign_cc-forwarded `CFLAGS`/`CXXFLAGS`. The hardening claim in the PR body — "publicly-deployed sipi binary" — would have silently excluded the JP2 decoder, which is the highest-value remaining attack surface after libmagic.

**Tried:** Patching kakadu's Makefiles upstream is impractical (proprietary, no patch source). Detecting the build path via Bazel `select()` would need new per-platform variants.

**Solution:** The `postfix_script` wrapper synthesises a `clang++` invocation that already prepends `--sysroot`. Extend the same wrapper to also inject `-fstack-protector-strong`, `-D_FORTIFY_SOURCE=2` (all platforms), and `-fstack-clash-protection` (Linux only, via the same `uname -s` case statement that gates the sysroot).

## Gotchas

- **Sanitizer/fuzz hardening neutralization relies on clang's "last wins" precedence.** Bazel guarantees the resolution order of base `build --copt` followed by per-config `build:asan --copt`. The neutralization in turn relies on clang treating later `-U_FORTIFY_SOURCE` / `-fno-stack-protector` as overriding earlier `-D_FORTIFY_SOURCE=2` / `-fstack-protector-strong`. This is de-facto correct for LLVM 19 (current toolchain) but is not a Bazel-guaranteed property. If the toolchain ever switches to GCC or a different LLVM major, re-verify via `bazel aquery --config=asan 'mnemonic("CppCompile", //src/cli:sipi)'`.
- **`--per_file_copt=libmagic@…` is a substring match.** It matches any source path containing the string `libmagic`. The build graph today has no other such path, but a future test fixture, generated header, or wrapper file with `libmagic` in its name would silently inherit the fortify exemption. Add an `aquery` regression check in CI if libmagic-adjacent files become common.
- **Adding new hardening flags requires three coordinated edits.** Production hardening in `.bazelrc` reaches all BCR cc_library deps and most rules_foreign_cc deps automatically, but it does NOT reach kakadu (wrapper override) and may not reach future deps with similarly unusual build paths. When adding a new hardening flag, audit `bazel/kakadu.BUILD.bazel` and any future custom-make wrapper alongside `.bazelrc`.
- **Host config is intentionally unhardened.** Do not propagate hardening to `--host_copt` without re-verifying every BCR / foreign_cc dep's host build (libmagic 5.47 is the known conflict but others may surface).
- **No `checksec` gate in CI yet.** The Test Plan below verifies hardening locally; a future follow-up should add a CI step that runs `checksec --output=json` on the Linux `-c opt` binary and asserts the expected flags, preventing silent regressions.

## Test Plan

- [x] `ci.yml` test matrix green on darwin-aarch64, linux-x86_64, linux-aarch64
- [x] `sanitizer.yml` green — verified via aquery that ASan/UBSan compile lines end with `-U_FORTIFY_SOURCE` + `-fno-stack-protector` (last-wins neutralization)
- [x] `fuzz.yml` green — same neutralization applied to `build:fuzz`
- [x] Docker image (`//src:image`) builds and the smoke test passes
- [x] `just bazel-coverage` produces lcov on linux-amd64
- [x] `nm bazel-bin/src/cli/sipi` on darwin-aarch64: 7301 `__stack_chk_fail` call sites; 8 distinct `__*_chk` fortify symbols (`memcpy`, `memmove`, `memset`, `strcat`, `strcpy`, `strlcat`, `strlcpy`, `strncpy`)
- [x] `nm` on the kakadu archive shows 56 stack-canary references (was 0 pre-change), confirming the wrapper injection reached kakadu
- [x] `otool -hv bazel-bin/src/cli/sipi` on darwin: PIE flag set
- [ ] `checksec --file=bazel-bin/src/cli/sipi` on Linux `-c opt` (CI runner): STACK CANARY ✓, NX ✓, RELRO Full ✓, FORTIFY ✓, PIE ✓, BindNow ✓ — to be verified manually after CI green; follow-up to add as automated gate

Closes DEV-6282.