### PR TITLE
build(bazel): make the build + benchmark tooling resolve cleanly in the Nix dev shell

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -6,3 +6,19 @@
 .vscode
 .direnv
 .claude
+
+# Out-of-Bazel build-output trees (also in .gitignore). These hold
+# extracted third-party sources (gtest, sentry-native's vendored
+# benchmark, …) carrying their own BUILD files that are not part of the
+# Bazel graph — without this, `bazel build //...` descends into them and
+# fails to load. Bazel is the build system; these are CMake-era leftovers.
+_build
+build
+build-linux
+build-mac
+build-fuzz
+cmake-build-debug
+cmake-build-debug-remote
+cmake-build-debug-inside-docker
+cmake-build-dockerdebug
+cmake-build-relwithdebinfo-inside-docker

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -346,6 +346,14 @@ pip.parse(
     hub_name = "sipi_bench_pip",
     python_version = "3.12",
     requirements_lock = "//tools/benchmark:requirements.txt",
+    # Use prebuilt binary wheels only (discard sdists). numpy/scipy ship
+    # cp312 wheels for every platform we target, so nothing compiles from
+    # source — which also means rules_python skips its macOS `xcrun
+    # xcodebuild` SDK probe (it only runs when building an sdist). That
+    # probe fails in the Nix dev shell, whose DEVELOPER_DIR points at the
+    # nix apple-sdk (SDK headers + xcrun, but no `xcodebuild` tool). Keeps
+    # `just bench-compare` hermetic and host-Xcode-free.
+    download_only = True,
 )
 use_repo(pip, "sipi_bench_pip")
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -343,9 +343,6 @@ python.toolchain(python_version = "3.12")
 
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip", dev_dependency = True)
 pip.parse(
-    hub_name = "sipi_bench_pip",
-    python_version = "3.12",
-    requirements_lock = "//tools/benchmark:requirements.txt",
     # Use prebuilt binary wheels only (discard sdists). numpy/scipy ship
     # cp312 wheels for every platform we target, so nothing compiles from
     # source — which also means rules_python skips its macOS `xcrun
@@ -354,6 +351,9 @@ pip.parse(
     # nix apple-sdk (SDK headers + xcrun, but no `xcodebuild` tool). Keeps
     # `just bench-compare` hermetic and host-Xcode-free.
     download_only = True,
+    hub_name = "sipi_bench_pip",
+    python_version = "3.12",
+    requirements_lock = "//tools/benchmark:requirements.txt",
 )
 use_repo(pip, "sipi_bench_pip")
 

--- a/justfile
+++ b/justfile
@@ -295,7 +295,12 @@ bench-compare before after *FLAGS='':
     set -euo pipefail
     BEFORE="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
     AFTER="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"
-    bazel run //tools/benchmark:compare -- "${@:3}" benchmarks "$BEFORE" "$AFTER"
+    # `set positional-arguments` + the `*FLAGS=''` default expand to a single
+    # empty positional when no flags are given, which compare.py would read as
+    # the (invalid) `mode`. Keep only the non-empty extra flags.
+    flags=()
+    for f in "${@:3}"; do [ -n "$f" ] && flags+=("$f"); done
+    bazel run //tools/benchmark:compare -- ${flags[@]+"${flags[@]}"} benchmarks "$BEFORE" "$AFTER"
 
 #####################################
 # Bazel Docker (rules_oci)

--- a/tools/benchmark/BUILD.bazel
+++ b/tools/benchmark/BUILD.bazel
@@ -15,6 +15,11 @@ load("@sipi_bench_pip//:requirements.bzl", "requirement")
 py_library(
     name = "gbench",
     srcs = glob(["gbench/*.py"]),
+    # `manual` keeps `bazel build //...` from analyzing this (and fetching
+    # the numpy/scipy wheels) — the bench tooling is local-dev only and its
+    # sole consumer `:compare` is itself `manual` and pulls it explicitly
+    # via `just bench-compare`.
+    tags = ["manual"],
     deps = [
         requirement("numpy"),
         requirement("scipy"),


### PR DESCRIPTION
## Summary
Three independent fixes so the build and benchmark tooling work cleanly in the Nix dev shell on macOS — none touch product code or the C++ build graph.

## Changes
- **`bazel build //...` no longer fails during package loading** (`.bazelignore`): the wildcard was walking into the stale CMake `build/` tree (pre-Bazel-migration leftover, gitignored but not bazel-ignored) and choking on extracted third-party BUILD files (gtest, sentry-native's vendored benchmark). Add the gitignored out-of-Bazel build-output dirs to `.bazelignore`.
- **`//tools/benchmark:gbench` tagged `manual`**: it was the only un-`manual` bench target left in the wildcard, inconsistent with its already-`manual` consumer `:compare`. Keeps the local-dev benchmark tooling out of `bazel build //...`.
- **Bench numpy/scipy fetched as binary wheels** (`download_only = True` on the `sipi_bench_pip` hub): rules_python's `whl_library` builds them from sdist by default, and its macOS sdist path probes `xcrun xcodebuild -showsdks` — which fails in the Nix shell (its `DEVELOPER_DIR` points at the nix apple-sdk: SDK headers + `xcrun`, but no `xcodebuild` tool). The hermetic LLVM toolchain's own macOS SDK can't help — `whl_library` is a repository rule and runs before toolchain resolution. numpy/scipy ship cp312 wheels for every platform, so `download_only` skips the probe entirely (`if not (download_only or is_wheel)`). Fully hermetic, no host Xcode.
- **`just bench-compare a b` (no flags) fixed**: `set positional-arguments` + the `*FLAGS=''` default forwarded an empty positional as compare.py's `mode`, so the documented no-flags invocation died with `argument mode: invalid choice: ''`. Filter out empty extra-flag args.

## Test Plan
- `bazel build //...` — completes (141 targets).
- `bazel build //src/... //test/...` — green (the real project, unaffected).
- `just bench-compare` — verified end-to-end under the Nix `DEVELOPER_DIR` with no host Xcode and no `--repo_env`, both with and without extra flags (cold numpy/scipy re-fetch confirmed using binary wheels, xcodebuild probe skipped).

## Note
A pre-existing `bazel mod tidy` warning about the LLVM toolchain extension's `use_repo` (`llvm-toolchain-minimal-*`) is unrelated to these changes (reproduces before this branch) and left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)