### PR TITLE
ci: consolidate flaky e2e retry onto Bazel --flaky_test_attempts; remove Rust retry plumbing

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -292,20 +292,28 @@ build:fuzz --@llvm//config:asan=true
 # bazel-testlogs — useful for inner-loop iteration. CI flips this off.
 test --test_output=errors
 
-# Retry the three timing-sensitive e2e tests up to 3x. They assert on
-# connection / cache timing budgets that a loaded CI runner (observed on
-# linux-arm64) can blow on a single attempt — surfacing as a transient
-# `hyper::Error(IncompleteMessage)` on a cache-hit GET, not a logic bug. A
-# genuinely broken test still fails all 3 attempts, so this masks flakes, not
+# Retry the timing-sensitive e2e tests up to 3x — the single retry mechanism
+# for the suite (replaces the bespoke Rust `retry_flaky` helper / inline poll
+# loops, removed in favour of Bazel's native `--flaky_test_attempts`). These
+# four assert on server-side timing the test can't pin down deterministically:
+#   - latency / iiif_compliance / resource_limits: connection / cache budgets a
+#     loaded CI runner (observed on linux-arm64) blows on a single attempt —
+#     surfacing as a transient `hyper::Error(IncompleteMessage)`.
+#   - memory_budget / resource_limits: an eventually-consistent state settling
+#     just after the response (the decode-budget gauge returning to 0; the musl
+#     binary recovering after a heavy transform pipeline).
+# A genuinely broken test still fails all 3 attempts, so this masks flakes, not
 # regressions. `--flaky_test_attempts` is `accumulate_value` (one entry per
-# target) and matches the target label as a regex; a no-op for invocations
-# that don't include the target. Living in `.bazelrc` (not a per-workflow
-# flag) means ci.yml, sanitizer.yml, and local `just bazel-test` all inherit
-# it — single source of truth. (sanitizer.yml also passes these inline for
-# the ASan run; the duplicate same-value entries are harmless.)
+# target) and matches the target label as a regex; a no-op for invocations that
+# don't include the target. Living in `.bazelrc` (not a per-workflow flag)
+# means ci.yml, sanitizer.yml, and local `just bazel-test` all inherit it —
+# single source of truth. (sanitizer.yml still passes latency/iiif_compliance/
+# resource_limits inline for the ASan run; the duplicate same-value entries are
+# harmless and can be dropped once that PR lands.)
 test --flaky_test_attempts=//test/e2e-rust:latency@3
 test --flaky_test_attempts=//test/e2e-rust:iiif_compliance@3
 test --flaky_test_attempts=//test/e2e-rust:resource_limits@3
+test --flaky_test_attempts=//test/e2e-rust:memory_budget@3
 
 # ── Remote cache ────────────────────────────────────────────────────────────
 # DEV-6517: gRPC remote cache via bazel-remote on Cloud Run, backed by GCS.

--- a/.bazelrc
+++ b/.bazelrc
@@ -292,6 +292,21 @@ build:fuzz --@llvm//config:asan=true
 # bazel-testlogs — useful for inner-loop iteration. CI flips this off.
 test --test_output=errors
 
+# Retry the three timing-sensitive e2e tests up to 3x. They assert on
+# connection / cache timing budgets that a loaded CI runner (observed on
+# linux-arm64) can blow on a single attempt — surfacing as a transient
+# `hyper::Error(IncompleteMessage)` on a cache-hit GET, not a logic bug. A
+# genuinely broken test still fails all 3 attempts, so this masks flakes, not
+# regressions. `--flaky_test_attempts` is `accumulate_value` (one entry per
+# target) and matches the target label as a regex; a no-op for invocations
+# that don't include the target. Living in `.bazelrc` (not a per-workflow
+# flag) means ci.yml, sanitizer.yml, and local `just bazel-test` all inherit
+# it — single source of truth. (sanitizer.yml also passes these inline for
+# the ASan run; the duplicate same-value entries are harmless.)
+test --flaky_test_attempts=//test/e2e-rust:latency@3
+test --flaky_test_attempts=//test/e2e-rust:iiif_compliance@3
+test --flaky_test_attempts=//test/e2e-rust:resource_limits@3
+
 # ── Remote cache ────────────────────────────────────────────────────────────
 # DEV-6517: gRPC remote cache via bazel-remote on Cloud Run, backed by GCS.
 # The URL and a pointer to the credential helper are constructed in each

