### PR TITLE
feat(cli): add `sipi health` subcommand for container healthchecks

### DIFF
--- a/docs/src/guide/running.md
+++ b/docs/src/guide/running.md
@@ -11,7 +11,7 @@ docker run -p 1024:1024 daschswiss/sipi
 ## Running SIPI as a Command-line Image Converter
 
 SIPI now uses verb-noun subcommands (`convert`, `query`, `compare`,
-`verify`, `server`) instead of the legacy `--convert` / `--query` /
+`verify`, `server`, `health`) instead of the legacy `--convert` / `--query` /
 `--compare` / `--file` / `--outf` flags. A bare `sipi` invocation
 errors with a usage message — every operation needs an explicit
 subcommand.
@@ -39,6 +39,30 @@ sipi compare file1.tif file2.jpg
 ```bash
 sipi server --config config/sipi.config.lua
 ```
+
+## Health Check
+
+`sipi health` is a self-contained liveness probe. It performs an HTTP `GET` on
+the local [`/health`](../operation/health-endpoint.md) endpoint and maps the
+result to a process exit code, following the Docker/Swarm healthcheck
+convention:
+
+- **0** — the endpoint returned HTTP 200 (healthy).
+- **1** — connection refused, timeout, or any non-200 response (unhealthy).
+
+```bash
+sipi health            # probes http://127.0.0.1:1024/health
+sipi health --port 80  # probe a server running on a different port
+```
+
+The host is always `127.0.0.1` and the path is always `/health`; only the port
+is configurable. A separate `sipi health` process cannot know whether the
+running server took its port from a config file, an env var, or `--serverport`,
+so the caller passes the port it configured (`--port`, default `1024`). The
+probe uses a short (~2 s) timeout so a wedged server reports unhealthy rather
+than hanging. Because it needs no `curl` in the image, it is the intended
+container/orchestrator liveness command (see
+[Health Endpoint](../operation/health-endpoint.md)).
 
 ## Logging
 
@@ -257,6 +281,10 @@ whether the conversion succeeded:
 
 **Important for calling services:** Always check the exit code. A non-zero exit code
 means the output file was not produced (or is incomplete).
+
+The `sipi health` subcommand follows the same convention: **0** = healthy
+(`/health` returned 200), **1** = unhealthy (connection refused, timeout, or
+non-200).
 
 ### Error Output
 

--- a/docs/src/guide/sipi.md
+++ b/docs/src/guide/sipi.md
@@ -78,6 +78,17 @@ is ignored for comparison:
 /path/to/sipi compare file1 file2
 ```
 
+#### Health Check
+Probe a running SIPI server's `/health` endpoint and exit `0` (healthy) or `1`
+(unhealthy). Used as the container/orchestrator liveness command:
+
+```bash
+/path/to/sipi health [--port <n>]   # default port 1024
+```
+
+See [Running SIPI](running.md) and [Health Endpoint](../operation/health-endpoint.md)
+for details.
+
 #### General Options for the Command Line Use 
 In command line mode, SIPI supports the following options:
 

--- a/docs/src/operation/health-endpoint.md
+++ b/docs/src/operation/health-endpoint.md
@@ -12,18 +12,28 @@ Returns JSON with server status, version, and uptime:
 - **Method**: GET only
 - **Route**: Registered before the catch-all IIIF handler
 
-## Docker Swarm HEALTHCHECK
+## Healthcheck Ownership
 
-The image (built from `flake.nix` via `pkgs.dockerTools.streamLayeredImage`)
-declares the equivalent of:
+The image does **not** embed a Docker `HEALTHCHECK`. `HEALTHCHECK` is a
+Docker-specific extension, not part of the OCI image spec, so the Bazel
+`rules_oci` image carries none. Liveness is owned by the orchestration layer —
+the docker-compose / Swarm `healthcheck:` stanza (provisioned in ops-deploy,
+INFRA-1226):
 
+```yaml
+healthcheck:
+  test: ["CMD", "/sbin/sipi", "health", "--port", "1024"]
+  interval: 30s
+  timeout: 5s
+  start_period: 10s
+  retries: 3
 ```
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD curl -sf http://localhost:1024/health || exit 1
-```
 
