### PR TITLE
build: re-arm fuzz gate via toolchain libFuzzer runtime (Phase 13)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -244,67 +244,48 @@ build:ubsan --linkopt=-fno-sanitize=vptr
 
 # ── Fuzz harness — opt-in via --config=fuzz ────────────────────────────────
 # Replaces the deleted `.#fuzz` Nix variant. CI's `fuzz.yml` workflow
-# (`Build fuzz target` and `Run fuzzer` steps) consumes it via
-# `just bazel-build-fuzz` and `just bazel-run-fuzz <corpus> <duration>
-# <seed>`.
+# consumes it via `just bazel-build-fuzz` and `just bazel-run-fuzz
+# <corpus> <duration> <seed>`.
 #
 # `--platforms=//tools/fuzz:<host>_fuzz` is set by the justfile recipes
-# based on `uname` (linux-x86_64 → `linux_x86_64_fuzz`, darwin-aarch64 →
-# `darwin_aarch64_fuzz`) — both platforms carry the
-# `//tools/fuzz:fuzz_enabled` constraint, which:
+# based on `uname`. The platform carries `//tools/fuzz:fuzz_enabled`,
+# which activates the `target_compatible_with` gate on
+# `//fuzz/handlers:iiif_handler_uri_parser_fuzz` (it builds under
+# `--config=fuzz`, skips analysis otherwise). A single hermetic LLVM
+# toolchain (libc++) serves both the normal and the fuzz build.
 #
-#   1. Does not select a toolchain. One hermetic LLVM toolchain (libc++ on
-#      every platform) serves both the normal and the fuzz build, and
-#      libc++ is libFuzzer's ABI on linux-x86_64 and darwin-aarch64 alike.
+# Instrumentation + runtimes come from the toolchain's own sanitizer
+# flags — same mechanism as `build:asan` above (DEV-6563 Phase 13):
+#   * `--@llvm//config:fuzzer=true` — `-fsanitize=fuzzer` on every target
+#     compile (libFuzzer coverage: trace-pc-guard / trace-cmp / …) and
+#     link, and builds + links the compiler-rt **libFuzzer runtime** from
+#     source (the runtime ADR-0014 carved this gate out for).
+#   * `--@llvm//config:asan=true` — ASan instrumentation + runtime, which
+#     the harness has always carried alongside libFuzzer.
+# These are global (every reachable dep instrumented), not the old
+# first-party `--per_file_copt` scoping — the toolchain bundles runtime
+# provisioning with the global flag and exposes no runtime-only knob. The
+# fuzz binary's reachable graph is just `//src/shttps:fuzz_subset`
+# (+ curl / jansson / libmagic / lua / openssl / sqlite3 / zlib), so the
+# coverage map stays bounded. libFuzzer supplies the binary's `main()`;
+# only that one `cc_binary` is built under `--config=fuzz`, so the global
+# `-fsanitize=fuzzer` link flag never reaches a production binary.
 #
-#   2. Activates the `target_compatible_with = ["//tools/fuzz:fuzz_enabled"]`
-#      gate on `//fuzz/handlers:iiif_handler_uri_parser_fuzz`, so it
-#      builds under `--config=fuzz` and skips analysis otherwise —
-#      equivalent to a `if (CMAKE_CXX_COMPILER_ID MATCHES Clang)` source gate.
+# **linux-x86_64 only.** Darwin is gapped under hermetic-llvm, on two
+# layers: (1) the macOS toolchain args omit the sanitizer header/runtime
+# wiring the Linux args carry (`undefined symbol: __asan_init`), and (2)
+# even once that is patched in, building the darwin compiler-rt sanitizer
+# runtimes from source hits an upstream Bazel-sandbox bug ("Could not copy
+# inputs into sandbox: compiler-rt/include (File exists)"). The module README
+# flags non-Linux sanitizer support as WIP. `bazel-build-fuzz` still selects
+# `darwin_aarch64_fuzz` locally but will not link until both close upstream;
+# the CI gate is linux-x86_64 regardless. See the `build:asan` note.
 #