--- a/test/e2e-rust/src/lib.rs
+++ b/test/e2e-rust/src/lib.rs
@@ -566,37 +566,3 @@ pub fn http_client() -> reqwest::blocking::Client {
         .expect("Failed to build HTTP client")
 }
 
-/// Retry a test assertion up to `max_attempts` times.
-///
-/// The closure should return `Ok(())` on success or `Err(message)` on failure.
-/// Between attempts, sleeps for 2 seconds. Panics if all attempts fail.
-///
-/// Use this for assertions that depend on server-side timing (e.g., an RAII
-/// guard releasing after the response is sent, so metrics don't update
-/// instantly). Do NOT use this for connection-level retries — those are
-/// solved by disabling connection pooling in `http_client()`.
-pub fn retry_flaky<F>(max_attempts: u32, f: F)
-where
-    F: Fn() -> Result<(), String>,
-{
-    let mut last_err = String::new();
-    for attempt in 1..=max_attempts {
-        match f() {
-            Ok(()) => return,
-            Err(e) => {
-                last_err = e;
-                if attempt < max_attempts {
-                    eprintln!(
-                        "[retry_flaky] attempt {}/{} failed: {}",
-                        attempt, max_attempts, last_err
-                    );
-                    std::thread::sleep(Duration::from_secs(2));
-                }
-            }
-        }
-    }
-    panic!(
-        "Test failed after {} attempts. Last error: {}",
-        max_attempts, last_err
-    );
-}

--- a/test/e2e-rust/tests/memory_budget.rs
+++ b/test/e2e-rust/tests/memory_budget.rs
@@ -1,4 +1,4 @@
-use sipi_e2e::{http_client, retry_flaky, test_data_dir, SipiServer};
+use sipi_e2e::{http_client, test_data_dir, SipiServer};
 
 /// Start with enforce mode and a given budget.
 fn start_enforce(budget: &str) -> SipiServer {
@@ -215,27 +215,25 @@ fn metrics_used_gauge_returns_to_zero() {
     let _ = resp.bytes(); // consume body
 
     // The RAII guard releases budget when the handler function returns,
-    // which is slightly after the response body is sent. Retry to allow
-    // the server to finish cleanup.
-    let base = srv.base_url.clone();
-    retry_flaky(5, move || {
-        let metrics = c
-            .get(format!("{}/metrics", base))
-            .send()
-            .map_err(|e| format!("metrics request failed: {}", e))?
-            .text()
-            .map_err(|e| format!("metrics body failed: {}", e))?;
+    // which is slightly after the response body is sent. If the gauge has
+    // not settled to 0 by the time we scrape /metrics, the assertion fails
+    // and Bazel re-runs the whole test (`--flaky_test_attempts` for this
+    // target in `.bazelrc`) — the single retry mechanism for the suite.
+    let metrics = c
+        .get(format!("{}/metrics", srv.base_url))
+        .send()
+        .expect("metrics request failed")
+        .text()
+        .expect("metrics body failed");
 
-        let used_line = metrics
-            .lines()
-            .find(|l| l.starts_with("sipi_decode_memory_used_bytes "));
+    let used_line = metrics
+        .lines()
+        .find(|l| l.starts_with("sipi_decode_memory_used_bytes "));
 
-        match used_line {
-            Some(line) if line.ends_with(" 0") => Ok(()),
-            Some(line) => Err(format!("used bytes not yet 0: {}", line)),
-            None => Ok(()), // metric not present = budget not tracked
-        }
-    });
+    // `None` = budget not tracked (metric absent); only assert when present.
+    if let Some(line) = used_line {
+        assert!(line.ends_with(" 0"), "used bytes not yet 0: {}", line);
+    }
 }
 
 #[test]

--- a/test/e2e-rust/tests/resource_limits.rs
+++ b/test/e2e-rust/tests/resource_limits.rs
@@ -218,26 +218,21 @@ fn transform_pipeline_memory() {
         );
     }
 
