### PR TITLE
fix(cli): shut down sentry transport before curl cleanup on all exit paths

### DIFF
--- a/src/cli/sipi.cpp
+++ b/src/cli/sipi.cpp
@@ -7,6 +7,7 @@
  * \brief Implements an IIIF server with many features.
  *
  */
+#include <cstdlib>
 #include <dirent.h>
 #include <iostream>
 #include <string>
@@ -466,6 +467,18 @@ int main(int argc, char *argv[])
     log_err("Library initialization failed: %s", e.to_string().c_str());
     return EXIT_FAILURE;
   }
+
+  // Shut down sentry's background transport thread (joined/drained by
+  // sentry_close()) before static destructors run — in particular before
+  // ~LibraryInitialiser calls curl_global_cleanup(). Registered AFTER the
+  // static LibraryInitialiser has finished construction, so per
+  // [basic.start.term] this handler runs BEFORE ~LibraryInitialiser at exit.
+  // This covers every exit path: subcommand callbacks that call exit(), a
+  // CLI11 parse error that returns from main, and normal return. Without it,
+  // curl teardown races the live sentry-http thread and corrupts the heap.
+  // (std::abort() from my_terminate_handler bypasses atexit, leaving
+  // sentry-native's inproc crash reporting intact.)
+  std::atexit([] { Sipi::observability::close_sentry(); });
 
   CLI::App sipiopt("SIPI is an IIIF image server and image format converter.");
   sipiopt.require_subcommand(1);
@@ -1656,12 +1669,10 @@ int main(int argc, char *argv[])
 
   CLI11_PARSE(sipiopt, argc, argv);
 
-  // `require_subcommand(1)` guarantees one of the subcommand callbacks
-  // fired and invoked `exit(...)`. The only way control reaches here is
-  // if CLI11 exited the program with a usage error before the callback
-  // ran — in which case we just flush sentry and return success
-  // (CLI11 has already written its own error to stderr and the user
-  // saw a non-zero exit via CLI11's own path).
-  Sipi::observability::close_sentry();
+  // Unreachable in practice: `require_subcommand(1)` means either a
+  // subcommand callback fired and called exit(), or CLI11_PARSE already
+  // returned from main with the parse-error code. Sentry teardown is handled
+  // by the std::atexit(close_sentry) registered above, which runs on every
+  // exit() / return path. Kept only to give main a return value.
   return EXIT_SUCCESS;
 }

--- a/src/observability/sentry_init.cpp
+++ b/src/observability/sentry_init.cpp
@@ -5,6 +5,7 @@
 
 #include "observability/sentry_init.h"
 
+#include <atomic>
 #include <string>
 
 #include <sentry.h>
@@ -44,6 +45,17 @@ void init_sentry(const SentryConfig &cfg)
   sentry_init(options);
 }
 
-void close_sentry() { sentry_close(); }
+void close_sentry()
+{
+  // Idempotent: only the first caller invokes sentry_close(). sentry_close()
+  // blocks until the background transport thread has drained/joined — it must
+  // complete before ~LibraryInitialiser runs curl_global_cleanup() at process
+  // exit (see the std::atexit registration in sipi.cpp). It is NULL-guarded in
+  // sentry-native (no-op when never initialised), so the flag mainly prevents
+  // a redundant shutdown attempt and its spurious warning on repeated calls.
+  static std::atomic_flag closed = ATOMIC_FLAG_INIT;
+  if (closed.test_and_set()) { return; }
+  sentry_close();
+}
 
 }// namespace Sipi::observability

--- a/test/e2e-rust/tests/cli.rs
+++ b/test/e2e-rust/tests/cli.rs
@@ -238,3 +238,69 @@ fn cli_version_flag() {
         stdout
     );
 }
