### PR TITLE
build: gate darwin→linux cross-compilation in CI (Phase 10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,8 +176,42 @@ jobs:
           fi
           nix develop --command bash -c "just bazel-test $REMOTE $BES"
 
-      # Docker steps run on Linux only: //src:image is gated by host-CPU
-      # `target_compatible_with` and would error out on macOS-aarch64.
+      # darwin→linux cross-compilation gate (DEV-6563 Phase 10). Builds the
+      # Linux OCI image for both target arches FROM the macOS runner, proving
+      # every native cc_library (kakadu/libtiff/exiv2/…) cross-compiles through
+      # the relocatable hermetic clang toolchain with no host-include leaks.
+      # darwin-only: the Linux runners build `//src:image` natively in the
+      # Docker-smoke step, so cross-compilation is the macOS host's job to
+      # prove. Build-only (no `docker load`) — there is no Linux Docker daemon
+      # on the macOS runner.
+      - name: Cross-build Linux image (darwin→linux)
+        if: matrix.platform == 'darwin-arm64'
+        env:
+          GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
+          BAZEL_CACHE_PASSWORD: ${{ secrets.BAZEL_CACHE_PASSWORD }}
+          BUILDBUDDY_ORG_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
+        run: |
+          if [ -n "$BAZEL_CACHE_PASSWORD" ]; then
+            CACHE_HOST=bazel-cache-proxy-pbjdzenira-uc.a.run.app
+            REMOTE="--remote_cache=grpcs://$CACHE_HOST:443 --experimental_remote_downloader=grpcs://$CACHE_HOST:443 --experimental_remote_downloader_local_fallback --credential_helper=$CACHE_HOST=$GITHUB_WORKSPACE/tools/bazel-cred-helper.sh --remote_upload_local_results=true"
+          else
+            REMOTE=""
+          fi
+          if [ -n "$BUILDBUDDY_ORG_API_KEY" ]; then
+            BES="--bes_backend=grpcs://dasch.buildbuddy.io --bes_results_url=https://dasch.buildbuddy.io/invocation/ --bes_header=x-buildbuddy-api-key=$BUILDBUDDY_ORG_API_KEY --build_metadata=ROLE=CI"
+          else
+            BES=""
+          fi
+          nix develop --command bash -c "just bazel-cross-build-image amd64 $REMOTE $BES"
+          nix develop --command bash -c "just bazel-cross-build-image arm64 $REMOTE $BES"
+
+      # Docker steps run on Linux only because they `docker load` the image
+      # into a local Linux Docker daemon (absent on the macOS runner) — not
+      # because the image can't be built on macOS. //src:image is gated on the
+      # target OS (`target_compatible_with = ["@platforms//os:linux"]`), which
+      # the cross-build step above satisfies via `--platforms=linux_*`. With no
+      # platform override the default host platform on macOS is darwin, which
+      # fails that gate, so building it here would need the same override.
       #
       # `bazel-test-smoke` is one Bazel invocation that:
       #   1. Builds //src:image as a transitive `data` dep of

--- a/docs/src/development/bazel.md
+++ b/docs/src/development/bazel.md
@@ -172,8 +172,16 @@ See [Kakadu setup](kakadu.md) for the full version-bump procedure.
 
 Linux-only targets (`//src:image`, `//src:image_load`,
 `//src:image_push_*`, `//src:sipi_debug_layout`) are gated by
-`target_compatible_with = ["@platforms//os:linux"]` and skipped on
-macOS hosts. The fuzz harness is supported on linux-x86_64 (CI) and
+`target_compatible_with = ["@platforms//os:linux"]` — on the **target**
+OS, not the host. A macOS host builds them by setting the target
+platform explicitly (`--platforms=//bazel/platforms:linux_{amd64,arm64}`),
+which the hermetic-llvm toolchain cross-compiles end to end (bundled
+per-target glibc + libc++; no sysroot). `just bazel-cross-build-image
+{amd64,arm64}` wraps this; the darwin-arm64 CI runner exercises both on
+every PR. Without a `--platforms` override the default host platform on
+macOS is darwin, which fails the linux gate and skips the target.
+
+The fuzz harness is supported on linux-x86_64 (CI) and
 darwin-aarch64 (local dev) — `just bazel-build-fuzz` selects the
 host's matching `//tools/fuzz:<host>_fuzz` platform automatically.
 linux-aarch64 is out of scope for the fuzz harness.

--- a/docs/src/development/building.md
+++ b/docs/src/development/building.md
@@ -93,12 +93,25 @@ The full test matrix runs on macOS-aarch64, linux-x86_64, and
 linux-aarch64. CI exercises every variant on every platform; a
 green CI run verifies macOS as well as Linux.
 
-For Linux-target builds from a macOS host, the simplest path is
-[OrbStack](https://orbstack.dev/) or any other lightweight Linux
-VM with the dev shell available inside it (`nix develop` from a
-shared workdir). Native cross-compilation via the hermetic-llvm
-toolchain's bundled per-target sysroots is on the post-launch
-roadmap (out of scope for the Y → Y+7 migration).
+A macOS host cross-compiles the Linux OCI image directly — the
+hermetic-llvm toolchain declares every exec×target pair and bundles a
+per-target glibc + libc++ + compiler-rt, so no sysroot, VM, or host
+Linux toolchain is needed. `rules_foreign_cc` was the only thing that
+host-bound the build; with it gone (ADR-0015), every native
+`cc_library` (kakadu/libtiff/exiv2/…) compiles through the relocatable
+clang for the target platform:
+
+```bash
+just bazel-cross-build-image amd64   # build //src:image for linux-x86_64
+just bazel-cross-build-image arm64   # build //src:image for linux-aarch64
+```
+
+These are build-only (no `docker load`, since a macOS host has no Linux
+Docker daemon) and run on the darwin-arm64 CI runner on every PR so the
+capability can't silently regress. To actually load/run the image,
+either use a Linux host's `bazel-docker-build-{amd64,arm64}` or a
+lightweight Linux VM such as [OrbStack](https://orbstack.dev/) with the
+dev shell available inside it (`nix develop` from a shared workdir).
 
 ## All `just` targets
 
@@ -117,6 +130,7 @@ groups:
 | `bazel-build-sanitized [*FLAGS]` | `bazel build --config=asan --config=ubsan //src/cli:sipi` |
 | `bazel-build-fuzz [*FLAGS]` | libFuzzer harness (linux-x86_64 in CI, darwin-aarch64 local) |
 | `bazel-run-fuzz corpus duration [seed]` | Run libFuzzer harness against a corpus |
+| `bazel-cross-build-image {amd64,arm64}` | Cross-build `//src:image` for the Linux target arch (build-only; darwin→linux gate) |
 | `bazel-docker-build-{amd64,arm64}` | Build + load per-arch image as `daschswiss/sipi:latest` |
 | `bazel-docker-push-{amd64,arm64}` | Push to `daschswiss/sipi:{latest,v<version>}-${arch}` |
 | `bazel-docker-publish-manifest` | `crane index append` → multi-arch manifest at `daschswiss/sipi:v<version>` |

--- a/justfile
+++ b/justfile
@@ -330,6 +330,28 @@ bazel-docker-build-amd64 *FLAGS='':
 bazel-docker-build-arm64 *FLAGS='':
     bazel run --stamp --platforms=//bazel/platforms:linux_arm64 --verbose_failures {{FLAGS}} //src:image_load
 
+# Cross-build the Linux OCI image for `arch` (amd64|arm64) WITHOUT loading it
+# into a Docker daemon. This is the darwin→linux cross-compilation gate: it
+# builds `//src:image` under `--platforms=//bazel/platforms:linux_${arch}` so a
+# macOS host (where there is no Linux Docker daemon, so `bazel-docker-build-*`
+# cannot `docker load`) can still prove every native dep cross-compiles through
+# the relocatable hermetic clang toolchain. CI runs both arches on the
+# darwin-arm64 runner so the capability can't silently regress. No `--stamp`:
+# cross-compile validity is independent of the workspace-status version embed,
+# and skipping it keeps the gate fast.
+bazel-cross-build-image arch *FLAGS='':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    case "{{arch}}" in
+        amd64) PLATFORM=//bazel/platforms:linux_amd64 ;;
+        arm64) PLATFORM=//bazel/platforms:linux_arm64 ;;
+        *)
+            echo "ERROR: unknown arch '{{arch}}' (expected: amd64, arm64)" >&2
+            exit 1
+            ;;
+    esac
+    bazel build --platforms="$PLATFORM" --verbose_failures {{FLAGS}} //src:image
+
 # Push the per-arch image to docker.io/daschswiss/sipi with two tags:
 # `latest-${arch}` and `v<version>-${arch}`. Driven by `oci_push`'s
 # `remote_tags` attribute consuming `:remote_tags_${arch}`. The


