### PR TITLE
ci: hoist GH_TOKEN to job-level env in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,13 @@ jobs:
             runner: ubuntu-24.04
           - arch: arm64
             runner: ubuntu-24.04-arm
+    env:
+      # Every bazel build/run/test in this job re-evaluates the
+      # kakadu_archive repository_rule, which fetches from a private
+      # GitHub release and requires GH_TOKEN. Hoisted to the job level so
+      # any future Bazel step inherits it (cf. publish.yml history where
+      # adding it per-step caused repeated near-miss failures).
+      GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -53,7 +60,6 @@ jobs:
       # gating needed.
       - name: Build Docker image (Bazel rules_oci)
         env:
-          GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
           BAZEL_CACHE_PASSWORD: ${{ secrets.BAZEL_CACHE_PASSWORD }}
           BUILDBUDDY_ORG_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
         # See ci.yml for the `nix develop --command` rationale (foreign_cc
@@ -76,7 +82,6 @@ jobs:
       # image already loaded by the build step above is left alone.
       - name: Run Docker smoke tests
         env:
-          GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
           BAZEL_CACHE_PASSWORD: ${{ secrets.BAZEL_CACHE_PASSWORD }}
           BUILDBUDDY_ORG_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
         run: |
@@ -118,6 +123,12 @@ jobs:
             debug_file: sipi-arm64.debug
             sbom_file: sbom-arm64.spdx.json
             sbom_name: sbom-arm64
+    env:
+      # Every bazel build/run/test in this job re-evaluates the
+      # kakadu_archive repository_rule, which fetches from a private
+      # GitHub release and requires GH_TOKEN. Hoisted to the job level so
+      # any future Bazel step inherits it.
+      GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -152,7 +163,6 @@ jobs:
       # two jobs (release-please tag push).
       - name: Build Docker image (Bazel rules_oci) + sipi-debug
         env:
-          GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
           BAZEL_CACHE_PASSWORD: ${{ secrets.BAZEL_CACHE_PASSWORD }}
           BUILDBUDDY_ORG_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
         # Binary version + OCI image tag come from version.txt, which
@@ -174,10 +184,6 @@ jobs:
           nix develop --command bash -c "just bazel-docker-build-${{ matrix.arch }} $REMOTE $BES"
       - name: Extract debug symbols for Sentry upload
         env:
-          # Bazel re-evaluates the kakadu_archive repository_rule on every
-          # invocation, even when :sipi is fully cached. The rule fetches
-          # from a private GitHub release and requires GH_TOKEN.
-          GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
           BAZEL_CACHE_PASSWORD: ${{ secrets.BAZEL_CACHE_PASSWORD }}
           BUILDBUDDY_ORG_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
         # The genrule depends on `:sipi`, already built and in the
@@ -197,7 +203,6 @@ jobs:
           nix develop --command bash -c "just bazel-docker-extract-debug ${{ matrix.arch }} $REMOTE $BES"
       - name: Run Docker smoke tests
         env:
-          GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
           BAZEL_CACHE_PASSWORD: ${{ secrets.BAZEL_CACHE_PASSWORD }}
           BUILDBUDDY_ORG_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
         run: |


### PR DESCRIPTION
## Summary

Follow-up to #659. The v5.0.0 publish kept failing on the next un-`GH_TOKEN`-ed Bazel step: first **Extract debug symbols** (fixed in #659), then **Push image to Docker Hub** in run [26565201120](https://github.com/dasch-swiss/sipi/actions/runs/26565201120). Same kakadu / `repository_rule` analysis, same missing env var, same fix.

Rather than patch step #N+1 again, this PR **hoists `GH_TOKEN` to job-level env** on both `validate-docker` and `publish-docker`. Any future Bazel step in either job inherits it automatically.

```
$ grep -c 'GH_TOKEN:' .github/workflows/publish.yml
2   # down from 5; one per job
```

The benign `WARNING: Remote Cache: NOT_FOUND` Bazel stack trace seen during this run is unrelated — `experimental_remote_downloader` reports that the bazel-cache-proxy (stock buchgr/bazel-remote, no upstream auth) can't fetch the private kakadu archive on Bazel's behalf, then `--experimental_remote_downloader_local_fallback` kicks in and `kakadu_archive` downloads it directly via `gh release download` with `GH_TOKEN`. No suppression needed.

Refs: [DEV-6572](https://linear.app/dasch/issue/DEV-6572/ci-publishyml-extract-debug-step-missing-gh-token-blocks-docker)

## Follow-up after merge

v5.0.0 tag will be force-moved a second time to the fix commit; the GH Release survives identically (body intact, auto-relinks, no assets to lose).

## Test plan

- [x] Local: `grep -c 'GH_TOKEN:' .github/workflows/publish.yml` returns 2.
- [x] Local: diff is +13 / -8, all in env blocks of `publish.yml`.
- [ ] After merge + tag re-push: validate-docker + publish-docker (both arches) all green; manifest + sentry jobs run; `daschswiss/sipi:v5.0.0` multi-arch index visible; Sentry release has both debug symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)