-The actual encoding is in `flake.nix` under `config.Healthcheck`
-(durations in nanoseconds).
+The check uses the self-contained
+[`sipi health`](../guide/running.md#health-check) subcommand, which probes
+`http://127.0.0.1:1024/health` and exits `0` (healthy) or `1` (unhealthy).
+Because the probe is a sipi subcommand, the image needs no `curl` binary for the
+healthcheck.
 
 **Swarm behavior**: Docker Swarm has a single HEALTHCHECK — no separate liveness/readiness probes. When HEALTHCHECK fails after `retries`, Swarm kills and replaces the container. The `start_period` gives 10s for initialization (failures don't count, but container *receives traffic* during this period).
 

--- a/src/cli/commands/BUILD.bazel
+++ b/src/cli/commands/BUILD.bazel
@@ -13,6 +13,7 @@ Today's commands:
     `cmd_convert_access_file(ConvertAccessFileArgs)`
   * `sipi verify [access-file|service-file]` → `verify.{h,cpp}` →
     `cmd_verify(VerifyArgs)`
+  * `sipi health` → `health.{h,cpp}` → `cmd_health(HealthArgs)`
 
 The `:commands` cc_library is consumed by `//src/cli:sipi` (the binary
 target) and by `:commands_test` (the co-located unit tests).
@@ -27,11 +28,13 @@ cc_library(
     srcs = [
         "convert_access_file.cpp",
         "convert_service_file.cpp",
+        "health.cpp",
         "verify.cpp",
     ],
     hdrs = [
         "convert_access_file.h",
         "convert_service_file.h",
+        "health.h",
         "verify.h",
     ],
     copts = ["-fexceptions"],
@@ -50,6 +53,7 @@ cc_test(
     srcs = [
         "convert_access_file_test.cpp",
         "convert_service_file_test.cpp",
+        "health_test.cpp",
         "verify_test.cpp",
     ],
     data = ["//test/_test_data:images"],

--- a/src/cli/commands/health.cpp
+++ b/src/cli/commands/health.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2016 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+ * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "cli/commands/health.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+#include <curl/curl.h>
+
+namespace Sipi::cli {
+
+namespace {
+
+// Swallow the response body so it never lands on stdout — only the exit code
+// matters for a healthcheck.
+size_t discard_body(char *, size_t size, size_t nmemb, void *) { return size * nmemb; }
+
+}// namespace
+
+int cmd_health(const HealthArgs &args)
+{
+  // `curl_global_init` is performed by LibraryInitialiser in main() before any
+  // subcommand callback fires, so a plain `curl_easy_init` is safe here.
+  const std::string url = "http://127.0.0.1:" + std::to_string(args.port) + "/health";
+
+  CURL *curl = curl_easy_init();
+  if (curl == nullptr) {
+    std::fprintf(stderr, "health: failed to initialise HTTP client\n");
+    return EXIT_FAILURE;
+  }
+
+  curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+  curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+  curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, 1000L);
+  curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, 2000L);// fail fast; never hang the probe
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, discard_body);
+
+  const CURLcode rc = curl_easy_perform(curl);
+  long status = 0;
+  if (rc == CURLE_OK) { curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status); }
+  curl_easy_cleanup(curl);
+
+  if (rc != CURLE_OK) {
+    std::fprintf(stderr, "health: %s failed: %s\n", url.c_str(), curl_easy_strerror(rc));
+    return EXIT_FAILURE;
+  }
+  if (status != 200) {
+    std::fprintf(stderr, "health: %s returned HTTP %ld\n", url.c_str(), status);
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}
+
+}// namespace Sipi::cli

--- a/src/cli/commands/health.h
+++ b/src/cli/commands/health.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2016 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+ * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#ifndef SIPI_CLI_COMMANDS_HEALTH_H
+#define SIPI_CLI_COMMANDS_HEALTH_H
+
+namespace Sipi::cli {
+
+/*!
+ * Arguments for `sipi health`.
+ *
+ * The probe target is always `http://127.0.0.1:<port>/health` — the host
+ * (loopback, no resolver dependency) and the path are fixed; only the port
+ * is configurable. A separate `sipi health` process cannot know whether the
+ * running server got its port from a config file, an env var, or
+ * `--serverport`, so the caller (who configured the server) passes the port
+ * it knows. Default `1024` matches the conventional sipi port and the image's
+ * `exposed_ports`.
+ */
+struct HealthArgs
+{
+  int port = 1024;
+};
+
+/*!
+ * Run `sipi health`: GET `http://127.0.0.1:<port>/health` and map the result
+ * to a process exit code, following the Docker/Swarm healthcheck convention.
+ *
+ *   - `EXIT_SUCCESS` (0) — the endpoint returned HTTP 200 (healthy).
+ *   - `EXIT_FAILURE` (1) — connection refused, timeout, or any non-200
+ *                          response (unhealthy).
+ */
+[[nodiscard]] int cmd_health(const HealthArgs &args);
+
+}// namespace Sipi::cli
+
+#endif

--- a/src/cli/commands/health_test.cpp
+++ b/src/cli/commands/health_test.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2026 Swiss National Data and Service Center for the Humanities
+ * and/or DaSCH Service Platform contributors. SPDX-License-Identifier:
+ * AGPL-3.0-or-later
+ */
+
+// Health subcommand unit tests.
+//
+// The OK path (server returns 200 → exit 0) is covered end-to-end by the Rust
+// e2e suite (`test/e2e-rust/tests/health.rs`) and the Docker smoke test, both
+// of which have a live server to probe. Here we cover the NOK path
+// hermetically: with nothing listening on the target port, `cmd_health` must
+// return EXIT_FAILURE.
+//
+// Unlike the CLI binary, this test does not go through `LibraryInitialiser`,
+// so it performs `curl_global_init` / `curl_global_cleanup` itself.
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+
+#include <curl/curl.h>
+
+#include "cli/commands/health.h"
+
+namespace {
+
+class HealthTest : public ::testing::Test
+{
+protected:
+  void SetUp() override { curl_global_init(CURL_GLOBAL_ALL); }
+  void TearDown() override { curl_global_cleanup(); }
+};
+
+// Nothing listens on port 1 → connection refused → unhealthy.
+TEST_F(HealthTest, ReturnsFailureWhenNothingListening)
+{
+  EXPECT_EQ(Sipi::cli::cmd_health(Sipi::cli::HealthArgs{ .port = 1 }), EXIT_FAILURE);
+}
+
+}// namespace

--- a/src/cli/sipi.cpp
+++ b/src/cli/sipi.cpp
@@ -36,6 +36,7 @@
 #include "logging/logger.h"
 #include "cli/commands/convert_access_file.h"
 #include "cli/commands/convert_service_file.h"
+#include "cli/commands/health.h"
 #include "cli/commands/verify.h"
 #include "SipiConf.h"
 #include "observability/connection_metrics_adapter.h"
@@ -1640,6 +1641,18 @@ int main(int argc, char *argv[])
   cmd_compare->add_option("files", optCompare, "Two files to compare.")->expected(2);
   attach_output_opts(cmd_compare);
   cmd_compare->callback([&]() { exit(run_compare()); });
+
+  // ----- health ----------------------------------------------------------
+  // Self-contained liveness probe for container/orchestrator healthchecks:
+  // GET http://127.0.0.1:<port>/health, exit 0 if healthy, 1 otherwise. The
+  // caller passes the port the server was configured with (`--port`); a
+  // separate process can't discover it from config/env/flags.
+  int optHealthPort = 1024;
+  CLI::App *cmd_health = sipiopt.add_subcommand(
+    "health", "Probe the local /health endpoint; exit 0 if healthy, 1 otherwise.");
+  cmd_health->add_option("--port", optHealthPort, "Port the sipi server listens on.")
+    ->check(CLI::Range(1, 65535));
+  cmd_health->callback([&]() { exit(Sipi::cli::cmd_health({ optHealthPort })); });
 
   CLI11_PARSE(sipiopt, argc, argv);
 

--- a/test/e2e-rust/tests/docker_smoke.rs
+++ b/test/e2e-rust/tests/docker_smoke.rs
@@ -269,3 +269,18 @@ fn docker_image_health_endpoint() {
     assert!(body["version"].is_string(), "version should be present");
     assert!(body["uptime_seconds"].is_number(), "uptime_seconds should be present");
 }
+
+// The `sipi health` subcommand run *inside* the container — the exact command
+// the orchestration-layer healthcheck uses (no `curl` dependency). The server
+// listens on 1024 (the image default), so zero-arg `health` probes it and
+// exits 0. `docker exec` of an explicit binary path needs no shell, so the
+// distroless image is fine.
+#[test]
+fn docker_image_health_subcommand() {
+    let container = DockerContainer::start();
+    let status = Command::new("docker")
+        .args(["exec", &container.id, "/sbin/sipi", "health"])
+        .status()
+        .expect("docker exec sipi health failed");
+    assert!(status.success(), "in-container `sipi health` should exit 0 against a healthy server");
+}

--- a/test/e2e-rust/tests/health.rs
+++ b/test/e2e-rust/tests/health.rs
@@ -1,6 +1,8 @@
 mod common;
 
 use common::{client, server};
+use sipi_e2e::sipi_bin_path;
+use std::process::Command;
 
 #[test]
 fn health_returns_200_with_json() {
@@ -34,4 +36,27 @@ fn health_responds_quickly() {
 
     assert_eq!(resp.status().as_u16(), 200);
     assert!(elapsed.as_millis() < 100, "health should respond within 100ms, took {}ms", elapsed.as_millis());
+}
+
+// `sipi health` against a live server returns exit 0 (healthy). The `--port`
+// flag lets the probe target the harness's ephemeral server port.
+#[test]
+fn health_subcommand_exits_zero_when_healthy() {
+    let srv = server();
+    let status = Command::new(sipi_bin_path())
+        .args(["health", "--port", &srv.http_port.to_string()])
+        .status()
+        .expect("failed to run sipi health");
+    assert!(status.success(), "sipi health should exit 0 against a healthy server");
+}
+
+// `sipi health` with nothing listening returns exit 1 (unhealthy). Port 1 is
+// never bound, so the connection is refused.
+#[test]
+fn health_subcommand_exits_one_when_no_server() {
+    let status = Command::new(sipi_bin_path())
+        .args(["health", "--port", "1"])
+        .status()
+        .expect("failed to run sipi health");
+    assert_eq!(status.code(), Some(1), "sipi health should exit 1 when nothing is listening");
 }


### PR DESCRIPTION
Relates to INFRA-1226 (ops-deploy side moves the HEALTHCHECK to the compose stanza).

## Motivation

The sipi image is moving toward pure-OCI output (Bazel `rules_oci`, `@distroless_base`). OCI has no `HEALTHCHECK` field, so liveness must move to the orchestration layer (the compose / Swarm `healthcheck:` stanza — INFRA-1226). Today that healthcheck shells out to `curl -sf http://localhost:1024/health`, and the image bundles the `/usr/bin/curl` CLI via the `@bookworm//:flat` apt layer **solely** for that purpose (`MODULE.bazel:195-197`).

This change adds the sipi-side capability that lets the healthcheck drop `curl`: a self-contained `sipi health` subcommand. The compose stanza can then become `["CMD", "/sbin/sipi", "health", "--port", "1024"]`, and the bundled curl CLI can be removed later (smaller runtime surface, fewer CVEs).

## Summary

- New `sipi health` subcommand: probes `http://127.0.0.1:<port>/health` and exits **0 = healthy / 1 = unhealthy** (Docker/Swarm convention).
- `--port` (default `1024`) is the only knob; host (`127.0.0.1`) and path (`/health`) are fixed.
- No `curl` needed in the image for healthchecks.

## Key Changes

### Subcommand
- `src/cli/commands/health.{h,cpp}` — `cmd_health(HealthArgs)`, following the existing per-command pattern (ADR-0003).
- `src/cli/sipi.cpp` — `--port` option (range-checked 1–65535) + subcommand registration.
- libcurl GET with a ~2s connect+total timeout, response body discarded, short stderr diagnostic on failure (surfaces in `docker inspect`'s `Health.Log`).

### Tests
- `src/cli/commands/health_test.cpp` — NOK path (closed port → exit 1), hermetic; inits libcurl itself since it doesn't go through `LibraryInitialiser`.
- `test/e2e-rust/tests/health.rs` — OK path (`health --port <ephemeral>` against the live harness server → 0) and NOK path (→ 1).
- `test/e2e-rust/tests/docker_smoke.rs` — `docker exec <id> /sbin/sipi health` inside the running container (server on 1024) — the exact production healthcheck command.

### Docs
- `docs/src/guide/running.md`, `docs/src/guide/sipi.md`, `docs/src/operation/health-endpoint.md` updated (subcommand list, Health Check sections, replaced the stale flake.nix/curl HEALTHCHECK section with the compose-ownership model).

## Challenges and Decisions

### How does a separate process learn the server's port?
**Problem:** `sipi health` is a fresh process; it can't read the running server's bound port from memory. The port can come from a config file, an env var, or `--serverport`.
**Tried:** auto-discovery — read the same config file via `SipiConf`, or read `SIPI_SERVERPORT`, or have the server publish a portfile. Each couples health to one specific port source or adds new machinery/failure modes.
**Solution:** an explicit `--port` (default 1024). The healthcheck author, who configured the server, passes the port they know. Explicit over magic; no config parsing, no portfile. As a bonus, the flag makes the binary directly testable against the ephemeral-port e2e harness.

### Why no image-level HEALTHCHECK?
OCI has no such field and `rules_oci` emits none — that is the premise of INFRA-1226. Liveness is owned by the compose stanza, intentionally not added in `src/BUILD.bazel`.

## Gotchas

- **Sequencing:** dropping `/usr/bin/curl` from the `@bookworm` apt install (`MODULE.bazel`) is a follow-up that must land **only after** INFRA-1226 switches the compose healthcheck to `sipi health`. Removing it now would break the still-curl-based check. Do not touch the apt layer in this PR.
- `sipi`'s outbound HTTP uses **libcurl** (the shared library) — unaffected. This is only about the `/usr/bin/curl` CLI binary.
- Host is hardcoded to `127.0.0.1` (not `localhost`) to avoid any hostname-resolver dependency in distroless.

## Test Plan

- [x] `just bazel-build`
- [x] Manual: `sipi health --port 1` → exit 1; live server on 1024 → exit 0; `--port 70000` rejected; `--help` correct
- [x] `just bazel-test-unit` (15/15, incl. `commands_test` → `HealthTest`)
- [x] full e2e suite (23/23, incl. new `health` binary tests)
- [x] `just bazel-coverage` (39 pass, 1 skipped = docker-feature test) — ran because a `BUILD.bazel` changed, per the repo invariant
- [x] `just bazel-test-smoke` — `docker_image_health_subcommand` (runs in CI; needs a built OCI image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)