-# Sanitizer flags mirror today's CMake build:
-#   * `-fsanitize=fuzzer-no-link` (compile) + `-fsanitize=fuzzer` (link) —
-#     libFuzzer harness instrumentation. Compile-side uses the
-#     `-no-link` variant so the runtime is added only at the binary's
-#     final link line, not pulled into every transitive `cc_library`.
-#   * `-fsanitize-coverage=trace-cmp` — `__sanitizer_cov_trace_*` callbacks
-#     for libFuzzer's value-profile heuristic (matches
-#     `fuzz/handlers/CMakeLists.txt:34`).
-#   * `-fsanitize=address` (compile + link) — today's fuzz target builds
-#     with ASan as well (`fuzz/handlers/CMakeLists.txt:35,40-41`).
-#
-# Compile flags are scoped to first-party translation units via
-# `--per_file_copt=^(src|shttps|fuzz|test)/.*\.(cpp|cc|cxx|c|mm)$@<flag>`,
-# matching the asan/ubsan blocks above: only sipi's own four shttps cpps +
-# `iiif_handler.cpp` carry libFuzzer instrumentation, while the third-party
-# deps reachable from `//shttps:fuzz_subset` (curl / jansson / libmagic /
-# lua / openssl / sqlite3 / zlib via `:shttps_headers`) build uninstrumented —
-# the corpus-search-space minimisation goal of the explicit subset.
-#
-# **Why `--linkopt=-fsanitize=fuzzer` is NOT here.** The libFuzzer runtime
-# defines `main()` and expects `LLVMFuzzerTestOneInput`; a global linkopt
-# would break the production `//src/cli:sipi` link and every other
-# `cc_binary`/`cc_test`. `-fsanitize=fuzzer` and `-fsanitize=address` are
-# scoped to the fuzz binary itself via `cc_binary(linkopts = [...])` in
-# `//fuzz/handlers:iiif_handler_uri_parser_fuzz` — target-level linkopts
-# apply only to that binary's own link line.
-#
-# `-fsanitize=address` *could* stay global — the asan runtime
-# self-links without user-provided symbols, so the configure-test
-# executable links fine (proven by sanitizer.yml). Both libFuzzer
-# link flags live together on the target so the rationale-and-fix
-# stays in one place; see `fuzz/handlers/BUILD.bazel`.
-#
-# `--platforms` is set by the justfile recipe (per-host; see above), not
-# here — `.bazelrc` cannot pick a platform based on `uname`, but the
-# recipe can.
-# Neutralize production hardening for fuzz — same rationale as `build:asan`
-# (fuzz inherits ASan instrumentation; fortify conflict is identical).
+# Neutralize production hardening for fuzz — same rationale as `build:asan`.
 build:fuzz --copt=-U_FORTIFY_SOURCE
 build:fuzz --copt=-fno-stack-protector
-build:fuzz --per_file_copt=^(src|shttps|fuzz|test)/.*\.(cpp|cc|cxx|c|mm)$@-fsanitize=fuzzer-no-link
-build:fuzz --per_file_copt=^(src|shttps|fuzz|test)/.*\.(cpp|cc|cxx|c|mm)$@-fsanitize-coverage=trace-cmp
-build:fuzz --per_file_copt=^(src|shttps|fuzz|test)/.*\.(cpp|cc|cxx|c|mm)$@-fsanitize=address
+build:fuzz --@llvm//config:fuzzer=true
+build:fuzz --@llvm//config:asan=true
 
 # ── Test ───────────────────────────────────────────────────────────────────
 # Surface test stderr immediately on failure rather than collecting it into

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -19,14 +19,17 @@
 permissions:
   contents: read
 
-# Nightly `schedule` disabled under the hermetic-llvm toolchain: its minimal
-# prebuilt ships no libFuzzer runtime. Kept as a manual (workflow_dispatch)
-# target. (The old global-instrument-breaks-third-party-CMake-deps blocker is
-# gone now that the build is all-native — see
-# docs/adr/0015-native-cc_library-over-foreign_cc.md.) See
-# docs/adr/0014-toolchain-provider-swap.md ("Carved-out instrumentation
-# gates"). Restore the `schedule:` block below once a fuzz runtime is wired.
+# Re-armed under hermetic-llvm (DEV-6563 Phase 13). `--config=fuzz` sets
+# `--@llvm//config:{fuzzer,asan}=true`, so the toolchain builds + links the
+# compiler-rt libFuzzer + ASan runtimes from source — the missing-runtime
+# blocker ADR-0014 carved this gate out for. foreign_cc=0 (ADR-0015) removed
+# the global-instrument-breaks-third-party-CMake-deps blocker. Runs on
+# linux-x86_64 (darwin sanitizer runtimes are upstream-gapped — see
+# docs/adr/0014-toolchain-provider-swap.md "Carved-out instrumentation gates").
 on:
+  schedule:
+    # Run at 02:00 UTC every night
+    - cron: '0 2 * * *'
   workflow_dispatch:
     inputs:
       duration:

--- a/fuzz/handlers/BUILD.bazel
+++ b/fuzz/handlers/BUILD.bazel
@@ -5,14 +5,16 @@ Build via `just bazel-build-fuzz`; run via
 `bazel build|run --config=fuzz //fuzz/handlers:iiif_handler_uri_parser_fuzz`,
 which:
 
-  1. Selects platform `//tools/fuzz:linux_x86_64_fuzz`, routing toolchain
-     resolution to `@llvm_toolchain_fuzz` (libstdc++ for libFuzzer ABI).
+  1. Selects platform `//tools/fuzz:<host>_fuzz`. A single hermetic LLVM
+     toolchain (libc++) serves the fuzz build on every platform.
   2. Activates the `target_compatible_with = ["//tools/fuzz:fuzz_enabled"]`
      gate on the binary — without `--config=fuzz` the target is skipped.
