### PR TITLE
Add Tracy profiler to the IIIF hot path (opt-in, dev-only)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -272,6 +272,31 @@ build:fuzz --copt=-fno-stack-protector
 build:fuzz --@llvm//config:fuzzer=true
 build:fuzz --@llvm//config:asan=true
 
+# ── Tracy profiler — opt-in via --config=tracy ─────────────────────────────
+# Local-dev only, never CI-gated (like `just bench` / `just valgrind`).
+# `just bazel-build-tracy` adds `-c opt` and builds //src/cli:sipi; run the
+# binary and connect the Tracy GUI over TCP 8086. The `@tracy//:tracy` dep is
+# always in the graph but inert until TRACY_ENABLE is defined here, so these
+# flags are the *only* thing that arms the profiler.
+#
+#   * TRACY_ENABLE   — master switch. Defined globally so it reaches both
+#     TracyClient.cpp and every instrumented first-party TU (the zone macros in
+#     `src/observability/profiling.h` are no-ops without it).
+#   * TRACY_ON_DEMAND — a long-running server must not buffer profiling data
+#     when no GUI is attached; with this, collection starts only on connect.
+#   * -fno-omit-frame-pointer + -g + --strip=never — symbol-accurate zones and
+#     enable Tracy's statistical call-stack sampling alongside the manual zones.
+build:tracy --copt=-DTRACY_ENABLE
+build:tracy --copt=-DTRACY_ON_DEMAND
+build:tracy --copt=-fno-omit-frame-pointer
+build:tracy --copt=-g
+build:tracy --strip=never
+# Tracy's headers (pulled into instrumented first-party TUs via profiling.h) trip
+# -Wthread-safety-analysis on their lock-free queue internals. Vendored code we
+# don't maintain; silence it for this dev-only config (the warning still applies
+# to first-party code in the normal/sanitizer builds).
+build:tracy --copt=-Wno-thread-safety-analysis
+
 # ── Test ───────────────────────────────────────────────────────────────────
 # Surface test stderr immediately on failure rather than collecting it into
 # bazel-testlogs — useful for inner-loop iteration. CI flips this off.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -588,3 +588,18 @@ http_archive(
     url = "https://github.com/libsdl-org/libtiff/archive/refs/tags/v4.7.1.tar.gz",
 )
 
+# Tracy — opt-in, dev-only frame/zone profiler (https://github.com/wolfpld/tracy).
+# Not a BCR module (verified: registry has no `tracy`), so it follows the native
+# `cc_library` pattern per ADR-0015. The dep is *always* in the graph but inert:
+# the profiler machinery in `public/client/*.cpp` is gated behind `TRACY_ENABLE`,
+# which only `--config=tracy` defines, so a normal build links no listening
+# socket and collects nothing. See `bazel/tracy.BUILD.bazel` and
+# `docs/adr/0016-tracy-opt-in-dev-profiler.md`.
+http_archive(
+    name = "tracy",
+    build_file = "//bazel:tracy.BUILD.bazel",
+    sha256 = "d4efc50ebcb0bfcfdbba148995aeb75044c0d80f5d91223aebfaa8fa9e563d2b",
+    strip_prefix = "tracy-0.13.1",
+    url = "https://github.com/wolfpld/tracy/archive/refs/tags/v0.13.1.tar.gz",
+)
+

