### PR TITLE
ci: pass GH_TOKEN to publish.yml Extract-debug step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -174,6 +174,10 @@ jobs:
           nix develop --command bash -c "just bazel-docker-build-${{ matrix.arch }} $REMOTE $BES"
       - name: Extract debug symbols for Sentry upload
         env:
+          # Bazel re-evaluates the kakadu_archive repository_rule on every
+          # invocation, even when :sipi is fully cached. The rule fetches
+          # from a private GitHub release and requires GH_TOKEN.
+          GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
           BAZEL_CACHE_PASSWORD: ${{ secrets.BAZEL_CACHE_PASSWORD }}
           BUILDBUDDY_ORG_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
         # The genrule depends on `:sipi`, already built and in the


### PR DESCRIPTION
## Summary

Adds the missing `GH_TOKEN` env var to the **Extract debug symbols for Sentry upload** step in `.github/workflows/publish.yml`, plus a short explanatory comment so the trap doesn't recur.

The `v5.0.0` release run [26560490536](https://github.com/dasch-swiss/sipi/actions/runs/26560490536) failed on both `publish-docker / amd64` and `publish-docker / arm64` at this step:

```
ERROR: kakadu_archive: no GH_TOKEN/GITHUB_TOKEN in env and `gh auth token` failed:
no oauth token found for github.com
ERROR: //src:sipi_debug_layout failed; build aborted: Analysis failed
```

Bazel re-evaluates the `kakadu_archive` `repository_rule` on every invocation, even when `:sipi` is fully cached from the build step just above. The rule fetches from a private GitHub release and always requires `GH_TOKEN` at analysis time. Every other Bazel step in `publish.yml` already sets `GH_TOKEN` (lines 56, 79, 155, 196); this one was the outlier.

Refs: [DEV-6572](https://linear.app/dasch/issue/DEV-6572/ci-publishyml-extract-debug-step-missing-gh-token-blocks-docker)

## Follow-up after merge

To re-release v5.0.0 without bumping the version, the `v5.0.0` tag will be moved to the fix commit (the publish workflow re-reads its YAML from the tag's commit, so `rerun --failed` against the old tag would still use the broken YAML). The existing GH Release entry will survive the tag delete/re-push cycle — body intact, auto-relinks to the new tag commit, no assets to lose.

## Test plan

- [x] Local verification: diff is 4 lines, matches the pattern used by all other Bazel steps in this file.
- [ ] After merge + tag re-push: `publish-docker / {amd64,arm64}` → Extract debug step → succeeds.
- [ ] `manifest` and `sentry` jobs run and succeed.
- [ ] `daschswiss/sipi:v5.0.0` multi-arch index visible on Docker Hub.
- [ ] Sentry release `v5.0.0` has both `sipi-amd64.debug` and `sipi-arm64.debug` symbols uploaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)