### PR DESCRIPTION
[DEV-6563](https://linear.app/dasch/issue/DEV-6563)

## Summary
- Phase 10 of the foreign_cc elimination plan: prove and CI-gate darwin→linux cross-compilation of the Linux OCI image.
- With `rules_foreign_cc` gone (ADR-0015), the only host-binding build step is removed — the hermetic-llvm toolchain cross-compiles `//src:image` end to end from a macOS host.
- No `target_compatible_with` change: the `@platforms//os:linux` gate stays; a macOS host satisfies it via `--platforms=linux_*`.

## Changes
- **justfile**: new `bazel-cross-build-image {amd64,arm64}` recipe — build-only cross-build of `//src:image` (no `docker load`, since a macOS host has no Linux daemon).
- **CI (`ci.yml`)**: a darwin-only step cross-builds both Linux arches on every PR so the capability can't silently regress. Corrected the stale "host-CPU gate" comment on the Docker-smoke step to the accurate "target-OS gate, satisfied via `--platforms`".
- **Docs**: `building.md` / `bazel.md` now describe cross-compilation as supported (was "post-launch roadmap").

## Verification (local, darwin-aarch64)
- `bazel build --platforms=//bazel/platforms:linux_amd64 //src:image` → green (exit 0).
- `bazel build --platforms=//bazel/platforms:linux_arm64 //src:image` → green (exit 0).
- **No host-include leaks**: every dep pulls `external/llvm++glibc+glibc_headers_<arch>.2.28/include/features.h`; an exiv2 cross-compile `aquery --include_commandline` shows **zero** `/usr/include` / macOS-SDK / `/Library/Developer` paths.
- **Kakadu SIMD**: AVX2 (amd64) and NEON (arm64) both link from the darwin exec host — per-target `select()` keys on the target platform.

## Test Plan
- Build-only tooling + docs change; the cross-builds above are the test.
- CI will exercise the new darwin→linux step on this PR across the 3-platform matrix.

## Screenshots
N/A