### PR TITLE
fix(cli): sipi compare per-channel delta uses absolute difference

### DIFF
--- a/src/SipiImage.cpp
+++ b/src/SipiImage.cpp
@@ -1839,6 +1839,69 @@ std::optional<double> SipiImage::compare(const SipiImage &rhs) const
 
 /*==========================================================================*/
 
+std::optional<PixelDelta> SipiImage::maxPixelDelta(const SipiImage &rhs) const
+{
+  if ((nx != rhs.nx) || (ny != rhs.ny) || (nc != rhs.nc) || (bps != rhs.bps) || (photo != rhs.photo)) { return {}; }
+
+  // Read the raw pixel store directly in row-major order (`y * nx + x`),
+  // matching operator-= and the format handlers — NOT getPixel, whose
+  // transposed `x * nx + y` indexing is only correct for square images.
+  double sum_abs = 0.;
+  int max_abs = 0;
+  size_t max_x = 0, max_y = 0;
+
+  // Absolute per-channel difference over a signed widening of the two
+  // samples: a plain `s1 - s2` is non-negative-typed at the call site
+  // (getPixel returns int but the historical compare loop stored it in a
+  // size_t), which underflows for s2 > s1 and corrupts the maximum.
+  auto accumulate = [&](size_t x, size_t y, int s1, int s2) {
+    const int signed_diff = s1 - s2;
+    const int dv = signed_diff < 0 ? -signed_diff : signed_diff;
+    if (dv > max_abs) {
+      max_abs = dv;
+      max_x = x;
+      max_y = y;
+    }
+    sum_abs += dv;
+  };
+
+  switch (bps) {
+  case 8: {
+    const byte *ltmp = pixels;
+    const byte *rtmp = rhs.pixels;
+    for (size_t y = 0; y < ny; y++) {
+      for (size_t x = 0; x < nx; x++) {
+        for (size_t c = 0; c < nc; c++) {
+          const size_t idx = nc * (y * nx + x) + c;
+          accumulate(x, y, ltmp[idx], rtmp[idx]);
+        }
+      }
+    }
+    break;
+  }
+  case 16: {
+    const word *ltmp = reinterpret_cast<const word *>(pixels);
+    const word *rtmp = reinterpret_cast<const word *>(rhs.pixels);
+    for (size_t y = 0; y < ny; y++) {
+      for (size_t x = 0; x < nx; x++) {
+        for (size_t c = 0; c < nc; c++) {
+          const size_t idx = nc * (y * nx + x) + c;
+          accumulate(x, y, ltmp[idx], rtmp[idx]);
+        }
+      }
+    }
+    break;
+  }
+  default:
+    return {};
+  }
+
+  const double mean_abs = sum_abs / static_cast<double>(nx * ny * nc);
+  return PixelDelta{ .mean_abs = mean_abs, .max_abs = max_abs, .max_x = max_x, .max_y = max_y };
+}
+
+/*==========================================================================*/
+
 
 std::ostream &operator<<(std::ostream &outstr, const SipiImage &rhs)
 {

--- a/src/SipiImage.hpp
+++ b/src/SipiImage.hpp
@@ -114,6 +114,28 @@ enum SkipMetadata : std::uint8_t {
 enum InfoError { INFO_ERROR };
 
 /*!
+ * \struct PixelDelta
+ *
+ * Per-channel absolute pixel-difference statistics between two images,
+ * as reported by the `sipi compare` command. `max_abs` is the largest
+ * |sample₁ − sample₂| across all pixels and channels, located at
+ * (`max_x`, `max_y`); `mean_abs` is the mean |Δ| over every sample.
+ *
+ * NOTE: `max_x`/`max_y` are codec-store (row-major `y * nx + x`)
+ * coordinates, matching the pixel layout used by `operator-=` and the
+ * format handlers. They are NOT compatible with `getPixel`/`setPixel`,
+ * which index transposed as `x * nx + y`; do not feed them back into
+ * those accessors.
+ */
+struct PixelDelta
+{
+  double mean_abs;//!< mean absolute per-channel difference
+  int max_abs;//!< maximum absolute per-channel difference
+  size_t max_x;//!< x coordinate of the maximum absolute difference (codec-store order)
+  size_t max_y;//!< y coordinate of the maximum absolute difference (codec-store order)
+};
+
+/*!
  * \class SipiImage
  *
  * Base class for all images in the Sipi package.
@@ -586,6 +608,19 @@ public:
    * \returns Returns similarity index, returns in [0..1]
    */
   std::optional<double> compare(const SipiImage &rhs) const;
+
+  /*!
+   * Computes the per-channel absolute pixel-difference statistics against
+   * another image. Unlike `operator-=` (which rescales the signed diff into
+   * a displayable visualization), this reads the raw samples and reports the
+   * true mean and maximum |Δ| plus the location of the maximum. Used by
+   * `sipi compare` as the codec-rebaseline tolerance metric.
+   *
+   * \param[in] rhs image to compare against
+   * \returns the difference statistics, or nullopt if the images are not
+   *          comparable (differing dimensions, channels, bit depth, or photometric interpretation)
+   */
+  [[nodiscard]] std::optional<PixelDelta> maxPixelDelta(const SipiImage &rhs) const;
 
   /*!
    * Add a watermark to a file...

--- a/src/cli/sipi.cpp
+++ b/src/cli/sipi.cpp
@@ -865,37 +865,33 @@ int main(int argc, char *argv[])
     Sipi::SipiImage img1, img2;
     img1.read(optCompare[0]);
     img2.read(optCompare[1]);
-    bool result = img1 == img2;
 
-    if (!result) {
-      img1 -= img2;
-      img1.write("tif", "diff.tif");
-    }
-
-    if (result) {
+    if (img1 == img2) {
       log_info("Files identical!");
-    } else {
-      double diffval = 0.;
-      size_t maxdiff = 0;
-      size_t max_x = 0, max_y = 0;
-      for (size_t y = 0; y < img1.getNy(); y++) {
-        for (size_t x = 0; x < img1.getNx(); x++) {
-          for (size_t c = 0; c < img1.getNc(); c++) {
-            size_t dv = img1.getPixel(x, y, c) - img2.getPixel(x, y, c);
-            if (dv > maxdiff) {
-              maxdiff = dv;
-              max_x = x;
-              max_y = y;
-            }
-            diffval += static_cast<float>(dv);
-          }
-        }
-      }
-      diffval /= static_cast<double>(img1.getNy() * img1.getNx() * img1.getNc());
-      log_info("Files differ: avg: %f max: %zu (%zu, %zu) See diff.tif", diffval, maxdiff, max_x, max_y);
+      return 0;
     }
 
-    return result ? 0 : -1;
+    // Capture the per-channel delta from the original pixels before the
+    // `img1 -= img2` visualization step below rewrites img1 into the
+    // normalized diff (which would otherwise corrupt the reported avg/max).
+    const std::optional<Sipi::PixelDelta> delta = img1.maxPixelDelta(img2);
+
+    if (!delta.has_value()) {
+      // Differing channel count / bit depth / photometric interpretation:
+      // no meaningful per-channel delta, and `img1 -= img2` would throw.
+      log_info("Files differ: dimensions or format not comparable.");
+      return -1;
+    }
+
+    img1 -= img2;
+    img1.write("tif", "diff.tif");
+    log_info("Files differ: avg: %f max: %d (%zu, %zu) See diff.tif",
+      delta->mean_abs,
+      delta->max_abs,
+      delta->max_x,
+      delta->max_y);
+
+    return -1;
   };
 
   //

--- a/test/unit/sipiimage/pixel_delta_regression_test.cpp
+++ b/test/unit/sipiimage/pixel_delta_regression_test.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2016 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+ * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Regression test — `SipiImage::maxPixelDelta` (the metric behind the
+ * `sipi compare` command). The original `run_compare` loop computed the
+ * per-channel difference as `size_t dv = img1.getPixel(...) - img2.getPixel(...)`,
+ * an unsigned subtraction that underflows to a huge value whenever the
+ * second image's sample is larger — corrupting the reported max and avg.
+ * These tests assert the true *absolute* delta is reported for diffs in
+ * BOTH directions (some pixels brighter, some darker), so a regression to
+ * the unsigned form would produce an enormous max and fail loudly.
+ */
+
+#include <gtest/gtest.h>
+
+#include "../../../src/SipiImage.hpp"
+
+namespace {
+
+using Sipi::PhotometricInterpretation;
+using Sipi::PixelDelta;
+using Sipi::SipiImage;
+
+// `setPixel`/`getPixel` index pixels as `x * nx + y`, whereas the pixel
+// store (and `maxPixelDelta`) is row-major `y * nx + x`. The two are
+// transposes of one another, so the (max_x, max_y) reported for a value
+// written via setPixel(a, b) comes back as (b, a). Placing the maximum on
+// the diagonal (x == y) makes the location assertion transpose-invariant.
+
+TEST(MaxPixelDelta, AbsoluteDeltaBothDirections)
+{
+  constexpr size_t N = 4;
+  SipiImage img1(N, N, 1, 8, PhotometricInterpretation::MINISBLACK);
+  SipiImage img2(N, N, 1, 8, PhotometricInterpretation::MINISBLACK);
+
+  // Constructor does not zero-initialize the buffer — fill every cell.
+  for (size_t y = 0; y < N; ++y) {
+    for (size_t x = 0; x < N; ++x) {
+      img1.setPixel(x, y, 0, 100);
+      img2.setPixel(x, y, 0, 100);
+    }
+  }
+
+  // img2 brighter (the unsigned-underflow trigger): |Δ| = 190.
+  img1.setPixel(1, 0, 0, 10);
+  img2.setPixel(1, 0, 0, 200);
+  // img1 brighter: |Δ| = 150.
+  img1.setPixel(0, 1, 0, 200);
+  img2.setPixel(0, 1, 0, 50);
+  // Maximum, on the diagonal, img2 brighter: |Δ| = 250.
+  img1.setPixel(2, 2, 0, 5);
+  img2.setPixel(2, 2, 0, 255);
+
+  const std::optional<PixelDelta> delta = img1.maxPixelDelta(img2);
+  ASSERT_TRUE(delta.has_value());
+
+  // True max |Δ| is 250 — a regressed unsigned subtraction would report a
+  // value near SIZE_MAX for the 5-vs-255 pixel.
+  EXPECT_EQ(delta->max_abs, 250);
+  EXPECT_EQ(delta->max_x, 2u);
+  EXPECT_EQ(delta->max_y, 2u);
+
+  // Mean |Δ| = (190 + 150 + 250) / 16 samples = 36.875.
+  EXPECT_DOUBLE_EQ(delta->mean_abs, 590.0 / 16.0);
+}
+
+TEST(MaxPixelDelta, SixteenBitBrighterSecondImage)
+{
+  SipiImage img1(2, 2, 1, 16, PhotometricInterpretation::MINISBLACK);
+  SipiImage img2(2, 2, 1, 16, PhotometricInterpretation::MINISBLACK);
+
+  for (size_t y = 0; y < 2; ++y) {
+    for (size_t x = 0; x < 2; ++x) {
+      img1.setPixel(x, y, 0, 1000);
+      img2.setPixel(x, y, 0, 1000);
+    }
+  }
+
+  // 16-bit, img2 far brighter: |Δ| = 59000. The unsigned form underflows
+  // even more catastrophically here.
+  img1.setPixel(0, 0, 0, 1000);
+  img2.setPixel(0, 0, 0, 60000);
+
+  const std::optional<PixelDelta> delta = img1.maxPixelDelta(img2);
+  ASSERT_TRUE(delta.has_value());
+  EXPECT_EQ(delta->max_abs, 59000);
+  EXPECT_DOUBLE_EQ(delta->mean_abs, 59000.0 / 4.0);
+}
+
+TEST(MaxPixelDelta, IdenticalImagesReportZero)
+{
+  SipiImage img1(3, 3, 1, 8, PhotometricInterpretation::MINISBLACK);
+  SipiImage img2(3, 3, 1, 8, PhotometricInterpretation::MINISBLACK);
+
+  for (size_t y = 0; y < 3; ++y) {
+    for (size_t x = 0; x < 3; ++x) {
+      img1.setPixel(x, y, 0, 42);
+      img2.setPixel(x, y, 0, 42);
+    }
+  }
+
+  const std::optional<PixelDelta> delta = img1.maxPixelDelta(img2);
+  ASSERT_TRUE(delta.has_value());
+  EXPECT_EQ(delta->max_abs, 0);
+  EXPECT_DOUBLE_EQ(delta->mean_abs, 0.0);
+}
+
+TEST(MaxPixelDelta, IncomparableDimensionsReturnsNullopt)
+{
+  SipiImage img1(4, 4, 1, 8, PhotometricInterpretation::MINISBLACK);
+  SipiImage img2(2, 2, 1, 8, PhotometricInterpretation::MINISBLACK);
+
+  EXPECT_FALSE(img1.maxPixelDelta(img2).has_value());
+}
+
+}// namespace


### PR DESCRIPTION
[DEV-6643](https://linear.app/dasch/issue/DEV-6643)

Phase 0 of the SIPI BCR codec-migration plan — lands the verification-tooling fix before any codec golden re-baseline.

## Summary
- `sipi compare` reported a corrupt difference metric for any non-identical image pair. Two compounding defects: an unsigned-subtraction underflow (`size_t dv = getPixel - getPixel`, where `getPixel` returns `int`), and `img1 -= img2` running *before* the stats loop so the loop read the normalized diff visualization instead of the original pixels.
- Extracts the metric into `SipiImage::maxPixelDelta` (returns mean/max |Δ| + location), reading raw samples row-major and using a signed widening for the absolute difference.
- Makes `sipi compare` sound as the **tolerance gate** for the libjpeg-turbo golden re-baseline later in the migration.

## Changes
- **`SipiImage::maxPixelDelta` + `PixelDelta` struct** (`src/SipiImage.{hpp,cpp}`) — true absolute per-channel delta, 8/16-bit, `std::optional` (nullopt on incomparable channels/bit-depth/photometric interpretation).
- **`run_compare`** (`src/cli/sipi.cpp`) — computes the delta from original pixels before the `-=` visualization; reports a clean "not comparable" message instead of letting `operator-=` throw uncaught on a format mismatch.
- **Regression test** (`test/unit/sipiimage/pixel_delta_regression_test.cpp`) — both-direction diffs (the underflow trigger), 8- and 16-bit, identical, and incomparable-nullopt.

## Test Plan
- `bazel test //test/unit/sipiimage:sipi_image_tests` — full suite green (4 new `MaxPixelDelta` cases + existing).
- `just bazel-build` — green on darwin-aarch64.
- CLI smoke (`bazel-bin/src/cli/sipi compare`): identical → `Files identical!` (exit 0); differ → `avg: 3.15 max: 187 (197, 871)` (sane absolute max, exit 255); RGB-vs-GRAY → `dimensions or format not comparable.` (exit 255, no crash — previously threw uncaught).
- 3-platform CI (darwin-arm64, linux-amd64, linux-arm64) under hermetic LLVM 22 via the normal PR pipeline.

## Known follow-up
`getPixel`/`setPixel` index pixels as `x*nx+y` while the pixel store (`operator-=`, `compare()`, codec handlers, and this new method) uses row-major `y*nx+x`. They alias different memory for non-square images — a real pre-existing latent bug, tracked separately and added to the migration plan as a follow-up phase. `PixelDelta::max_x/max_y` are documented as codec-store coordinates (not `getPixel`-compatible) to avoid the trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)