### PR TITLE
fix(image): getPixel/setPixel use row-major pixel indexing

### DIFF
--- a/src/SipiImage.cpp
+++ b/src/SipiImage.cpp
@@ -1844,8 +1844,7 @@ std::optional<PixelDelta> SipiImage::maxPixelDelta(const SipiImage &rhs) const
   if ((nx != rhs.nx) || (ny != rhs.ny) || (nc != rhs.nc) || (bps != rhs.bps) || (photo != rhs.photo)) { return {}; }
 
   // Read the raw pixel store directly in row-major order (`y * nx + x`),
-  // matching operator-= and the format handlers — NOT getPixel, whose
-  // transposed `x * nx + y` indexing is only correct for square images.
+  // matching operator-=, the format handlers, and getPixel/setPixel.
   double sum_abs = 0.;
   int max_abs = 0;
   size_t max_x = 0, max_y = 0;

--- a/src/SipiImage.hpp
+++ b/src/SipiImage.hpp
@@ -121,11 +121,9 @@ enum InfoError { INFO_ERROR };
  * |sample₁ − sample₂| across all pixels and channels, located at
  * (`max_x`, `max_y`); `mean_abs` is the mean |Δ| over every sample.
  *
- * NOTE: `max_x`/`max_y` are codec-store (row-major `y * nx + x`)
- * coordinates, matching the pixel layout used by `operator-=` and the
- * format handlers. They are NOT compatible with `getPixel`/`setPixel`,
- * which index transposed as `x * nx + y`; do not feed them back into
- * those accessors.
+ * `max_x`/`max_y` are row-major (`y * nx + x`) pixel coordinates, matching
+ * the layout used by `operator-=`, the format handlers, and
+ * `getPixel`/`setPixel` — so they may be fed back into those accessors.
  */
 struct PixelDelta
 {
@@ -288,7 +286,18 @@ public:
    */
   ~SipiImage();
 
-  int getPixel(size_t x, size_t y, size_t c)
+  /*!
+   * Gets the value of a pixel sample.
+   *
+   * Indexes the pixel buffer row-major (`nc * (y * nx + x) + c`), matching the
+   * codec store written by the format handlers and read by `maxPixelDelta`.
+   *
+   * \param[in] x X position
+   * \param[in] y Y position
+   * \param[in] c Color channel
+   * \return The sample value
+   */
+  [[nodiscard]] int getPixel(size_t x, size_t y, size_t c)
   {
     if (x >= nx) throw((int)1);
     if (y >= ny) throw((int)2);
@@ -296,11 +305,11 @@ public:
     switch (bps) {
     case 8: {
       unsigned char *tmp = (unsigned char *)pixels;
-      return static_cast<int>(tmp[nc * (x * nx + y) + c]);
+      return static_cast<int>(tmp[nc * (y * nx + x) + c]);
     }
     case 16: {
       unsigned short *tmp = (unsigned short *)pixels;
-      return static_cast<int>(tmp[nc * (x * nx + y) + c]);
+      return static_cast<int>(tmp[nc * (y * nx + x) + c]);
     }
     default: {
       throw((int)6);
@@ -326,13 +335,13 @@ public:
     case 8: {
       if (val > 0xff) throw((int)4);
       unsigned char *tmp = (unsigned char *)pixels;
-      tmp[nc * (x * nx + y) + c] = (unsigned char)val;
+      tmp[nc * (y * nx + x) + c] = (unsigned char)val;
       break;
     }
     case 16: {
       if (val > 0xffff) throw((int)5);
       unsigned short *tmp = (unsigned short *)pixels;
-      tmp[nc * (x * nx + y) + c] = (unsigned short)val;
+      tmp[nc * (y * nx + x) + c] = (unsigned short)val;
       break;
     }
     default: {

--- a/test/unit/sipiimage/pixel_accessor_regression_test.cpp
+++ b/test/unit/sipiimage/pixel_accessor_regression_test.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2016 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+ * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Regression test — `SipiImage::getPixel`/`setPixel` index the pixel buffer
+ * row-major (`nc * (y * nx + x) + c`), matching the codec store written by
+ * the format handlers and read by `operator-=`/`maxPixelDelta`.
+ *
+ * Before the fix the accessors indexed transposed (`x * nx + y`). For a
+ * square image both formulae cover the same index set, so a setPixel ->
+ * getPixel round-trip stayed self-consistent and hid the bug; it only
+ * diverges for non-square images, where a transposed setPixel writes to a
+ * different offset than the codec store reads. These tests therefore use
+ * non-square images.
+ */
+
+#include <gtest/gtest.h>
+
+#include <optional>
+
+#include "../../../src/SipiImage.hpp"
+
+namespace {
+
+using Sipi::PhotometricInterpretation;
+using Sipi::PixelDelta;
+using Sipi::SipiImage;
+
+// Pins setPixel to the row-major store the format handlers and maxPixelDelta
+// use: maxPixelDelta reads the raw buffer row-major and reports store-order
+// coordinates, so it is an oracle independent of the accessor under test.
+// With a non-square image and a delta at an off-diagonal coordinate, the
+// transposed (pre-fix) setPixel would land at — and be reported at — the
+// transposed location (1, 2), failing the asserts below.
+TEST(PixelAccessor, SetPixelLandsAtRowMajorStoreNonSquare)
+{
+  constexpr size_t NX = 3;// width
+  constexpr size_t NY = 5;// height (non-square: NX != NY)
+  SipiImage img1(NX, NY, 1, 8, PhotometricInterpretation::MINISBLACK);
+  SipiImage img2(NX, NY, 1, 8, PhotometricInterpretation::MINISBLACK);
+
+  // Constructor does not zero-initialize the buffer — fill every cell.
+  for (size_t y = 0; y < NY; ++y) {
+    for (size_t x = 0; x < NX; ++x) {
+      img1.setPixel(x, y, 0, 40);
+      img2.setPixel(x, y, 0, 40);
+    }
+  }
+  img1.setPixel(2, 1, 0, 250);// one distinctive sample, off-diagonal (x != y)
+
+  const std::optional<PixelDelta> delta = img2.maxPixelDelta(img1);
+  ASSERT_TRUE(delta.has_value());
+  EXPECT_EQ(delta->max_abs, 250 - 40);
+  EXPECT_EQ(delta->max_x, 2u);
+  EXPECT_EQ(delta->max_y, 1u);
+}
+
+// getPixel and setPixel must be exact inverses across a non-square,
+// multi-channel image — pinning both the spatial (`y * nx + x`) and the
+// channel-interleaving (`nc * … + c`) terms, and guarding against a future
+// change that corrects only one accessor.
+TEST(PixelAccessor, GetSetRoundTripNonSquareMultiChannel)
+{
+  constexpr size_t NX = 3;
+  constexpr size_t NY = 2;
+  constexpr size_t NC = 3;
+  SipiImage img(NX, NY, NC, 8, PhotometricInterpretation::RGB);
+
+  // Encode each (cell, channel) into a distinct value (max 5*10+2+1 = 53).
+  const auto value = [](size_t x, size_t y, size_t c) { return static_cast<int>((y * NX + x) * 10 + c) + 1; };
+
+  for (size_t y = 0; y < NY; ++y) {
+    for (size_t x = 0; x < NX; ++x) {
+      for (size_t c = 0; c < NC; ++c) { img.setPixel(x, y, c, value(x, y, c)); }
+    }
+  }
+  for (size_t y = 0; y < NY; ++y) {
+    for (size_t x = 0; x < NX; ++x) {
+      for (size_t c = 0; c < NC; ++c) { EXPECT_EQ(img.getPixel(x, y, c), value(x, y, c)); }
+    }
+  }
+}
+
+// Same round-trip on the 16-bit branch of the accessors (same shape; only
+// `bps` and the value scale differ).
+TEST(PixelAccessor, GetSetRoundTripNonSquareMultiChannelSixteenBit)
+{
+  constexpr size_t NX = 3;
+  constexpr size_t NY = 2;
+  constexpr size_t NC = 3;
+  SipiImage img(NX, NY, NC, 16, PhotometricInterpretation::RGB);
+
+  // Encode each (cell, channel) into a distinct value (max 5*1000+2+1 = 5003).
+  const auto value = [](size_t x, size_t y, size_t c) { return static_cast<int>((y * NX + x) * 1000 + c) + 1; };
+
+  for (size_t y = 0; y < NY; ++y) {
+    for (size_t x = 0; x < NX; ++x) {
+      for (size_t c = 0; c < NC; ++c) { img.setPixel(x, y, c, value(x, y, c)); }
+    }
+  }
+  for (size_t y = 0; y < NY; ++y) {
+    for (size_t x = 0; x < NX; ++x) {
+      for (size_t c = 0; c < NC; ++c) { EXPECT_EQ(img.getPixel(x, y, c), value(x, y, c)); }
+    }
+  }
+}
+
+}// namespace

--- a/test/unit/sipiimage/pixel_delta_regression_test.cpp
+++ b/test/unit/sipiimage/pixel_delta_regression_test.cpp
@@ -22,11 +22,12 @@ using Sipi::PhotometricInterpretation;
 using Sipi::PixelDelta;
 using Sipi::SipiImage;
 
-// `setPixel`/`getPixel` index pixels as `x * nx + y`, whereas the pixel
-// store (and `maxPixelDelta`) is row-major `y * nx + x`. The two are
-// transposes of one another, so the (max_x, max_y) reported for a value
-// written via setPixel(a, b) comes back as (b, a). Placing the maximum on
-// the diagonal (x == y) makes the location assertion transpose-invariant.
+// `setPixel`/`getPixel` and the pixel store read by `maxPixelDelta` are
+// both row-major `y * nx + x`, so the (max_x, max_y) reported for a value
+// written via setPixel(x, y) is exactly (x, y). The non-square case is
+// covered by pixel_accessor_regression_test; this square fixture passes with
+// or without the fix only because its maximum-delta pixel is on the diagonal
+// (2, 2), where the two index formulae coincide.
 
 TEST(MaxPixelDelta, AbsoluteDeltaBothDirections)
 {


### PR DESCRIPTION
[DEV-6647](https://linear.app/dasch/issue/DEV-6647)

## Summary
- `SipiImage::getPixel`/`setPixel` indexed the pixel buffer transposed (`nc*(x*nx+y)+c`) while the rest of `SipiImage` (format handlers, `operator-=`, `compare()`, `maxPixelDelta`) is row-major (`nc*(y*nx+x)+c`). The two agree for square images but diverge for non-square ones, so the accessors touched the wrong pixel relative to the decoded buffer.
- Switches both accessors to row-major. No production code calls them (the only first-party callers are the unit tests), so there was no compensating logic to undo.
- Phase 2 of the foreign_cc-elimination plan: a correct pixel-accessor foundation precedes the codec migrations whose verification leans on pixel comparison.

## Changes
- **Fix:** `getPixel`/`setPixel` → row-major `nc*(y*nx+x)+c` (`src/SipiImage.hpp`). Documented the indexing on `getPixel` and marked it `[[nodiscard]]`.
- **Comment consistency:** corrected the `PixelDelta` doc and the `maxPixelDelta` note (`src/SipiImage.{hpp,cpp}`) that described the now-removed transposition; same for the header comment in `pixel_delta_regression_test.cpp`.
- **Test:** new `test/unit/sipiimage/pixel_accessor_regression_test.cpp` — a non-square `setPixel`→store check using `maxPixelDelta` as an independent row-major oracle, plus multi-channel 8/16-bit get/set round-trips pinning the channel-interleaving term.

## Test Plan
- `bazel test //test/unit/sipiimage:sipi_image_tests` — green (full suite).
- Verified the oracle test is a genuine regression guard: temporarily reverting `setPixel` to the transposed form makes `SetPixelLandsAtRowMajorStoreNonSquare` fail red (reports `(1,2)` instead of `(2,1)`); restoring the fix makes it pass.
- 3-platform CI (darwin-arm64, linux-amd64, linux-arm64) covers the matrix.

## Screenshots
N/A — no UI changes.