### PR TITLE
ci: move cross-compile gate to a dedicated amd64 runner (off the darwin gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,35 +176,6 @@ jobs:
           fi
           nix develop --command bash -c "just bazel-test $REMOTE $BES"
 
-      # darwin→linux cross-compilation gate (DEV-6563 Phase 10). Builds the
-      # Linux OCI image for both target arches FROM the macOS runner, proving
-      # every native cc_library (kakadu/libtiff/exiv2/…) cross-compiles through
-      # the relocatable hermetic clang toolchain with no host-include leaks.
-      # darwin-only: the Linux runners build `//src:image` natively in the
-      # Docker-smoke step, so cross-compilation is the macOS host's job to
-      # prove. Build-only (no `docker load`) — there is no Linux Docker daemon
-      # on the macOS runner.
-      - name: Cross-build Linux image (darwin→linux)
-        if: matrix.platform == 'darwin-arm64'
-        env:
-          GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
-          BAZEL_CACHE_PASSWORD: ${{ secrets.BAZEL_CACHE_PASSWORD }}
-          BUILDBUDDY_ORG_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
-        run: |
-          if [ -n "$BAZEL_CACHE_PASSWORD" ]; then
-            CACHE_HOST=bazel-cache-proxy-pbjdzenira-uc.a.run.app
-            REMOTE="--remote_cache=grpcs://$CACHE_HOST:443 --experimental_remote_downloader=grpcs://$CACHE_HOST:443 --experimental_remote_downloader_local_fallback --credential_helper=$CACHE_HOST=$GITHUB_WORKSPACE/tools/bazel-cred-helper.sh --remote_upload_local_results=true"
-          else
-            REMOTE=""
-          fi
-          if [ -n "$BUILDBUDDY_ORG_API_KEY" ]; then
-            BES="--bes_backend=grpcs://dasch.buildbuddy.io --bes_results_url=https://dasch.buildbuddy.io/invocation/ --bes_header=x-buildbuddy-api-key=$BUILDBUDDY_ORG_API_KEY --build_metadata=ROLE=CI"
-          else
-            BES=""
-          fi
-          nix develop --command bash -c "just bazel-cross-build-image amd64 $REMOTE $BES"
-          nix develop --command bash -c "just bazel-cross-build-image arm64 $REMOTE $BES"
-
       # Docker steps run on Linux only because they `docker load` the image
       # into a local Linux Docker daemon (absent on the macOS runner) — not
       # because the image can't be built on macOS. //src:image is gated on the
@@ -273,6 +244,59 @@ jobs:
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: scout-results.sarif
+
+  # Cross-compilation gate (DEV-6563 Phase 10). A dedicated linux-amd64 runner
+  # cross-builds for linux-arm64 and darwin-arm64, proving every native
+  # cc_library (kakadu/libtiff/exiv2/…) compiles through the relocatable
+  # hermetic clang toolchain for a non-host target. Kept as its own job on its
+  # own runner — NOT a step in the `test` matrix — so the cross-build never
+  # slows the (expensive) darwin gate; it runs in parallel instead. Build-only:
+  # no `docker load`, no tests.
+  cross-build:
+    name: cross-build / amd64→{linux-arm64,darwin}
+    runs-on: ubuntu-24.04
+    concurrency:
+      group: ${{ github.workflow }}-cross-build-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # workspace_status.sh stamp needs git history
+          lfs: false      # build-only — no LFS test fixtures needed
+      - uses: DeterminateSystems/determinate-nix-action@v3
+        with:
+          # gh_release_archive (Kakadu fetch) reads GH_TOKEN via `gh`; keep it
+          # out of the daemon's env sanitisation.
+          extra-conf: |
+            extra-experimental-features = configurable-impure-env
+      - uses: DeterminateSystems/magic-nix-cache-action@v13
+        with:
+          use-flakehub: "false"  # GHA cache backend only; FlakeHub is a paid plan we're not on.
+
+      # `//src:image` is `@platforms//os:linux`-gated, so the linux-arm64
+      # check builds the image (same as the darwin gate) while the darwin
+      # check builds the `sipi` binary (which pulls every native dep through
+      # the cross toolchain). The `if [ -n "$BAZEL_CACHE_PASSWORD" ]` blocks
+      # mirror the test job — fork PRs run cold.
+      - name: Cross-build (amd64 → linux-arm64 image + darwin sipi)
+        env:
+          GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
+          BAZEL_CACHE_PASSWORD: ${{ secrets.BAZEL_CACHE_PASSWORD }}
+          BUILDBUDDY_ORG_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
+        run: |
+          if [ -n "$BAZEL_CACHE_PASSWORD" ]; then
+            CACHE_HOST=bazel-cache-proxy-pbjdzenira-uc.a.run.app
+            REMOTE="--remote_cache=grpcs://$CACHE_HOST:443 --experimental_remote_downloader=grpcs://$CACHE_HOST:443 --experimental_remote_downloader_local_fallback --credential_helper=$CACHE_HOST=$GITHUB_WORKSPACE/tools/bazel-cred-helper.sh --remote_upload_local_results=true"
+          else
+            REMOTE=""
+          fi
+          if [ -n "$BUILDBUDDY_ORG_API_KEY" ]; then
+            BES="--bes_backend=grpcs://dasch.buildbuddy.io --bes_results_url=https://dasch.buildbuddy.io/invocation/ --bes_header=x-buildbuddy-api-key=$BUILDBUDDY_ORG_API_KEY --build_metadata=ROLE=CI"
+          else
+            BES=""
+          fi
+          nix develop --command bash -c "just bazel-cross-build-image arm64 $REMOTE $BES"
+          nix develop --command bash -c "just bazel-build --platforms=//bazel/platforms:darwin_arm64 $REMOTE $BES"
 
   # Build documentation. Pure Python/MkDocs — Nix is only here so we can
   # provision `just` consistently with the other jobs.

--- a/bazel/platforms/BUILD.bazel
+++ b/bazel/platforms/BUILD.bazel
@@ -1,12 +1,21 @@
-"""Plain Linux platform definitions.
+"""Target platform definitions for explicit `--platforms=` builds.
 
-Used by the `bazel-docker-build-${arch}` and `bazel-docker-push-${arch}`
-just recipes via `--platforms=//bazel/platforms:linux_${arch}`. Per-arch
-CI runners typically have a matching host platform already, but pinning
-the build platform explicitly makes the image's `architecture` config
-deterministic regardless of how the runner advertises its host triple
-(GitHub-hosted ubuntu-24.04-arm reports differently from a self-hosted
-arm64 runner, for example).
+The `linux_*` platforms drive the `bazel-docker-build-${arch}` and
+`bazel-docker-push-${arch}` just recipes via
+`--platforms=//bazel/platforms:linux_${arch}`. Per-arch CI runners
+typically have a matching host platform already, but pinning the build
+platform explicitly makes the image's `architecture` config deterministic
+regardless of how the runner advertises its host triple (GitHub-hosted
+ubuntu-24.04-arm reports differently from a self-hosted arm64 runner, for
+example).
+
+`darwin_arm64` exists for the cross-compilation gates: it lets a non-macOS
+exec host (e.g. the linux-amd64 CI runner) cross-build `//src/cli:sipi` for
+macOS via `--platforms=//bazel/platforms:darwin_arm64`. There is no
+`darwin_amd64` — the toolchain declares only the `macos-aarch64` target
+(`MODULE.bazel`'s `toolchain.target` tags). The Linux-only OCI image targets
+(`//src:image`, …) cannot target darwin, so the darwin cross-check builds the
+`sipi` binary, not the image.
 
 The fuzz harness has its own platform definitions under //tools/fuzz/
 because it needs the additional `fuzz_enabled` constraint to flip the
@@ -30,5 +39,13 @@ platform(
     constraint_values = [
         "@platforms//cpu:arm64",
         "@platforms//os:linux",
+    ],
+)
+
+platform(
+    name = "darwin_arm64",
+    constraint_values = [
+        "@platforms//cpu:arm64",
+        "@platforms//os:macos",
     ],
 )

--- a/docs/src/development/bazel.md
+++ b/docs/src/development/bazel.md
@@ -177,9 +177,15 @@ OS, not the host. A macOS host builds them by setting the target
 platform explicitly (`--platforms=//bazel/platforms:linux_{amd64,arm64}`),
 which the hermetic-llvm toolchain cross-compiles end to end (bundled
 per-target glibc + libc++; no sysroot). `just bazel-cross-build-image
-{amd64,arm64}` wraps this; the darwin-arm64 CI runner exercises both on
-every PR. Without a `--platforms` override the default host platform on
-macOS is darwin, which fails the linux gate and skips the target.
+{amd64,arm64}` wraps this. Without a `--platforms` override the default
+host platform on macOS is darwin, which fails the linux gate and skips
+the target.
+
+Cross-compilation is gated on every PR by a dedicated `cross-build` CI
+job on a linux-amd64 runner (separate from the test matrix, so it doesn't
+slow the darwin gate): it cross-builds the linux-arm64 image and the
+darwin-arm64 `sipi` binary (`--platforms=//bazel/platforms:darwin_arm64`
+— the OCI image is Linux-only, so darwin builds the binary).
 
 The fuzz harness is supported on linux-x86_64 (CI) and
 darwin-aarch64 (local dev) — `just bazel-build-fuzz` selects the

--- a/docs/src/development/building.md
+++ b/docs/src/development/building.md
@@ -93,13 +93,13 @@ The full test matrix runs on macOS-aarch64, linux-x86_64, and
 linux-aarch64. CI exercises every variant on every platform; a
 green CI run verifies macOS as well as Linux.
 
-A macOS host cross-compiles the Linux OCI image directly — the
-hermetic-llvm toolchain declares every exec×target pair and bundles a
-per-target glibc + libc++ + compiler-rt, so no sysroot, VM, or host
-Linux toolchain is needed. `rules_foreign_cc` was the only thing that
-host-bound the build; with it gone (ADR-0015), every native
-`cc_library` (kakadu/libtiff/exiv2/…) compiles through the relocatable
-clang for the target platform:
+Any host cross-compiles for any supported target — the hermetic-llvm
+toolchain declares every exec×target pair and bundles a per-target glibc
++ libc++ + compiler-rt, so no sysroot, VM, or host toolchain for the
+target is needed. `rules_foreign_cc` was the only thing that host-bound
+the build; with it gone (ADR-0015), every native `cc_library`
+(kakadu/libtiff/exiv2/…) compiles through the relocatable clang for the
+target platform. A macOS host builds the Linux OCI image directly:
 
 ```bash
 just bazel-cross-build-image amd64   # build //src:image for linux-x86_64
@@ -107,10 +107,12 @@ just bazel-cross-build-image arm64   # build //src:image for linux-aarch64
 ```
 
 These are build-only (no `docker load`, since a macOS host has no Linux
-Docker daemon) and run on the darwin-arm64 CI runner on every PR so the
-capability can't silently regress. To actually load/run the image,
-either use a Linux host's `bazel-docker-build-{amd64,arm64}` or a
-lightweight Linux VM such as [OrbStack](https://orbstack.dev/) with the
+Docker daemon). On every PR a dedicated linux-amd64 `cross-build` CI job
+exercises the cross toolchain (amd64 → linux-arm64 image, amd64 → darwin
+`sipi`) so the capability can't silently regress — on its own runner, so
+it doesn't slow the darwin gate. To actually load/run the image, either
+use a Linux host's `bazel-docker-build-{amd64,arm64}` or a lightweight
+Linux VM such as [OrbStack](https://orbstack.dev/) with the
 dev shell available inside it (`nix develop` from a shared workdir).
 
 ## All `just` targets
@@ -130,7 +132,7 @@ groups:
 | `bazel-build-sanitized [*FLAGS]` | `bazel build --config=asan --config=ubsan //src/cli:sipi` |
 | `bazel-build-fuzz [*FLAGS]` | libFuzzer harness (linux-x86_64 in CI, darwin-aarch64 local) |
 | `bazel-run-fuzz corpus duration [seed]` | Run libFuzzer harness against a corpus |
-| `bazel-cross-build-image {amd64,arm64}` | Cross-build `//src:image` for the Linux target arch (build-only; darwin→linux gate) |
+| `bazel-cross-build-image {amd64,arm64}` | Cross-build `//src:image` for the Linux target arch (build-only; cross-compile gate) |
 | `bazel-docker-build-{amd64,arm64}` | Build + load per-arch image as `daschswiss/sipi:latest` |
 | `bazel-docker-push-{amd64,arm64}` | Push to `daschswiss/sipi:{latest,v<version>}-${arch}` |
 | `bazel-docker-publish-manifest` | `crane index append` → multi-arch manifest at `daschswiss/sipi:v<version>` |

--- a/justfile
+++ b/justfile
@@ -331,14 +331,14 @@ bazel-docker-build-arm64 *FLAGS='':
     bazel run --stamp --platforms=//bazel/platforms:linux_arm64 --verbose_failures {{FLAGS}} //src:image_load
 
 # Cross-build the Linux OCI image for `arch` (amd64|arm64) WITHOUT loading it
-# into a Docker daemon. This is the darwin→linux cross-compilation gate: it
-# builds `//src:image` under `--platforms=//bazel/platforms:linux_${arch}` so a
-# macOS host (where there is no Linux Docker daemon, so `bazel-docker-build-*`
-# cannot `docker load`) can still prove every native dep cross-compiles through
-# the relocatable hermetic clang toolchain. CI runs both arches on the
-# darwin-arm64 runner so the capability can't silently regress. No `--stamp`:
-# cross-compile validity is independent of the workspace-status version embed,
-# and skipping it keeps the gate fast.
+# into a Docker daemon. Builds `//src:image` under
+# `--platforms=//bazel/platforms:linux_${arch}` so a host of any OS (e.g. a
+# macOS dev box, where there is no Linux Docker daemon so `bazel-docker-build-*`
+# cannot `docker load`) can prove every native dep cross-compiles through the
+# relocatable hermetic clang toolchain. The dedicated linux-amd64 `cross-build`
+# CI job runs the arm64 arch on every PR so the capability can't silently
+# regress. No `--stamp`: cross-compile validity is independent of the
+# workspace-status version embed, and skipping it keeps the gate fast.
 bazel-cross-build-image arch *FLAGS='':
     #!/usr/bin/env bash
     set -euo pipefail


### PR DESCRIPTION
[DEV-6563](https://linear.app/dasch/issue/DEV-6563)

## Summary
The darwin-arm64 entry of the `test` job cross-built the Linux image from macOS (Phase 10), adding ~13 min to the most expensive runner. This moves cross-compilation to its own `cross-build` job on a separate **linux-amd64** runner — parallel, and never slows the darwin gate.

## Changes
- **New `cross-build` job** (`ubuntu-24.04`, own concurrency group). From the amd64 exec host it cross-builds the two non-native targets:
  - `linux-arm64`: `//src:image` (`just bazel-cross-build-image arm64`).
  - `darwin-arm64`: `//src/cli:sipi` (`just bazel-build --platforms=//bazel/platforms:darwin_arm64`) — the OCI image is `@platforms//os:linux`-gated, so darwin builds the binary, which still compiles every native dep through the cross toolchain.
- **`//bazel/platforms:darwin_arm64`** platform added (no `darwin_amd64` — the toolchain declares only the `macos-aarch64` target).
- **Removed** the darwin→linux cross-build step from the `test` job.
- Docs (`bazel.md` / `building.md`) + the justfile recipe comment updated to describe the dedicated job.

## Trade-off (worth a look)
This swaps the cross-compile **exec host** from darwin to amd64. We now gate amd64→linux-arm64 and amd64→darwin, and no longer gate darwin→linux. That's the intended move (keep the cross-check off the costly darwin runner); the toolchain is relocatable, so darwin→linux is very likely still fine, but it's no longer CI-verified.

## Verification
- Local: `//src/cli:sipi` builds under `--platforms=darwin_arm64` (✅), linux-arm64 image cross-builds (✅).
- The **amd64→darwin** cross path only runs on a Linux exec host, so its first real validation is this PR's `cross-build` job (same as how the Phase 10 gate self-validated). If `linux→darwin` hits a toolchain gap (macOS SDK / link-wrapper), I'll see it on this PR and adjust.

## Test Plan
- `cross-build` job on this PR exercises both cross targets on a linux-amd64 runner.

## Screenshots
N/A