-  3. Injects `-fsanitize=fuzzer-no-link` + `-fsanitize-coverage=trace-cmp`
-     + `-fsanitize=address` (compile, scoped to first-party via
-     `--per_file_copt`) and `-fsanitize=fuzzer` + `-fsanitize=address`
-     (link) — see `.bazelrc` `build:fuzz` block.
+  3. Sets `--@llvm//config:fuzzer=true` + `--@llvm//config:asan=true` (via
+     `.bazelrc` `build:fuzz`), so the toolchain adds the libFuzzer + ASan
+     instrumentation and builds + links their compiler-rt runtimes from
+     source. libFuzzer supplies this binary's `main()`; it is the only
+     `cc_binary` built under `--config=fuzz`. linux-x86_64 only (darwin
+     sanitizer runtimes are upstream-gapped — see `.bazelrc` `build:fuzz`).
 
 The four shttps cpps + `iiif_handler.cpp` that make up the harness's
 explicit subset live under `//src/shttps:fuzz_subset` (kept in shttps's
@@ -37,19 +39,12 @@ cc_binary(
     # `just nix-run-fuzz <corpus> <duration> fuzz/handlers/corpus`
     # interface, preserved verbatim by the new bazel-run-fuzz recipe).
     data = ["//fuzz/handlers/corpus:seed_corpus"],
-    # libFuzzer + ASan link flags scoped to this target — NOT global
-    # `--linkopt` in `.bazelrc`. `-fsanitize=fuzzer` pulls in the
-    # libFuzzer runtime (which defines `main()` and expects
-    # `LLVMFuzzerTestOneInput`); putting it on a global linkopt would
-    # break the production `//src/cli:sipi` link and every other
-    # `cc_binary`/`cc_test`. Target-level `linkopts` apply only to this
-    # binary's own link line, so the fuzzer runtime reaches only the
-    # harness. `-fsanitize=address` is paired here so both libFuzzer
-    # link flags live next to the binary that needs them.
-    linkopts = [
-        "-fsanitize=fuzzer",
-        "-fsanitize=address",
-    ],
+    # No target-level `-fsanitize` linkopts: `--config=fuzz` sets
+    # `--@llvm//config:{fuzzer,asan}=true`, so the toolchain adds the
+    # libFuzzer + ASan link flags and their runtimes globally. Only this
+    # one `cc_binary` is built under `--config=fuzz`, so the global
+    # `-fsanitize=fuzzer` link flag (which pulls libFuzzer's `main()`)
+    # never reaches a production binary.
     target_compatible_with = ["//tools/fuzz:fuzz_enabled"],
     deps = ["//src/shttps:fuzz_subset"],
 )


### PR DESCRIPTION
[DEV-6563](https://linear.app/dasch/issue/DEV-6563)

## Summary
- Phase 13 of the foreign_cc elimination plan: re-arm the nightly `fuzz.yml` gate that ADR-0014 carved out under hermetic-llvm (no libFuzzer runtime in the minimal prebuilt).
- Same mechanism as Phase 12: `--config=fuzz` now sets `--@llvm//config:fuzzer=true` + `--@llvm//config:asan=true`, so the toolchain builds + links the compiler-rt libFuzzer + ASan runtimes from source.

## Changes
- **`.bazelrc`**: `build:fuzz` uses the toolchain config flags instead of `--per_file_copt -fsanitize=fuzzer-no-link/trace-cmp/address`.
- **`fuzz/handlers/BUILD.bazel`**: dropped the now-redundant target `linkopts = ["-fsanitize=fuzzer", "-fsanitize=address"]` (the toolchain config provides them globally; the fuzz binary is the only `cc_binary` built under `--config=fuzz`). Refreshed the docstring (the `@llvm_toolchain_fuzz`/libstdc++ routing was folded away at the LLVM swap).
- **`fuzz.yml`**: restored the nightly `schedule: cron '0 2 * * *'` trigger.

## Verification
- `bazel build --config=fuzz --platforms=//tools/fuzz:linux_x86_64_fuzz //fuzz/handlers:iiif_handler_uri_parser_fuzz` → green from darwin (libFuzzer + `libasan.static.a` built from source, fuzz binary linked).
- I'll trigger a `workflow_dispatch` run on this branch to validate the build + a short fuzz run on a real linux-x86_64 runner.

## Darwin (deferred — upstream-blocked)
You asked whether the macOS toolchain could be amended. I prototyped it: a local `single_version_override` patch adding the sanitizer header path + runtime link to `macos_toolchain_args` (mirroring the Linux args). It **applies cleanly and fixes the wiring** (analysis passes). But darwin is blocked on a *second*, deeper layer: building the darwin compiler-rt sanitizer runtimes from source hits a Bazel-sandbox bug — `Could not copy inputs into sandbox: compiler-rt/include (File exists)` — which persists with sandbox-reuse disabled and is independent of the wiring. The hermetic-llvm README flags non-Linux sanitizer support as WIP. So darwin asan/fuzz needs an upstream module fix; deferred to a follow-up (the wiring patch is captured for when layer 2 closes). CI gates are linux-x86_64 regardless.

## Test Plan
- Local linux cross-build green (above). `workflow_dispatch` run to confirm in CI. Nightly schedule exercises it ongoing once merged.

## Screenshots
N/A