--- a/bazel/tracy.BUILD.bazel
+++ b/bazel/tracy.BUILD.bazel
@@ -1,0 +1,52 @@
+"""Native `cc_library` for the Tracy profiler client.
+
+Tracy's "fast integration" path compiles exactly one translation unit,
+`public/TracyClient.cpp`, which `#include`s the implementation `.cpp` files
+(`client/*.cpp`, `common/*.cpp`) directly. Those included sources must therefore
+be available for textual inclusion but must NOT be compiled as separate `srcs`
+(they have no standalone linkage and would collide). They go in `textual_hdrs`.
+
+The whole profiler — sockets, sampling, the rpmalloc arena — sits behind
+`#ifdef TRACY_ENABLE` inside those files. `--config=tracy` defines `TRACY_ENABLE`
+globally (`.bazelrc`); without it, `TracyClient.cpp` compiles down to the thread-
+name helpers in `common/TracySystem.cpp` and nothing else — no listening socket,
+no background thread, no buffering. So this target is safe to keep as an
+unconditional dependency of the production graph. See
+`docs/adr/0016-tracy-opt-in-dev-profiler.md`.
+"""
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "tracy",
+    srcs = ["public/TracyClient.cpp"],
+    # The public instrumentation API consumers `#include <tracy/Tracy.hpp>`.
+    hdrs = glob([
+        "public/tracy/*.h",
+        "public/tracy/*.hpp",
+    ]),
+    # Everything TracyClient.cpp pulls in by relative `#include` — including the
+    # `.cpp` implementation files — exposed for textual inclusion only.
+    textual_hdrs = glob([
+        "public/client/**",
+        "public/common/**",
+        "public/libbacktrace/**",
+        "public/tracy/**",
+    ]),
+    includes = ["public"],
+    # Vendored third-party code we do not maintain: silence its warnings
+    # wholesale (deprecated sprintf, thread-safety-analysis, unused-function)
+    # rather than track upstream's churn flag-by-flag.
+    copts = ["-w"],
+    linkstatic = True,
+    linkopts = select({
+        # libbacktrace dlopen + the client's background socket thread.
+        "@platforms//os:linux": [
+            "-ldl",
+            "-lpthread",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/docs/adr/0016-tracy-opt-in-dev-profiler.md
+++ b/docs/adr/0016-tracy-opt-in-dev-profiler.md
@@ -1,0 +1,75 @@
+---
+status: accepted
+---
+
+# Tracy as an opt-in, dev-only profiler — always linked, inert unless `--config=tracy`
+
+SIPI vendors the [Tracy](https://github.com/wolfpld/tracy) profiler client as an
+**unconditional** Bazel dependency of the production graph, instrumented along the
+IIIF hot path (parse / cache / decode / process / encode) with scoped zones behind
+a single first-party shim, `src/observability/profiling.h`. The profiler is inert
+in every build except `--config=tracy`: the entire Tracy machinery — listening
+socket, sampling thread, allocation arena — is gated behind `TRACY_ENABLE`, which
+only the `build:tracy` block in `.bazelrc` defines. A normal or production build
+links a near-empty `TracyClient.cpp`, opens no socket, and collects nothing.
+
+Tracy is local-dev only and never CI-gated, alongside `just bench` and
+`just valgrind`. It answers "*where* in the code does the time go for this
+workload" — the live, per-thread, per-function complement to the aggregate
+Prometheus metrics and the isolated Google Benchmark microbenchmarks. See
+`docs/src/development/profiling.md`.
+
+## Considered options
+
+- **Always-linked, globally gated by `--config=tracy` — accepted.** One
+  `@tracy//:tracy` target, always in `//src:sipi_lib`'s graph; `--config=tracy`
+  defines `TRACY_ENABLE` globally so it reaches both `TracyClient.cpp` and every
+  instrumented first-party TU. The shim header `#include <tracy/Tracy.hpp>` is
+  therefore always resolvable, so instrumented code compiles in *every* config
+  (the macros are upstream no-ops without `TRACY_ENABLE`) with no `#ifdef` noise
+  at the call sites. Cost: the inert client TU compiles in normal/CI/Docker
+  builds, and the archive is fetched on every build. Both are negligible —
+  `TracyClient.cpp` reduces to the thread-name helpers in `common/TracySystem.cpp`
+  when disabled, and the fetch is one ~5 MB tarball behind the repository cache.
+
+- **`--define`-gated split target (`tracy_headers` always; `tracy_client` via
+  `select()`) — rejected (YAGNI).** Keeps the client TU out of non-Tracy builds
+  entirely, at the cost of a `bool_flag`/`config_setting`/`select()` apparatus and
+  a header-only-vs-client target split. The thing it saves — compiling one inert
+  TU — is not worth the machinery. Revisit only if Tracy must be provably absent
+  from production/CI artifacts.
+
+- **BCR `bazel_dep` — rejected (not available).** Tracy is not in the Bazel
+  Central Registry, so per ADR-0015 it is a native `cc_library` over an
+  `http_archive` (`bazel/tracy.BUILD.bazel`).
+
+- **Raw Tracy macros at every call site — rejected.** Instrumented code uses the
+  `SIPI_ZONE*` macros from `src/observability/profiling.h`, the single place
+  `<tracy/Tracy.hpp>` is included, so the codebase can be re-pointed at a different
+  profiler (or none) from one file. The lone exception is `src/shttps/Server.cpp`
+  worker-thread naming: shttps sits *below* observability in the dependency graph
+  and cannot include the shim without inverting that one-way direction, so it uses
+  the upstream header directly under an `#ifdef TRACY_ENABLE` guard.
+
+## Consequences
+
+- `MODULE.bazel`: `@tracy` `http_archive` pinned to v0.13.1.
+  `bazel/tracy.BUILD.bazel`: native `cc_library` — `srcs = [TracyClient.cpp]`,
+  the implementation `.cpp` files it textually `#include`s in `textual_hdrs`
+  (compiling them as `srcs` would double-compile and collide), `copts = ["-w"]`
+  to silence vendored-code warnings.
+- `.bazelrc`: a `build:tracy` block (`-DTRACY_ENABLE -DTRACY_ON_DEMAND
+  -fno-omit-frame-pointer -g --strip=never`). `TRACY_ON_DEMAND` keeps a
+  long-running server from buffering when no GUI is attached.
+- `justfile`: `bazel-build-tracy` (`-c opt --config=tracy`). `flake.nix`: a
+  `profiling` dev shell carrying the Tracy GUI on Linux (`brew install tracy` on
+  macOS — nixpkgs' GUI build is unreliable on aarch64-darwin).
+- Dependency edges for the shim: `//src/observability` gains `@tracy//:tracy` and
+  carries `profiling.h`; it propagates to `//src:sipi_lib`. `//src/shttps:shttps`
+  gains `@tracy//:tracy` for thread naming. The fuzz subset and the shared
+  `handlers/iiif_handler.cpp` are deliberately left untouched — the parse-tier
+  zone wraps the `parse_iiif_uri` *call site* in `SipiHttpServer.cpp` (sipi_lib
+  only), not the function body in the shared file.
+- Zero production impact: deployed binaries are built without `--config=tracy`,
+  so they carry no profiler. Verified by `bazel cquery` (the dep is present) plus
+  the absence of a listening socket at runtime.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -23,6 +23,7 @@ nav:
   - Developing: development/developing.md
   - Fuzz Testing: development/fuzzing.md
   - Benchmarking: development/benchmarking.md
+  - Profiling: development/profiling.md
   - Testing Strategy: development/testing-strategy.md
   - Downstream Dependencies: development/downstream-dependencies.md
   - Commit and PR Conventions: development/commit-conventions.md
@@ -91,6 +92,7 @@ plugins:
           - development/downstream-dependencies.md: "Runtime packages and downstream consumers"
           - development/fuzzing.md: "Fuzz testing with libFuzzer"
           - development/benchmarking.md: "Microbenchmarks with Google Benchmark: just bench, bench-compare, the regression decision rule"
+          - development/profiling.md: "Profiling with Tracy: just bazel-build-tracy, when to use Tracy vs Prometheus/Grafana vs bench, adding zones"
           - development/testing-strategy.md: "Testing strategy, coverage matrices, and feature inventory"
           - development/commit-conventions.md: "Commit organization and PR description conventions"
           - development/reviewer-guidelines.md: "Code review checklist for human and AI reviewers"

--- a/docs/src/development/profiling.md
+++ b/docs/src/development/profiling.md
@@ -1,0 +1,147 @@
+# Profiling
+
+Sipi integrates [Tracy](https://github.com/wolfpld/tracy), a real-time,
+nanosecond-resolution instrumentation profiler, to answer one question that the
+production metrics cannot: **for a given workload, where inside the request does
+the time actually go?** Tracy is opt-in, local-dev only, and adds zero overhead
+to normal builds.
+
+## When to use what
+
+Sipi has several observability and measurement tools. They do not overlap — each
+answers a different question, in a different place. Reaching for the wrong one
+wastes effort.
+
+| Tool | Question it answers | Scope | Where it runs | Overhead |
+|------|--------------------|-------|---------------|----------|
+| **Prometheus + Grafana** | *How does the service behave for real users — latency/cache/throughput distribution, in aggregate, over time? Is it trending worse?* | All requests, aggregated | **Production**, always-on | Negligible |
+| **Sentry** | *What broke, with what stack and context?* | Individual errors | Production | Negligible |
+| **OpenTelemetry tracing** *(not yet wired in Sipi)* | *For this one slow request, which stage ate the time?* | Per-request span tree | Production / staging | Low |
+| **Tracy** *(this doc)* | *Where in the code does the time go for this workload — per function, lock, allocation, thread, at ns resolution?* | One workload, deep | **Local dev**, opt-in | High while the GUI is connected |
+| **`just bench`** ([Benchmarking](benchmarking.md)) | *Did my specific change make this operation measurably faster?* | One isolated op | Local dev | Measurement harness |
+| **`just valgrind`** | *Is there a memory error or leak?* | Correctness, not speed | Local dev | Very high |
+
+A note on the production stack, because the three pieces are often conflated:
+**OpenTelemetry** is the instrumentation *standard* (how telemetry is emitted),
+**Prometheus** is the aggregate *metrics store* (the counters/gauges/histograms
+behind `GET /metrics`), and **Grafana** is the *visualization* layer on top.
+Sipi's production observability today is **Prometheus metrics + Sentry**; OTel
+tracing would be the per-request complement if and when it is added. None of them
+tell you which C++ function consumed the milliseconds — that is Tracy's job.
+
+## The loop
+
+The tools are stages of one workflow, not alternatives:
+
+1. **Grafana** surfaces *what matters to users* and *whether there is a problem*
+   (e.g. p99 latency on JP2 region requests is bad; cache hit-rate dropped).
+2. Reproduce that workload **locally**.
+3. **Tracy** shows you *where the time goes* in the code for that workload
+   (e.g. it is Kakadu decode, not encode; or an unexpected lock).
+4. **`just bench` + `just bench-compare`** *prove the fix* with the
+   [statistical-significance rule](benchmarking.md), on the same `-c opt` binary
+   and machine.
+5. Ship; **Grafana** *confirms* the production win.
+
+Tracy is step 3. Prometheus/Grafana are steps 1 and 5. Optimize from data, not
+from a hunch about which function "feels slow."
+
+## Building and running
+
+```bash
+just bazel-build-tracy        # -c opt --config=tracy //src/cli:sipi
+./bazel-bin/src/cli/sipi server --config config/sipi.localdev-config.lua
+```
+
+`just bazel-build-tracy` builds at `-c opt` (so the timeline reflects production
+codegen) and adds `--config=tracy`, which defines `TRACY_ENABLE` and
+`TRACY_ON_DEMAND` (see `.bazelrc`). Because the config touches every compile, the
+first Tracy build is a cold `-c opt` rebuild — subsequent ones are incremental.
+
+**On-demand.** With `TRACY_ON_DEMAND` the server collects nothing until the Tracy
+GUI connects, so it is safe to leave a Tracy build running. Connection is over TCP
+port **8086**.
+
+## Viewing the timeline
+
+The instrumented process listens on TCP port **8086** (`127.0.0.1`). The Tracy
+profiler can either connect to a live client or open a saved `.tracy` capture, and
+comes in two forms.
+
+### Browser — no install (easiest)
+
+<https://tracy.nereid.pl> is a WASM build that runs entirely in the page —
+nothing to install. It does both: click **Connect** and enter the client address
+(`127.0.0.1:8086` for a local run, or `host:8086` elsewhere), or load a saved
+`.tracy` capture file from disk.
+
+### Native desktop GUI
+
+The installable equivalent (same live-connect and capture-file loading).
+
+- **Linux:** `nix develop .#profiling` puts `tracy` (GUI) and `tracy-capture` on
+  your `PATH`.
+- **macOS:** `brew install tracy` (the nixpkgs GUI build is unreliable on
+  aarch64-darwin, so it is not in the `profiling` shell on macOS).
+
+Launch the profiler and click **Connect** (it auto-discovers a local client, or
+enter `host:8086`).
+
+To record a `.tracy` file headlessly — for CI, sharing, or feeding either viewer's
+file loader — `tracy-capture -o sipi.tracy` connects to the running client and
+captures until it disconnects.
+
+Either way, drive the server with IIIF requests; each worker thread
+(`sipi-worker`) shows a per-request timeline.
+
+## What is instrumented
+
+Zones mirror the four [benchmark tiers](benchmarking.md), so Tracy is the *live,
+end-to-end* counterpart to the *isolated, microbenchmark* view. A typical IIIF
+request decomposes as:
+
+```
+iiif_handler
+├─ parse_iiif_uri            (parse tier)
+└─ serve_iiif                (request handler)
+   ├─ SipiCache::check       (cache tier)
+   ├─ SipiImage::read        (decode tier)
+   │  └─ SipiIOJpeg::read    (or SipiIO{J2k,Tiff,Png}::read)
+   ├─ SipiImage::scale       (process tier)
+   ├─ SipiImage::rotate
+   ├─ SipiImage::convertToIcc
+   ├─ SipiIOJpeg::write      (encode tier)
+   └─ SipiCache::add
+```
+
+Instrumentation lives behind one first-party shim,
+[`src/observability/profiling.h`](../../../src/observability/profiling.h): code
+includes it and uses `SIPI_ZONE()` / `SIPI_ZONE_N("name")` rather than the Tracy
+macros directly, so the profiler dependency sits at a single site.
+
+## Adding a zone
+
+```cpp
+#include "observability/profiling.h"
+
+void SomeClass::hotMethod()
+{
+  SIPI_ZONE_N("SomeClass::hotMethod");   // or SIPI_ZONE() to use the function name
+  // ...
+}
+```
+
+`SIPI_ZONE*` expand to Tracy zones only under `--config=tracy`; in every other
+build they compile to nothing. The macros are RAII-scoped — the zone closes when
+the enclosing scope exits, including on early `return`.
+
+For a deeper dive (sampling, locks, memory, GPU), see the upstream
+[Tracy manual](https://github.com/wolfpld/tracy/releases) (`tracy.pdf`).
+
+## Why it is free when off
+
+Tracy is an unconditional Bazel dependency, but inert without `--config=tracy`:
+the entire profiler — sockets, sampling, the allocation arena — is gated behind
+`TRACY_ENABLE`, so a normal build links no listening socket and collects nothing.
+See [`docs/adr/0016-tracy-opt-in-dev-profiler.md`](../../adr/0016-tracy-opt-in-dev-profiler.md)
+for the rationale behind the always-present-but-inert wiring.

--- a/flake.nix
+++ b/flake.nix
@@ -124,6 +124,16 @@
               stdenv = pkgs.llvmPackages_19.libcxxStdenv;
               extraPackages = [ pkgs.llvmPackages_19.llvm ];
             };
+            # Tracy profiler GUI + capture tool, for `just bazel-build-tracy`
+            # sessions. Local-dev only. Gated to Linux: the nixpkgs `tracy` GUI
+            # build is unreliable on aarch64-darwin, so macOS devs install the
+            # GUI via `brew install tracy` instead (it connects over TCP, so a
+            # macOS GUI can also attach to a Tracy-instrumented server on Linux).
+            profiling = mkSipiShell {
+              name = "sipi-profiling";
+              stdenv = pkgs.llvmPackages_19.libcxxStdenv;
+              extraPackages = pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.tracy ];
+            };
           };
         }
       );

--- a/justfile
+++ b/justfile
@@ -152,6 +152,19 @@ bazel-build-sanitized *FLAGS='':
     bazel build --config=asan --config=ubsan --verbose_failures --stamp {{FLAGS}} //src/cli:sipi
     @echo "Binary at: $(pwd)/bazel-bin/src/cli/sipi"
 
+# Tracy-instrumented profiling build: `-c opt --config=tracy`. Local dev only,
+# never CI-gated (like `bench` / `valgrind`). `-c opt` so the timeline reflects
+# production codegen; `--config=tracy` (see `.bazelrc`) defines TRACY_ENABLE +
+# TRACY_ON_DEMAND so the binary profiles only while the Tracy GUI is connected.
+# Run the binary, then open the Tracy profiler and Connect (TCP 8086). The GUI
+# comes from `nix develop .#profiling` on Linux or `brew install tracy` on macOS;
+# it connects over the network too, so a macOS GUI can profile a Linux server.
+# See docs/src/development/profiling.md.
+bazel-build-tracy *FLAGS='':
+    bazel build -c opt --config=tracy --verbose_failures --stamp {{FLAGS}} //src/cli:sipi
+    @echo "Tracy-instrumented binary at: $(pwd)/bazel-bin/src/cli/sipi"
+    @echo "Run it, then open the Tracy profiler and Connect (localhost:8086)."
+
 # Resolve the per-host fuzz `--platforms=` label. linux-x86_64 → libstdc++
 # toolchain (`@llvm_toolchain_fuzz`) for libFuzzer ABI parity with the
 # prior CMake build. darwin-aarch64 → default `@llvm_toolchain` (Apple SDK

--- a/src/SipiCache.cpp
+++ b/src/SipiCache.cpp
@@ -29,6 +29,7 @@
 #include "SipiCache.h"
 #include "SipiError.hpp"
 #include "observability/metrics.h"
+#include "observability/profiling.h"
 #include "shttps/Global.h"
 #include "logging/logger.h"
 
@@ -376,6 +377,7 @@ int SipiCache::purge(bool use_lock)
 
 std::string SipiCache::check(const std::string &origpath_p, const std::string &canonical_p, bool block_file)
 {
+  SIPI_ZONE_N("SipiCache::check");
   struct stat fileinfo;
   SipiCache::CacheRecord fr;
 
@@ -459,6 +461,7 @@ void SipiCache::add(const std::string &origpath_p,
   int clevels_p,
   int numpages_p)
 {
+  SIPI_ZONE_N("SipiCache::add");
   size_t pos = cachepath_p.rfind('/');
   std::string cachepath;
 

--- a/src/SipiHttpServer.cpp
+++ b/src/SipiHttpServer.cpp
@@ -41,6 +41,7 @@
 #include "logging/logger.h"
 #include "SipiHttpServer.hpp"
 #include "observability/metrics.h"
+#include "observability/profiling.h"
 #include "generated/SipiVersion.h"
 #include "SipiMemoryBudget.h"
 #include "SipiPeakMemory.h"
@@ -1442,6 +1443,7 @@ static void serve_iiif(Connection &conn_obj,
   const std::string &uri,
   std::vector<std::string> params)
 {
+  SIPI_ZONE_N("serve_iiif");
   auto not_head_request = conn_obj.method() != Connection::HEAD;
   //
   // getting the identifier (which in case of a PDF or multipage TIFF my contain a page id (identifier@pagenum)
@@ -2129,6 +2131,7 @@ static void serve_iiif(Connection &conn_obj,
  */
 static void iiif_handler(Connection &conn_obj, shttps::LuaServer &luaserver, void *user_data, void *dummy)
 {
+  SIPI_ZONE_N("iiif_handler");
   auto *serv = static_cast<SipiHttpServer *>(user_data);
   const bool prefix_as_path = serv->prefix_as_path();
   const auto uri = conn_obj.uri();// has form "/pre/fix/es.../BAU_1_000441077_2_1.j2k/full/,1000/0/default.jpg"
@@ -2136,12 +2139,15 @@ static void iiif_handler(Connection &conn_obj, shttps::LuaServer &luaserver, voi
   std::vector<std::string> params{};
   auto request_type{ handlers::iiif_handler::UNDEFINED };
 
-  if (auto parse_url_result = handlers::iiif_handler::parse_iiif_uri(uri); parse_url_result.has_value()) {
-    params = parse_url_result.value().params;
-    request_type = parse_url_result.value().request_type;
-  } else {
-    send_error(conn_obj, Connection::BAD_REQUEST, parse_url_result.error());
-    return;
+  {
+    SIPI_ZONE_N("parse_iiif_uri");
+    if (auto parse_url_result = handlers::iiif_handler::parse_iiif_uri(uri); parse_url_result.has_value()) {
+      params = parse_url_result.value().params;
+      request_type = parse_url_result.value().request_type;
+    } else {
+      send_error(conn_obj, Connection::BAD_REQUEST, parse_url_result.error());
+      return;
+    }
   }
 
   switch (request_type) {

--- a/src/SipiImage.cpp
+++ b/src/SipiImage.cpp
@@ -28,6 +28,7 @@
 #include "formats/SipiIOPng.h"
 #include "formats/SipiIOTiff.h"
 #include "observability/metrics.h"
+#include "observability/profiling.h"
 #include "shttps/Global.h"
 #include "shttps/Hash.h"
 
@@ -280,6 +281,7 @@ void SipiImage::read(const std::string &filepath,
   bool force_bps_8,
   ScalingQuality scaling_quality)
 {
+  SIPI_ZONE_N("SipiImage::read");
   size_t pos = filepath.find_last_of('.');
   std::string fext = filepath.substr(pos + 1);
   std::string _fext;
@@ -356,6 +358,7 @@ std::vector<std::byte> SipiImage::compute_pixel_hash(shttps::HashType type) cons
 
 SipiImgInfo SipiImage::read_shape(const std::string &filepath) const
 {
+  SIPI_ZONE_N("SipiImage::read_shape");
   size_t pos = filepath.find_last_of('.');
   std::string fext = filepath.substr(pos + 1);
   std::string _fext;
@@ -475,6 +478,7 @@ void SipiImage::convertYCC2RGB()
 
 void SipiImage::convertToIcc(const Icc &target_icc_p, int new_bps)
 {
+  SIPI_ZONE_N("SipiImage::convertToIcc");
   cmsSetLogErrorHandler(icc_error_logger);
   cmsUInt32Number in_formatter, out_formatter;
 
@@ -711,6 +715,7 @@ void SipiImage::removeChannel(const unsigned int channel, const bool force_gray_
 
 bool SipiImage::crop(int x, int y, size_t width, size_t height)
 {
+  SIPI_ZONE_N("SipiImage::crop");
   if (x < 0) {
     width += x;
     x = 0;
@@ -908,6 +913,7 @@ word SipiImage::bilinn(word buf[], const int nx, const int ny, const double x, c
 
 bool SipiImage::scaleFast(size_t nnx, size_t nny)
 {
+  SIPI_ZONE_N("SipiImage::scaleFast");
   if (nnx <= 1 || nny <= 1 || nx <= 1 || ny <= 1) {
     log_warn("scaleFast: degenerate dimensions (src=%zux%zu, dst=%zux%zu), skipping", nx, ny, nnx, nny);
     return false;
@@ -953,6 +959,7 @@ bool SipiImage::scaleFast(size_t nnx, size_t nny)
 
 bool SipiImage::scaleMedium(size_t nnx, size_t nny)
 {
+  SIPI_ZONE_N("SipiImage::scaleMedium");
   if (nnx <= 1 || nny <= 1 || nx <= 1 || ny <= 1) {
     log_warn("scaleMedium: degenerate dimensions (src=%zux%zu, dst=%zux%zu), skipping", nx, ny, nnx, nny);
     return false;
@@ -1008,6 +1015,7 @@ bool SipiImage::scaleMedium(size_t nnx, size_t nny)
 
 bool SipiImage::scale(size_t nnx, size_t nny)
 {
+  SIPI_ZONE_N("SipiImage::scale");
   if (nnx <= 1 || nny <= 1 || nx <= 1 || ny <= 1) {
     log_warn("scale: degenerate dimensions (src=%zux%zu, dst=%zux%zu), skipping", nx, ny, nnx, nny);
     return false;
@@ -1132,6 +1140,7 @@ bool SipiImage::scale(size_t nnx, size_t nny)
 
 bool SipiImage::rotate(float angle, bool mirror)
 {
+  SIPI_ZONE_N("SipiImage::rotate");
   if (mirror) {
     if (bps == 8) {
       byte *inbuf = (byte *)pixels;
@@ -1432,6 +1441,7 @@ bool SipiImage::to8bps()
 
 bool SipiImage::toBitonal()
 {
+  SIPI_ZONE_N("SipiImage::toBitonal");
   if ((photo != PhotometricInterpretation::MINISBLACK) && (photo != PhotometricInterpretation::MINISWHITE)) {
     convertToIcc(Icc(icc_GRAY_D50), 8);
   }

--- a/src/formats/SipiIOJ2k.cpp
+++ b/src/formats/SipiIOJ2k.cpp
@@ -41,6 +41,7 @@
 #include "SipiImageError.hpp"
 #include "formats/SipiIOJ2k.h"
 #include "logging/logger.h"
+#include "observability/profiling.h"
 
 using namespace kdu_core;
 using namespace kdu_supp;
@@ -231,6 +232,7 @@ bool SipiIOJ2k::read(SipiImage *img,
   bool force_bps_8,
   ScalingQuality scaling_quality)
 {
+  SIPI_ZONE_N("SipiIOJ2k::read");
   if (!is_jpx(filepath.c_str())) return false;// It's not a JPGE2000....
 
   int num_threads;
@@ -685,6 +687,7 @@ bool SipiIOJ2k::read(SipiImage *img,
 
 SipiImgInfo SipiIOJ2k::read_shape(const std::string &filepath)
 {
+  SIPI_ZONE_N("SipiIOJ2k::read_shape");
   SipiImgInfo info;
   if (!is_jpx(filepath.c_str())) {
     info.success = SipiImgInfo::FAILURE;
@@ -893,6 +896,7 @@ static void write_essentials_box(kdu_supp::jp2_family_tgt *tgt, const std::vecto
 
 void SipiIOJ2k::write(SipiImage *img, const std::string &filepath, const SipiCompressionParams *params)
 {
+  SIPI_ZONE_N("SipiIOJ2k::write");
   kdu_customize_warnings(&kdu_sipi_warn);
   kdu_customize_errors(&kdu_sipi_error);
 

--- a/src/formats/SipiIOJpeg.cpp
+++ b/src/formats/SipiIOJpeg.cpp
@@ -27,6 +27,7 @@
 #include "SipiImage.hpp"
 #include "SipiImageError.hpp"
 #include "formats/SipiIOJpeg.h"
+#include "observability/profiling.h"
 
 #include "jerror.h"
 #include "jpeglib.h"
@@ -483,6 +484,7 @@ bool SipiIOJpeg::read(SipiImage *img,
   bool force_bps_8,
   ScalingQuality scaling_quality)
 {
+  SIPI_ZONE_N("SipiIOJpeg::read");
   int infile;
   //
   // open the input file
@@ -846,6 +848,7 @@ bool SipiIOJpeg::read(SipiImage *img,
 
 SipiImgInfo SipiIOJpeg::read_shape(const std::string &filepath)
 {
+  SIPI_ZONE_N("SipiIOJpeg::read_shape");
   SipiImgInfo info;
   //
   // open the input file
@@ -1037,6 +1040,7 @@ SipiImgInfo SipiIOJpeg::read_shape(const std::string &filepath)
 
 void SipiIOJpeg::write(SipiImage *img, const std::string &filepath, const SipiCompressionParams *params)
 {
+  SIPI_ZONE_N("SipiIOJpeg::write");
   int quality = 80;
   if ((params != nullptr) && (!params->empty())) {
     try {

--- a/src/formats/SipiIOPng.cpp
+++ b/src/formats/SipiIOPng.cpp
@@ -25,6 +25,7 @@
 #include "logging/logger.h"
 #include "SipiImageError.hpp"
 #include "formats/SipiIOPng.h"
+#include "observability/profiling.h"
 
 // bad hack in order to include definitions in png.h on debian systems
 #if !defined(PNG_TEXT_SUPPORTED)
@@ -132,6 +133,7 @@ bool SipiIOPng::read(SipiImage *img,
   bool force_bps_8,
   ScalingQuality scaling_quality)
 {
+  SIPI_ZONE_N("SipiIOPng::read");
   FILE *infile;
   unsigned char header[PNG_BYTES_TO_CHECK];
   png_structp png_ptr;
@@ -344,6 +346,7 @@ bool SipiIOPng::read(SipiImage *img,
 
 SipiImgInfo SipiIOPng::read_shape(const std::string &filepath)
 {
+  SIPI_ZONE_N("SipiIOPng::read_shape");
   SipiImgInfo info;
   unsigned char header[8];
 
@@ -461,6 +464,7 @@ static void conn_flush_data(png_structp png_ptr)
 
 void SipiIOPng::write(SipiImage *img, const std::string &filepath, const SipiCompressionParams *params)
 {
+  SIPI_ZONE_N("SipiIOPng::write");
   FILE *outfile = nullptr;
   png_structp png_ptr;
 

--- a/src/formats/SipiIOTiff.cpp
+++ b/src/formats/SipiIOTiff.cpp
@@ -26,6 +26,7 @@
 #include "SipiImageError.hpp"
 #include "formats/SipiIOTiff.h"
 #include "observability/metrics.h"
+#include "observability/profiling.h"
 
 
 #include "shttps/Global.h"
@@ -886,6 +887,7 @@ bool SipiIOTiff::read(SipiImage *img,
   bool force_bps_8,
   ScalingQuality scaling_quality)
 {
+  SIPI_ZONE_N("SipiIOTiff::read");
   TIFF *tif;
 
   if (nullptr != (tif = TIFFOpen(filepath.c_str(), "r"))) {
@@ -1462,6 +1464,7 @@ bool SipiIOTiff::read(SipiImage *img,
 
 SipiImgInfo SipiIOTiff::read_shape(const std::string &filepath)
 {
+  SIPI_ZONE_N("SipiIOTiff::read_shape");
   SipiImgInfo info;
   auto tif = std::unique_ptr<TIFF, decltype(&TIFFClose)>(TIFFOpen(filepath.c_str(), "r"), TIFFClose);
   if (tif) {
@@ -1617,6 +1620,7 @@ void SipiIOTiff::write_basic_tags(const SipiImage &img,
 
 void SipiIOTiff::write(SipiImage *img, const std::string &filepath, const SipiCompressionParams *params)
 {
+  SIPI_ZONE_N("SipiIOTiff::write");
   TIFF *tif;
   MEMTIFF *memtif = nullptr;
   auto rowsperstrip = (uint32_t)-1;

--- a/src/observability/BUILD.bazel
+++ b/src/observability/BUILD.bazel
@@ -39,6 +39,10 @@ cc_library(
     hdrs = [
         "connection_metrics_adapter.h",
         "metrics.h",
+        # The Tracy zone-macro shim. Header-only; the `@tracy//:tracy` dep below
+        # propagates the (inert-unless-`--config=tracy`) profiler to every
+        # //src:sipi_lib TU that `#include "observability/profiling.h"`.
+        "profiling.h",
         "sentry.h",
         "sentry_init.h",
     ],
@@ -56,6 +60,9 @@ cc_library(
         "//src/shttps:shttps",
         "//src:sipi_generated_hdrs",
         "@prometheus-cpp//core",
+        # Profiler shim (profiling.h). Inert unless `--config=tracy` defines
+        # TRACY_ENABLE; see bazel/tracy.BUILD.bazel.
+        "@tracy//:tracy",
     ],
 )
 

--- a/src/observability/profiling.h
+++ b/src/observability/profiling.h
@@ -1,0 +1,33 @@
+#ifndef SIPI_OBSERVABILITY_PROFILING_H
+#define SIPI_OBSERVABILITY_PROFILING_H
+
+// The single first-party touch-point for Tracy (https://github.com/wolfpld/tracy).
+// Instrumented code includes this header and uses the SIPI_* macros below; it
+// never includes <tracy/Tracy.hpp> directly. That keeps the profiler dependency
+// at one site and lets the whole codebase be re-pointed at a different profiler
+// (or none) by editing this file alone.
+//
+// Tracy is opt-in and dev-only: the macros expand to Tracy zones only under
+// `--config=tracy` (which defines TRACY_ENABLE; see .bazelrc and
+// docs/src/development/profiling.md). In every other build
+// <tracy/Tracy.hpp> defines its own macros as no-ops, so SIPI_ZONE* compile to
+// nothing — zero overhead, nothing to strip.
+//
+// Worker-thread naming in src/shttps/ uses <tracy/Tracy.hpp> directly rather
+// than this shim, because shttps sits below observability in the dependency
+// graph and cannot include this header without inverting that direction.
+#include <tracy/Tracy.hpp>
+
+// Profile the enclosing scope; the zone is labelled with the function name.
+#define SIPI_ZONE() ZoneScoped
+
+// Profile the enclosing scope under an explicit name. Prefer this where the
+// function name alone is ambiguous (e.g. the four format handlers' read()/
+// write(), which would otherwise all show up as "read"/"write").
+#define SIPI_ZONE_N(name) ZoneScopedN(name)
+
+// Mark the end of one logical unit of work (one IIIF request) for Tracy's
+// per-frame throughput view.
+#define SIPI_FRAME(name) FrameMarkNamed(name)
+
+#endif  // SIPI_OBSERVABILITY_PROFILING_H

--- a/src/shttps/BUILD.bazel
+++ b/src/shttps/BUILD.bazel
@@ -85,7 +85,13 @@ cc_library(
             "Shttp.cpp",  # standalone test driver, not part of the library
         ],
     ),
-    deps = [":shttps_headers"],
+    deps = [
+        ":shttps_headers",
+        # Server.cpp names the pool's worker threads for the Tracy timeline
+        # (`tracy::SetThreadName`). External dep, so it does not breach the
+        # SIPI→shttps one-way rule. Inert unless `--config=tracy`.
+        "@tracy//:tracy",
+    ],
 )
 
 # ── //src/shttps:fuzz_subset — minimal slice for libFuzzer ─────────────────────

--- a/src/shttps/Server.cpp
+++ b/src/shttps/Server.cpp
@@ -38,6 +38,11 @@
 #include "SockStream.h"
 #include "makeunique.h"
 
+// Tracy thread naming. shttps sits below //src/observability in the dependency
+// graph, so it uses the upstream header directly rather than the first-party
+// `observability/profiling.h` shim. Inert unless `--config=tracy`.
+#include <tracy/Tracy.hpp>
+
 static std::mutex debugio;// mutex to protect debugging messages from threads
 
 namespace shttps {
@@ -685,6 +690,9 @@ static int close_socket(const SocketControl::SocketInfo &socket_info)
 // waiting at the socket level, as soon as a thread from the thread pool is available.
 static void *socket_request_processor(void *arg)
 {
+#ifdef TRACY_ENABLE
+  tracy::SetThreadName("sipi-worker");
+#endif
   auto *tdata = static_cast<ThreadControl::ThreadChildData *>(arg);
   // pthread_t my_tid = pthread_self();
 


### PR DESCRIPTION
## Motivation

SIPI's production observability (Prometheus `/metrics`) exposes only an aggregate
request-duration histogram — there is no way to see *where inside a request* the
time goes (parse vs decode vs the process operators vs encode vs cache), live, per
worker thread, under load. The microbenchmarks measure each stage in isolation but
can't watch a real server.

## Summary

- Opt-in, dev-only Tracy profiler: `just bazel-build-tracy` → run → connect the Tracy GUI over TCP 8086.
- Hot-path zones mirror the four benchmark tiers; worker threads are named `sipi-worker`.
- Zero production overhead — the profiler is inert unless built with `--config=tracy`.

## Key Changes

### Build
- `@tracy` vendored as a native `cc_library` (not on BCR) pinned to v0.13.1; `--config=tracy` block in `.bazelrc` (`TRACY_ENABLE` + `TRACY_ON_DEMAND` + frame-pointer/symbol flags); `just bazel-build-tracy`; a `profiling` Nix dev shell (Tracy GUI on Linux).

### Instrumentation
- `src/observability/profiling.h` shim — the single Tracy touch-point (`SIPI_ZONE_N`). Zones on `parse_iiif_uri`, `SipiCache::check/add`, `SipiImage::read`/`read_shape` + each `SipiIO{Jpeg,J2k,Tiff,Png}::read/read_shape/write`, the process operators, and `iiif_handler`/`serve_iiif`; `sipi-worker` thread naming in shttps.

### Docs
- `docs/src/development/profiling.md` leads with *when to use what* (Tracy vs Prometheus/Grafana vs `just bench` vs valgrind) and the loop that ties them together; `docs/adr/0016-tracy-opt-in-dev-profiler.md`; CLAUDE.md / building.md recipe.

## Challenges and Decisions

### Always-linked vs gated dependency
**Problem:** instrumented code must compile against Tracy in every build, yet production must carry nothing.
**Tried:** a `--define`/`select()`-gated split (headers always, client only under `--config=tracy`) — extra `config_setting`/`bool_flag` machinery.
**Solution:** one always-present `@tracy//:tracy`; the whole profiler is gated behind `TRACY_ENABLE` (only `--config=tracy` defines it), so the client TU reduces to thread-name helpers when off — no socket, no buffering. Simpler, genuinely zero runtime cost. See ADR-0016.

### Parse-tier zone without touching the fuzz graph
**Problem:** `parse_iiif_uri` lives in `handlers/iiif_handler.cpp`, which is shared with the libFuzzer `fuzz_subset`.
**Solution:** wrap the zone at the `parse_iiif_uri` *call site* in `SipiHttpServer.cpp` (sipi_lib only), leaving the shared file and the fuzz graph untouched.

## Gotchas

- This branch and `refactor/header-hygiene` both edit `SipiImage.cpp` / `SipiHttpServer.cpp` / `SipiCache.cpp` / `formats/*.cpp` (zones here vs the `SipiImage.hpp`→`.h` include rewrite there). They conflict on the include line — rebase whichever merges second.
- Sanitizer/fuzz builds fail on macOS (pre-existing hermetic-LLVM gap, unrelated to this change); they gate on linux-x86_64 in CI.
- To view on macOS, `brew install tracy` (nixpkgs' GUI build is unreliable on aarch64-darwin); the GUI connects over TCP, so it can also profile a Linux server.

## Test Plan

- [x] `just bazel-build` + `just bazel-test-unit` (17/17) green; `@tracy` present but inert
- [x] `just bazel-build-tracy` links (`-c opt`); running it listens on `:8086`; a normal build does **not** (zero overhead, confirmed via `lsof`)
- [ ] Connect the Tracy GUI, issue IIIF requests across jpg/jp2/tif/png, confirm nested zones per `sipi-worker` thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)