+
+/// Regression test for the sentry/curl shutdown race.
+///
+/// When sipi is invoked with no subcommand AND SIPI_SENTRY_DSN is set,
+/// init_sentry() starts sentry-native's background HTTP transport thread
+/// before CLI parsing. CLI11's `require_subcommand(1)` then fails the parse
+/// and main exits — historically WITHOUT shutting sentry down, so the static
+/// ~LibraryInitialiser ran curl_global_cleanup() while the transport thread
+/// was mid-request, causing glibc heap corruption (intermittent SIGABRT or
+/// runaway allocation until OOM). The fix registers std::atexit(close_sentry)
+/// right after library init so the transport thread is joined before curl
+/// cleanup on every exit path.
+///
+/// The DSN points at an unreachable local endpoint so the transport thread is
+/// alive at exit, maximising the race window. The process must exit cleanly
+/// (not via signal) with a non-zero code and the normal usage error, and must
+/// not print any glibc memory-corruption markers.
+#[test]
+fn cli_no_subcommand_with_sentry_dsn_exits_clean() {
+    let sipi_bin = sipi_bin_path();
+
+    let result = Command::new(&sipi_bin)
+        .env("SIPI_SENTRY_DSN", "https://key@127.0.0.1:9/1")
+        .env("SIPI_SENTRY_ENVIRONMENT", "ci-regression")
+        .current_dir(repo_root())
+        .output()
+        .unwrap_or_else(|e| panic!("Failed to run sipi with no subcommand: {}", e));
+
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    let stdout = String::from_utf8_lossy(&result.stdout);
+
+    // Exited normally, not killed by SIGABRT/SIGSEGV from heap corruption.
+    assert!(
+        result.status.code().is_some(),
+        "sipi was killed by a signal ({:?}) — likely the sentry/curl shutdown race. stderr:\n{}\nstdout:\n{}",
+        result.status,
+        stderr,
+        stdout
+    );
+
+    // A missing subcommand is a usage error.
+    assert!(
+        !result.status.success(),
+        "expected non-zero exit for missing subcommand. stderr:\n{}",
+        stderr
+    );
+
+    // We reached CLI11's parse-error path, not some earlier abort.
+    assert!(
+        stderr.contains("A subcommand is required"),
+        "expected 'A subcommand is required' in stderr, got:\n{}",
+        stderr
+    );
+
+    // No glibc heap-corruption markers on either stream.
+    let combined = format!("{}{}", stderr, stdout).to_lowercase();
+    for marker in ["double free", "malloc", "corrupted", "unaligned fastbin"] {
+        assert!(
+            !combined.contains(marker),
+            "found memory-corruption marker {:?} in output:\nstderr:\n{}\nstdout:\n{}",
+            marker,
+            stderr,
+            stdout
+        );
+    }
+}


### PR DESCRIPTION
## Problem

Observed in production (vre-dev-01, since 2026-06-02): when sipi v5 is invoked **without a subcommand** and `SIPI_SENTRY_DSN` is set, the process intermittently dies with glibc heap corruption:

```
double free or corruption (!prev)
corrupted size vs. prev_size
malloc_consolidate(): unaligned fastbin chunk detected
corrupted double-linked list
```

…or instead balloons to ~4.18 GiB anon RSS on the `sentry-http` thread until the cgroup OOM killer fires (`sentry-http invoked oom-killer`, `Killed process (sipi)`).

## Root cause

- `init_sentry()` runs **before** CLI parsing and starts sentry-native's background HTTP transport thread.
- On a parse error (`require_subcommand(1)` → `RequiredError`), `CLI11_PARSE`'s catch does `return app.exit(e)` — main returns **without** `close_sentry()`. The post-parse `close_sentry()` was dead code (unreachable).
- The same gap exists on every subcommand callback: they call libc `exit()` directly, never closing sentry.
- The static `~LibraryInitialiser` then runs `curl_global_cleanup()` while the sentry transport thread is mid-request → heap corruption / runaway allocation.

## Fix

- Register `std::atexit(close_sentry)` immediately after library initialisation. Since the static `LibraryInitialiser` finishes construction before the `atexit` call, the handler runs **before** `~LibraryInitialiser` at exit ([basic.start.term]), so `sentry_close()` joins/drains the transport thread before `curl_global_cleanup()` — on every exit path: callbacks calling `exit()`, CLI11 parse errors, normal return. (`std::abort()` from `my_terminate_handler` bypasses atexit, leaving inproc crash reporting intact.)
- Make `close_sentry()` idempotent via `atomic_flag`.
- Remove the dead post-parse `close_sentry()` block.

## Test

New e2e regression test `cli_no_subcommand_with_sentry_dsn_exits_clean`: runs sipi with no args and an unreachable DSN (transport thread alive at exit), asserts clean non-signal exit, non-zero code, the CLI11 usage error, and no memory-corruption markers. Runs in the existing `//test/e2e-rust:cli` target, including under ASan/UBSan in sanitizer CI.

Verified locally: `bazel test //test/e2e-rust:cli` green (4/4); manual run exits 106 with clean stderr and no hang.

## Deployment note

The active dev crash-loop itself (wrong command line) is fixed in dasch-swiss/ops-deploy#1353. This PR removes the latent corruption for all short-lived CLI invocations with a DSN set (e.g. `query`/`convert` from dsp-ingest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)