-    // Verify server still responsive after all transforms.
-    // The musl static binary may need a moment to recover after heavy
-    // transform work, so allow a few retries for the health check.
+    // Verify server still responsive after all transforms. If the musl
+    // static binary hasn't recovered from the heavy transform work yet,
+    // this fails and Bazel re-runs the whole test
+    // (`--flaky_test_attempts` for this target in `.bazelrc`) — the single
+    // retry mechanism for the suite.
     let health_url = format!(
         "{}/unit/lena512.jp2/full/max/0/default.jpg",
         srv.base_url
     );
-    let mut health_ok = false;
-    for attempt in 1..=3 {
-        match c.get(&health_url).send() {
-            Ok(r) if r.status().as_u16() == 200 => {
-                health_ok = true;
-                break;
-            }
-            Ok(r) => eprintln!("[health] attempt {} returned {}", attempt, r.status()),
-            Err(e) => eprintln!("[health] attempt {} failed: {}", attempt, e),
-        }
-        std::thread::sleep(std::time::Duration::from_millis(500));
-    }
-    assert!(health_ok, "server not responsive after transform pipeline");
+    let resp = c.get(&health_url).send().expect("health check request failed");
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "server not responsive after transform pipeline"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Make Bazel's native `--flaky_test_attempts` the **single** retry mechanism for the e2e suite, and remove the bespoke Rust retry plumbing.

Surfaced by a flaky `latency` failure on linux-arm64 (`hyper::Error(IncompleteMessage)` on a cache-hit GET — passed on amd64/darwin in the same run). `sanitizer.yml` already retried the timing-sensitive tests inline; the normal `ci.yml` path didn't.

## Changes
- **`.bazelrc`**: retry the four timing-sensitive e2e tests 3x — `//test/e2e-rust:{latency,iiif_compliance,resource_limits,memory_budget}`. One source of truth, inherited by `ci.yml`, `sanitizer.yml`, and local `just bazel-test` (no per-workflow inline flags).
- **Remove Rust retry plumbing:**
  - Delete the `retry_flaky` helper (`test/e2e-rust/src/lib.rs`) and its sole caller's poll loop (`memory_budget::metrics_used_gauge_returns_to_zero`).
  - Replace the `resource_limits` inline `for attempt in 1..=3` health-readiness loop with a single check.
  - Both eventually-consistent waits (gauge settle, musl recovery) now rely on a whole-test Bazel retry.

## Why this is safe
A genuinely broken test still fails all 3 Bazel attempts, so this masks flakes, not regressions. The retried set is the known-timing-sensitive tests only — not a blanket suite-wide retry that could hide real bugs.

## Verification
- `bazel build //test/e2e-rust:{memory_budget,resource_limits}` → green (Rust compiles, no orphaned imports; `.bazelrc` parses).
- `bazel test //test/e2e-rust:{memory_budget,resource_limits}` → both PASS with the single-check assertions.
- `grep retry_flaky` → fully removed.

## Note
`sanitizer.yml` (in the still-open asan PR #677) still passes `latency/iiif_compliance/resource_limits` inline. Those are now redundant with `.bazelrc` (duplicate same-value `@3`, harmless, last-match-wins) — drop them as a trivial follow-up once #677 lands, to avoid a merge conflict here.