### PR TITLE
refactor(formats): decouple the image write path from shttps::Connection

### DIFF
--- a/include/SipiIO.h
+++ b/include/SipiIO.h
@@ -15,6 +15,7 @@
 
 #include "iiifparser/SipiRegion.h"
 #include "iiifparser/SipiSize.h"
+#include "formats/output_sink.h"
 
 #include <memory>
 
@@ -168,17 +169,15 @@ public:
 
 
   /*!
-   * Write an image for a file using the given file format implemented by the subclass
+   * Write an image using the given file format implemented by the subclass.
    *
    * \param img Pointer to SipiImage instance
-   * \param filepath Name of the image file to be written. Please note that
-   * - "-" means to write the image data to stdout
-   * - "HTTP" means to write the image data to the HTTP-server output
+   * \param sink Where the encoded bytes go (ADR-0006). A `FilePath` is written
+   * via the codec's native file/stdout writer (`"-"`/`"stdout:"` mean stdout);
+   * a `CallbackSink` or `TeeSink` is streamed through `SinkStream`.
    * \param params Compression parameters
    */
-  virtual void write(SipiImage *img, const std::string &filepath, const SipiCompressionParams *params) = 0;
-
-  void write(SipiImage *img, const std::string &filepath) { write(img, filepath, nullptr); }
+  virtual void write(SipiImage *img, const OutputSink &sink, const SipiCompressionParams *params) = 0;
 };
 }// namespace Sipi
 

--- a/include/formats/SipiIOJ2k.h
+++ b/include/formats/SipiIOJ2k.h
@@ -52,12 +52,13 @@ public:
   Sipi::SipiImgInfo read_shape(const std::string &filepath) override;
 
   /*!
-   * Write a TIFF image to a file, stdout or to a memory buffer
+   * Write a JPEG2000 image to the given OutputSink (file/stdout, or a streamed
+   * callback/tee per ADR-0006).
    *
    * \param *img Pointer to SipiImage instance
-   * \param filepath Name of the image file to be written.
+   * \param sink Where the encoded bytes go.
    */
-  void write(SipiImage *img, const std::string &filepath, const SipiCompressionParams *params) override;
+  void write(SipiImage *img, const OutputSink &sink, const SipiCompressionParams *params) override;
 };
 }// namespace Sipi
 

--- a/include/formats/SipiIOJpeg.h
+++ b/include/formats/SipiIOJpeg.h
@@ -52,12 +52,13 @@ public:
   Sipi::SipiImgInfo read_shape(const std::string &filepath) override;
 
   /*!
-   * Write a JPEG image to a file, stdout or to a memory buffer
+   * Write a JPEG image to the given OutputSink (file/stdout, or a streamed
+   * callback/tee per ADR-0006).
    *
    * \param *img Pointer to SipiImage instance
-   * \param filepath Name of the image file to be written.
+   * \param sink Where the encoded bytes go.
    */
-  void write(SipiImage *img, const std::string &filepath, const SipiCompressionParams *params) override;
+  void write(SipiImage *img, const OutputSink &sink, const SipiCompressionParams *params) override;
 };
 
 }// namespace Sipi

--- a/include/formats/SipiIOPng.h
+++ b/include/formats/SipiIOPng.h
@@ -49,16 +49,11 @@ public:
   /*!
    * Write a PNG image to a file, stdout or to a memory buffer
    *
-   * If the filepath is "-", the PNG file is built in an internal memory buffer
-   * and after finished transfered to stdout. This is necessary because libtiff
-   * makes extensive use of "lseek" which is not available on stdout!
-   *
    * \param *img Pointer to SipiImage instance
-   * \param filepath Name of the image file to be written. Please note that
-   * - "-" means to write the image data to stdout
-   * - "HTTP" means to write the image data to the HTTP-server output
+   * \param sink Where the encoded bytes go (ADR-0006): a FilePath (file or
+   * stdout via "-"/"stdout:"), or a streamed CallbackSink / TeeSink.
    */
-  void write(SipiImage *img, const std::string &filepath, const SipiCompressionParams *params) override;
+  void write(SipiImage *img, const OutputSink &sink, const SipiCompressionParams *params) override;
 };
 }// namespace Sipi
 

--- a/include/formats/SipiIOTiff.h
+++ b/include/formats/SipiIOTiff.h
@@ -103,16 +103,15 @@ public:
   /*!
    * Write a TIFF image to a file, stdout or to a memory buffer
    *
-   * If the filepath is "-", the TIFF file is built in an internal memory buffer
-   * and after finished transfered to stdout. This is necessary because libtiff
-   * makes extensive use of "lseek" which is not available on stdout!
+   * For a streamed sink (callback/tee) or stdout the TIFF is built in an
+   * internal memory buffer first, because libtiff makes extensive use of
+   * "lseek" which is not available on a non-seekable destination.
    *
    * \param *img Pointer to SipiImage instance
-   * \param filepath Name of the image file to be written. Please note that
-   * - "-" means to write the image data to stdout
-   * - "HTTP" means to write the image data to the HTTP-server output
+   * \param sink Where the encoded bytes go (ADR-0006): a FilePath (file or
+   * stdout via "-"/"stdout:"), or a streamed CallbackSink / TeeSink.
    */
-  void write(SipiImage *img, const std::string &filepath, const SipiCompressionParams *params) override;
+  void write(SipiImage *img, const OutputSink &sink, const SipiCompressionParams *params) override;
 };
 }// namespace Sipi
 

--- a/include/formats/output_sink.h
+++ b/include/formats/output_sink.h
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2016 - 2024 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+ * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/*!
+ * Typed write destinations for the format handlers (ADR-0006).
+ *
+ * `OutputSink` replaces the magic-string filepath sentinels (`"-"`/`"stdout:"`
+ * for stdout, `"HTTP"` for the HTTP-server output) at the `SipiIO::write`
+ * surface. It is deliberately free of any `shttps`/HTTP types: the HTTP socket
+ * is reached only through `CallbackSink`'s opaque C-ABI callback, so
+ * `src/formats/` carries no dependency on the transport layer. That callback
+ * signature (`SipiWriteFn`) is fixed here and reused verbatim by the Phase B/C
+ * FFI seam, where the Rust shell supplies the body-write callback.
+ */
+#ifndef SIPI_FORMATS_OUTPUT_SINK_H
+#define SIPI_FORMATS_OUTPUT_SINK_H
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace Sipi {
+
+/*!
+ * Opaque body-write callback. Returns 0 on success, non-zero on a write
+ * failure (peer gone, socket error). Identical to the Phase B/C FFI
+ * `SipiWriteFn`: a pure C-ABI callback so Rust can supply it unchanged.
+ */
+extern "C" {
+typedef int (*SipiWriteFn)(void *ctx, const uint8_t *data, size_t len);
+}
+
+/*!
+ * A filesystem path. `"-"` / `"stdout:"` keep their stdout meaning. Stdout is
+ * deliberately folded into FilePath rather than given a separate StdoutSink
+ * alternative (ADR-0006 listed one): each codec already special-cases the
+ * stdout string against its native writer, so a distinct type would add nothing.
+ */
+struct FilePath
+{
+  std::string path;
+};
+
+/*! An opaque C-ABI sink — the HTTP socket today, a Rust-owned sink in Phase C. */
+struct CallbackSink
+{
+  SipiWriteFn write;
+  void *ctx;
+};
+
+struct TeeSink;//!< forward declaration (a variant alternative may contain the variant)
+
+/*!
+ * Where encoded image bytes go. `FilePath` is handled by each codec's native
+ * file/stdout writer; `CallbackSink` and `TeeSink` are streamed through
+ * `SinkStream` (the codec drives its destination manager chunk-by-chunk).
+ */
+using OutputSink = std::variant<FilePath, CallbackSink, TeeSink>;
+
+/*!
+ * Broadcasts each encoded chunk to several sinks at once. Replaces the
+ * dual-write-to-socket-and-cache tee that `shttps::Connection` performs today
+ * (`openCacheFile` + `sendAndFlush`); per ADR-0007 the tee lives in the write
+ * loop, not in the request handler.
+ */
+struct TeeSink
+{
+  std::vector<OutputSink> sinks;
+};
+
+/*!
+ * True when the codec must stream the destination through `SinkStream` rather
+ * than use its native seekable file/stdout writer — i.e. for any sink that is
+ * not a bare `FilePath`.
+ */
+[[nodiscard]] bool is_streaming_sink(const OutputSink &sink);
+
+/*!
+ * Drives an `OutputSink` as a forward-only byte stream. A codec's destination
+ * manager (libjpeg dest mgr, libpng write fn, Kakadu `kdu_compressed_target`,
+ * the TIFF mem-buffer dump) calls `write()` once per encoded chunk.
+ *
+ * Failure policy mirrors `shttps::Connection`'s tee exactly:
+ * - A `CallbackSink` (the HTTP socket) is **fatal** — a non-zero return
+ *   propagates so the codec aborts its encode (the equivalent of today's
+ *   `OUTPUT_WRITE_FAIL`-driven abort), without a C++ exception crossing the
+ *   codec's C frames.
+ * - A `FilePath` leaf (the cache file in a tee) is **best-effort** — a write
+ *   or open failure is swallowed, matching shttps, which never aborts a
+ *   response because the cache write failed.
+ */
+class SinkStream
+{
+public:
+  explicit SinkStream(const OutputSink &sink);
+
+  /*! Write one chunk. Returns 0 on success, non-zero if a fatal sink failed. */
+  [[nodiscard]] int write(const uint8_t *data, size_t len);
+
+private:
+  struct Leaf
+  {
+    SipiWriteFn fn{ nullptr };//!< set for a CallbackSink leaf
+    void *ctx{ nullptr };
+    std::shared_ptr<std::ostream> file;//!< set for a FilePath leaf
+    bool fatal{ false };//!< CallbackSink failures abort; FilePath failures don't
+  };
+
+  void flatten(const OutputSink &sink);
+
+  std::vector<Leaf> leaves_;
+};
+
+}// namespace Sipi
+
+#endif// SIPI_FORMATS_OUTPUT_SINK_H

--- a/src/SipiHttpServer.cpp
+++ b/src/SipiHttpServer.cpp
@@ -1988,25 +1988,46 @@ static void serve_iiif(Connection &conn_obj,
     return;
   }
 
-  img.connection(&conn_obj);
   conn_obj.header("Cache-Control", "must-revalidate, post-check=0, pre-check=0");
   std::string cachefile;
 
   bool skip_cache = false;
 
+  // Body-write callback bridging the connection to the OutputSink seam — the
+  // one place shttps meets the format handlers in the IIIF write path. An
+  // shttps throw (OUTPUT_WRITE_FAIL / shttps::Error) must not cross into the
+  // codec (the Phase B/C FFI no-throw rule), so it becomes a non-zero return.
+  auto socket_write = [](void *ctx, const uint8_t *data, size_t len) -> int {
+    try {
+      static_cast<Connection *>(ctx)->sendAndFlush(data, len);
+      return 0;
+    } catch (...) {
+      return 1;
+    }
+  };
+
   try {
-    if (cache != nullptr) {
-      if (!skip_cache) {
-        try {
-          //!> open the cache file to write into.
-          cachefile = cache->getNewCacheFileName();
-          conn_obj.openCacheFile(cachefile);
-        } catch (const shttps::Error &err) {
-          send_error(conn_obj, Connection::INTERNAL_SERVER_ERROR, err);
-          return;
-        }
+    if (cache != nullptr && !skip_cache) {
+      //!> name the cache file to write into.
+      cachefile = cache->getNewCacheFileName();
+      // Preserve openCacheFile()'s writability check: a cache file we cannot
+      // create is a 500. The FilePath sink itself treats writes as best-effort.
+      std::ofstream cache_probe(cachefile, std::ofstream::out | std::ofstream::binary | std::ofstream::trunc);
+      if (cache_probe.fail()) {
+        send_error(conn_obj, Connection::INTERNAL_SERVER_ERROR, "Could not open cache file!");
+        return;
       }
     }
+
+    // The encoder writes once; the bytes are broadcast to the socket and, when
+    // caching, the cache file. This is the tee shttps::Connection performed via
+    // openCacheFile + sendAndFlush, moved into the write loop (ADR-0007).
+    const Sipi::OutputSink sink =
+      (cache != nullptr && !skip_cache)
+        ? Sipi::OutputSink{ Sipi::TeeSink{
+            { Sipi::CallbackSink{ socket_write, &conn_obj }, Sipi::FilePath{ cachefile } } } }
+        : Sipi::OutputSink{ Sipi::CallbackSink{ socket_write, &conn_obj } };
+
     switch (quality_format.format()) {
     case SipiQualityFormat::JPG: {
       conn_obj.status(Connection::OK);
@@ -2014,7 +2035,7 @@ static void serve_iiif(Connection &conn_obj,
       conn_obj.header("Content-Type", "image/jpeg");// set the header (mimetype)
       conn_obj.setChunkedTransfer();
       Sipi::SipiCompressionParams qp = { { JPEG_QUALITY, std::to_string(server->jpeg_quality()) } };
-      if (not_head_request) img.write("jpg", "HTTP", &qp);
+      if (not_head_request) img.write("jpg", sink, &qp);
       break;
     }
     case SipiQualityFormat::JP2: {
@@ -2022,7 +2043,7 @@ static void serve_iiif(Connection &conn_obj,
       conn_obj.header("Link", canonical_header);
       conn_obj.header("Content-Type", "image/jp2");// set the header (mimetype)
       conn_obj.setChunkedTransfer();
-      if (not_head_request) img.write("jpx", "HTTP");
+      if (not_head_request) img.write("jpx", sink);
       break;
     }
     case SipiQualityFormat::TIF: {
@@ -2031,7 +2052,7 @@ static void serve_iiif(Connection &conn_obj,
       conn_obj.header("Content-Type", "image/tiff");// set the header (mimetype)
       // no chunked transfer needed...
 
-      if (not_head_request) img.write("tif", "HTTP");
+      if (not_head_request) img.write("tif", sink);
       break;
     }
     case SipiQualityFormat::PNG: {
@@ -2040,7 +2061,7 @@ static void serve_iiif(Connection &conn_obj,
       conn_obj.header("Content-Type", "image/png");// set the header (mimetype)
       conn_obj.setChunkedTransfer();
 
-      if (not_head_request) img.write("png", "HTTP");
+      if (not_head_request) img.write("png", sink);
       break;
     }
     default: {
@@ -2059,11 +2080,12 @@ static void serve_iiif(Connection &conn_obj,
       conn_obj.flush();
     }
 
-    if (conn_obj.isCacheFileOpen()) {
-      conn_obj.closeCacheFile();
+    if (cache != nullptr) {
+      // The cache file was written by the FilePath sink and closed when
+      // SipiImage::write() returned (the SinkStream's ofstream destructs there).
 
       // Post-write check: if converted file exceeds cache_size, remove and skip
-      if (!skip_cache && cache != nullptr) {
+      if (!skip_cache) {
         long long max_cs = cache->getMaxCacheSize();
         if (max_cs > 0) {
           struct stat cache_stat;
@@ -2083,7 +2105,6 @@ static void serve_iiif(Connection &conn_obj,
     }
   } catch (Sipi::SipiError &err) {
     if (cache != nullptr) {
-      conn_obj.closeCacheFile();
       unlink(cachefile.c_str());
     }
     ImageContext sentry_ctx;
@@ -2099,7 +2120,6 @@ static void serve_iiif(Connection &conn_obj,
     // Client closed the socket mid-response (matches Traefik HTTP 499).
     // Not a server error: no Sentry capture, no response (the peer is gone).
     if (cache != nullptr) {
-      conn_obj.closeCacheFile();
       unlink(cachefile.c_str());
     }
     log_info("Client aborted HTTP response for %s", uri.c_str());
@@ -2107,7 +2127,6 @@ static void serve_iiif(Connection &conn_obj,
     return;
   } catch (Sipi::SipiImageError &err) {
     if (cache != nullptr) {
-      conn_obj.closeCacheFile();
       unlink(cachefile.c_str());
     }
     ImageContext sentry_ctx;

--- a/src/SipiImage.cpp
+++ b/src/SipiImage.cpp
@@ -53,7 +53,6 @@ SipiImage::SipiImage()
   iptc = nullptr;
   exif = nullptr;
   skip_metadata = SkipMetadata::SKIP_NONE;
-  conobj = nullptr;
   ensure_exif();
 };
 //============================================================================
@@ -97,7 +96,6 @@ SipiImage::SipiImage(const SipiImage &img_p)
   if (img_p.exif) exif = std::make_shared<Exif>(*img_p.exif);
   emdata = img_p.emdata;
   skip_metadata = img_p.skip_metadata;
-  conobj = img_p.conobj;
   app14_transform = img_p.app14_transform;
 }
 
@@ -108,13 +106,12 @@ SipiImage::SipiImage(SipiImage &&other) noexcept
     es(std::move(other.es)), orientation(other.orientation), photo(other.photo),
     pixels(other.pixels), xmp(std::move(other.xmp)), icc(std::move(other.icc)),
     iptc(std::move(other.iptc)), exif(std::move(other.exif)),
-    emdata(std::move(other.emdata)), conobj(other.conobj),
+    emdata(std::move(other.emdata)),
     skip_metadata(other.skip_metadata), app14_transform(other.app14_transform)
 {
   other.pixels = nullptr;
   other.nx = 0;
   other.ny = 0;
-  other.conobj = nullptr;
   other.app14_transform = 255;
 }
 
@@ -164,7 +161,6 @@ SipiImage::SipiImage(size_t nx_p, size_t ny_p, size_t nc_p, size_t bps_p, Photom
   iptc = nullptr;
   ensure_exif();
   skip_metadata = SkipMetadata::SKIP_NONE;
-  conobj = nullptr;
 }
 
 //============================================================================
@@ -189,7 +185,6 @@ SipiImage &SipiImage::operator=(const SipiImage &img_p)
     photo = img_p.photo;      // BUG FIX: missing in original operator=
     emdata = img_p.emdata;    // BUG FIX: missing in original operator=
     skip_metadata = img_p.skip_metadata;
-    conobj = img_p.conobj;
     app14_transform = img_p.app14_transform;
 
     size_t bufsiz;
@@ -246,13 +241,11 @@ SipiImage &SipiImage::operator=(SipiImage &&other) noexcept
     exif = std::move(other.exif);
     emdata = std::move(other.emdata);
     skip_metadata = other.skip_metadata;
-    conobj = other.conobj;
     app14_transform = other.app14_transform;
 
     other.pixels = nullptr;
     other.nx = 0;
     other.ny = 0;
-    other.conobj = nullptr;
     other.app14_transform = 255;
   }
   return *this;
@@ -404,13 +397,18 @@ void SipiImage::getDim(size_t &width, size_t &height) const
 
 //============================================================================
 
-void SipiImage::write(const std::string &ftype, const std::string &filepath, const SipiCompressionParams *params)
+void SipiImage::write(const std::string &ftype, const OutputSink &sink, const SipiCompressionParams *params)
 {
   // .at(): an unknown ftype must throw, not operator[]-insert a null
   // handler and segfault on the virtual call. Callers pass validated
   // format strings; the historical write() docstring advertised "j2k"
   // (the map key is "jpx"), which is exactly how this fired.
-  io.at(ftype)->write(this, filepath, params);
+  io.at(ftype)->write(this, sink, params);
+}
+
+void SipiImage::write(const std::string &ftype, const std::string &filepath, const SipiCompressionParams *params)
+{
+  write(ftype, OutputSink{ FilePath{ filepath } }, params);
 }
 
 //============================================================================

--- a/src/SipiImage.h
+++ b/src/SipiImage.h
@@ -15,9 +15,6 @@
 #include <string>
 // #include <unordered_map>
 
-#include "shttps/transport/Connection.h"
-//#include "shttps/util/Hash.h"
-
 #include "SipiIO.h"
 // #include "iiifparser/SipiRegion.h"
 #include "metadata/essentials.h"
@@ -165,7 +162,6 @@ protected:
   std::shared_ptr<Iptc> iptc;//!< Pointer to instance of Iptc class (\ref Iptc), or NULL
   std::shared_ptr<Exif> exif;//!< Pointer to instance of Exif class (\ref Exif), or NULL
   Essentials emdata;//!< Metadata to be stored in file header
-  shttps::Connection *conobj;//!< Pointer to HTTP connection
   SkipMetadata skip_metadata;//!< If true, all metadata is stripped off
 
   /*!
@@ -366,21 +362,6 @@ public:
    */
   void setSkipMetadata(SkipMetadata smd) { skip_metadata = smd; };
 
-
-  /*!
-   * Stores the connection parameters of the shttps server in an Image instance
-   *
-   * \param[in] conn_p Pointer to connection data
-   */
-  void connection(shttps::Connection *conobj_p) { conobj = conobj_p; };
-
-  /*!
-   * Retrieves the connection parameters of the mongoose server from an Image instance
-   *
-   * \returns Pointer to connection data
-   */
-  [[nodiscard]] shttps::Connection *connection() const { return conobj; };
-
   void essential_metadata(const Essentials &emdata_p) { emdata = emdata_p; }
 
   [[nodiscard]] Essentials essential_metadata() const { return emdata; }
@@ -472,12 +453,7 @@ public:
   void getDim(size_t &width, size_t &height) const;
 
   /*!
-   * Write an image to somewhere
-   *
-   * This method writes the image to a destination. The destination can be
-   * - a file if w path (filename) is given
-   * - stdout of the filepath is "-"
-   * - to the websocket, if the filepath is the string "HTTP" (given the webserver is activated)
+   * Write an image to the given OutputSink (ADR-0006).
    *
    * \param[in] ftype The file format that should be used to write the file. Supported are
    * the keys of the static SipiIO handler map (SipiImage.cpp):
@@ -486,7 +462,14 @@ public:
    * - "png" for PNG files
    * - "jpg" for JPEG files
    * Any other value throws std::out_of_range.
-   * \param[in] filepath String containing the path/filename
+   * \param[in] sink Where the encoded bytes go: a FilePath (file, or stdout via
+   * "-"/"stdout:"), a CallbackSink, or a TeeSink.
+   */
+  void write(const std::string &ftype, const OutputSink &sink, const SipiCompressionParams *params = nullptr);
+
+  /*!
+   * Convenience overload: write to a filesystem path (or stdout via "-" /
+   * "stdout:"). Equivalent to write(ftype, FilePath{filepath}, params).
    */
   void write(const std::string &ftype, const std::string &filepath, const SipiCompressionParams *params = nullptr);
 

--- a/src/SipiLua.cpp
+++ b/src/SipiLua.cpp
@@ -56,6 +56,19 @@ typedef struct
   std::string *filename;
 } SImage;
 
+// Bridges a Lua-bound shttps::Connection to the OutputSink body-write callback
+// (ADR-0006). An shttps throw (OUTPUT_WRITE_FAIL / shttps::Error) must not cross
+// into the codec, so it becomes a non-zero return.
+static int lua_conn_write(void *ctx, const uint8_t *data, size_t len)
+{
+  try {
+    static_cast<shttps::Connection *>(ctx)->sendAndFlush(data, len);
+    return 0;
+  } catch (...) {
+    return 1;
+  }
+}
+
 
 static int lua_filenamehash_helper(lua_State *L)
 {
@@ -1572,9 +1585,9 @@ static int SImage_write(lua_State *L)
     lua_getglobal(L, shttps::luaconnection);// push onto stack
     auto *conn = (shttps::Connection *)lua_touserdata(L, -1);// does not change the stack
     lua_remove(L, -1);// remove from stack
-    img->image->connection(conn);
     try {
-      img->image->write(ftype, "HTTP", comp_params.size() > 0 ? &comp_params : nullptr);
+      img->image->write(
+        ftype, CallbackSink{ lua_conn_write, conn }, comp_params.size() > 0 ? &comp_params : nullptr);
     } catch (SipiImageError &err) {
       lua_pop(L, lua_gettop(L));
       lua_pushboolean(L, false);
@@ -1643,10 +1656,8 @@ static int SImage_send(lua_State *L)
   auto *conn = (shttps::Connection *)lua_touserdata(L, -1);// does not change the stack
   lua_remove(L, -1);// remove from stack
 
-  img->image->connection(conn);
-
   try {
-    img->image->write(ftype, "HTTP");
+    img->image->write(ftype, CallbackSink{ lua_conn_write, conn });
   } catch (SipiImageError &err) {
     lua_pushboolean(L, false);
     lua_pushstring(L, err.to_string().c_str());

--- a/src/formats/SipiIOJ2k.cpp
+++ b/src/formats/SipiIOJ2k.cpp
@@ -32,7 +32,6 @@
 #include "kdu_stripe_compressor.h"
 #include "kdu_stripe_decompressor.h"
 
-#include "shttps/transport/Connection.h"
 #include "shttps/util/Global.h"
 #include "shttps/util/makeunique.h"
 #include "observability/metrics.h"
@@ -55,15 +54,15 @@ namespace Sipi {
 class J2kHttpStream : public kdu_core::kdu_compressed_target
 {
 private:
-  shttps::Connection *conobj;
+  SinkStream *sink;
 
 public:
-  //! Set when write()/close() fails because the peer closed the socket.
+  //! Set when write()/close() fails because the body sink (the socket) failed.
   //! Read from the top-level SipiIOJ2k::write error handler to distinguish
   //! client aborts from genuine Kakadu failures.
   bool client_aborted{ false };
 
-  J2kHttpStream(shttps::Connection *conobj_p);
+  J2kHttpStream(SinkStream *sink_p);
 
   ~J2kHttpStream() override;
 
@@ -84,7 +83,7 @@ public:
 //-------------------------------------------------------------------------
 // Constructor which takes the HTTP server connection as parameter
 //........................................................................
-J2kHttpStream::J2kHttpStream(shttps::Connection *conobj_p) : kdu_core::kdu_compressed_target() { conobj = conobj_p; };
+J2kHttpStream::J2kHttpStream(SinkStream *sink_p) : kdu_core::kdu_compressed_target() { sink = sink_p; };
 //-------------------------------------------------------------------------
 
 
@@ -101,12 +100,10 @@ J2kHttpStream::~J2kHttpStream(){
 //........................................................................
 bool J2kHttpStream::write(const kdu_byte *buf, int num_bytes)
 {
-  try {
-    conobj->sendAndFlush(buf, num_bytes);
-  } catch (int) {
-    // Catches shttps::OUTPUT_WRITE_FAIL — by definition a socket-write
-    // failure (peer FIN, RST, or write timeout). peerConnected()'s POLLRDHUP
-    // poll misses RST/timeout, so the throw itself is the abort signal.
+  // A non-zero sink return is a body-write failure (the socket is gone) — the
+  // equivalent of the old OUTPUT_WRITE_FAIL abort signal. No C++ exception
+  // crosses Kakadu's frames; the sink callback returns a status code.
+  if (sink->write(reinterpret_cast<const uint8_t *>(buf), static_cast<size_t>(num_bytes)) != 0) {
     client_aborted = true;
     return false;
   }
@@ -116,12 +113,8 @@ bool J2kHttpStream::write(const kdu_byte *buf, int num_bytes)
 
 bool J2kHttpStream::close()
 {
-  try {
-    conobj->flush();
-  } catch (int) {
-    client_aborted = true;
-    return false;
-  }
+  // Nothing to flush: each write() already pushed its chunk to the sink, and
+  // the HTTP framing/terminator is flushed by the request handler after write().
   return true;
 }
 
@@ -894,9 +887,15 @@ static void write_essentials_box(kdu_supp::jp2_family_tgt *tgt, const std::vecto
 }
 //=============================================================================
 
-void SipiIOJ2k::write(SipiImage *img, const std::string &filepath, const SipiCompressionParams *params)
+void SipiIOJ2k::write(SipiImage *img, const OutputSink &sink, const SipiCompressionParams *params)
 {
   SIPI_ZONE_N("SipiIOJ2k::write");
+  // A streamed sink (callback/tee) writes via J2kHttpStream → SinkStream; a
+  // FilePath opens the JP2 target on the path. `filepath` is derived only for
+  // the file branch and the error messages below.
+  const bool streaming = is_streaming_sink(sink);
+  const std::string filepath = streaming ? std::string("<http response>") : std::get<FilePath>(sink).path;
+
   kdu_customize_warnings(&kdu_sipi_warn);
   kdu_customize_errors(&kdu_sipi_error);
 
@@ -907,7 +906,9 @@ void SipiIOJ2k::write(SipiImage *img, const std::string &filepath, const SipiCom
   if ((num_threads = kdu_get_num_processors()) < 2) num_threads = 0;
 
   // Declared outside the try so the catch below can read `http->client_aborted`
-  // to distinguish client aborts from genuine Kakadu failures.
+  // to distinguish client aborts from genuine Kakadu failures. sink_stream
+  // outlives http (J2kHttpStream holds a raw SinkStream*).
+  std::unique_ptr<SinkStream> sink_stream;
   std::unique_ptr<J2kHttpStream> http;
 
   try {
@@ -958,9 +959,9 @@ void SipiIOJ2k::write(SipiImage *img, const std::string &filepath, const SipiCom
 
     jp2_family_tgt jp2_ultimate_tgt;
 
-    if (filepath == "HTTP") {
-      shttps::Connection *conobj = img->connection();
-      http = std::make_unique<J2kHttpStream>(conobj);
+    if (streaming) {
+      sink_stream = std::make_unique<SinkStream>(sink);
+      http = std::make_unique<J2kHttpStream>(sink_stream.get());
       jp2_ultimate_tgt.open(http.get(), &membroker);
     } else {
       jp2_ultimate_tgt.open(filepath.c_str(), &membroker);

--- a/src/formats/SipiIOJpeg.cpp
+++ b/src/formats/SipiIOJpeg.cpp
@@ -17,7 +17,6 @@
 
 #include <tiff.h>
 
-#include "shttps/transport/Connection.h"
 #include "shttps/util/makeunique.h"
 
 #include "logging/logger.h"
@@ -301,13 +300,13 @@ static void jpeg_file_src(struct jpeg_decompress_struct *cinfo, int file_id)
  */
 struct HtmlBuffer
 {
-  explicit HtmlBuffer(shttps::Connection *conn, size_t buflen_p = 65536)
-    : buffer(std::make_unique<JOCTET[]>(buflen_p)), buflen(buflen_p), conobj(conn)
+  explicit HtmlBuffer(SinkStream *sink_p, size_t buflen_p = 65536)
+    : buffer(std::make_unique<JOCTET[]>(buflen_p)), buflen(buflen_p), sink(sink_p)
   {}
 
   std::unique_ptr<JOCTET[]> buffer;
   size_t buflen;
-  shttps::Connection *conobj;
+  SinkStream *sink;
   bool client_aborted{ false };
 };
 
@@ -329,27 +328,18 @@ static void init_html_destination(j_compress_ptr cinfo)
 static boolean empty_html_buffer(j_compress_ptr cinfo)
 {
   auto *html_buffer = static_cast<HtmlBuffer *>(cinfo->client_data);
-  std::string err_msg;
-  try {
-    html_buffer->conobj->sendAndFlush(html_buffer->buffer.get(), html_buffer->buflen);
-    cinfo->dest->free_in_buffer = html_buffer->buflen;
-    cinfo->dest->next_output_byte = html_buffer->buffer.get();
-    return static_cast<boolean>(true);
-  } catch (const std::exception &e) {
-    // shttps::Error and other std::exception subclasses → genuine error path.
-    err_msg = e.what();
-  } catch (...) {
-    // sendAndFlush throws the bare shttps::OUTPUT_WRITE_FAIL enum — not derived
-    // from std::exception, so it reaches this branch. The throw itself is the
-    // abort signal: every OUTPUT_WRITE_FAIL means the underlying socket write
-    // failed (peer FIN, RST, write timeout). peerConnected() polls POLLRDHUP
-    // and misses RST/timeout, so we don't consult it.
-    err_msg = "shttps::OUTPUT_WRITE_FAIL";
+  // A non-zero return means the body sink (the HTTP socket) failed — the
+  // equivalent of the old OUTPUT_WRITE_FAIL: the client is gone. No C++
+  // exception crosses libjpeg's C frames (the sink callback returns a code).
+  if (html_buffer->sink->write(html_buffer->buffer.get(), html_buffer->buflen) != 0) {
     html_buffer->client_aborted = true;
+    log_err("JPEG HTTP write failed: sink write error");
+    ERREXIT(cinfo, JERR_FILE_WRITE);// triggers jpegErrorExit → longjmp
+    return FALSE;// unreachable
   }
-  log_err("JPEG HTTP write failed: %s", err_msg.c_str());
-  ERREXIT(cinfo, JERR_FILE_WRITE);  // triggers jpegErrorExit → longjmp
-  return FALSE;  // unreachable
+  cinfo->dest->free_in_buffer = html_buffer->buflen;
+  cinfo->dest->next_output_byte = html_buffer->buffer.get();
+  return static_cast<boolean>(true);
 }
 
 //=============================================================================
@@ -361,21 +351,13 @@ static void term_html_destination(j_compress_ptr cinfo)
 {
   auto *html_buffer = static_cast<HtmlBuffer *>(cinfo->client_data);
   const size_t nbytes = cinfo->dest->next_output_byte - html_buffer->buffer.get();
-  std::string err_msg;
-  try {
-    html_buffer->conobj->sendAndFlush(html_buffer->buffer.get(), nbytes);
-    return;
-  } catch (const std::exception &e) {
-    err_msg = e.what();
-  } catch (...) {
-    // See empty_html_buffer for the rationale: OUTPUT_WRITE_FAIL is itself
-    // the abort signal; no peerConnected() check needed.
-    err_msg = "shttps::OUTPUT_WRITE_FAIL";
+  if (html_buffer->sink->write(html_buffer->buffer.get(), nbytes) != 0) {
+    // See empty_html_buffer: a non-zero sink return is the abort signal.
     html_buffer->client_aborted = true;
+    log_err("JPEG HTTP write (term) failed: sink write error");
+    ERREXIT(cinfo, JERR_FILE_WRITE);
+    // unreachable
   }
-  log_err("JPEG HTTP write (term) failed: %s", err_msg.c_str());
-  ERREXIT(cinfo, JERR_FILE_WRITE);
-  // unreachable
 }
 
 //=============================================================================
@@ -1038,9 +1020,15 @@ SipiImgInfo SipiIOJpeg::read_shape(const std::string &filepath)
 //============================================================================
 
 
-void SipiIOJpeg::write(SipiImage *img, const std::string &filepath, const SipiCompressionParams *params)
+void SipiIOJpeg::write(SipiImage *img, const OutputSink &sink, const SipiCompressionParams *params)
 {
   SIPI_ZONE_N("SipiIOJpeg::write");
+  // A streamed sink (callback/tee) writes to the response stream via SinkStream;
+  // a FilePath uses libjpeg's native file/stdout writer. `filepath` is derived
+  // only for the file branch and the error messages below.
+  const bool streaming = is_streaming_sink(sink);
+  const std::string filepath = streaming ? std::string("<http response>") : std::get<FilePath>(sink).path;
+
   int quality = 80;
   if ((params != nullptr) && (!params->empty())) {
     try {
@@ -1086,11 +1074,11 @@ void SipiIOJpeg::write(SipiImage *img, const std::string &filepath, const SipiCo
   // setjmp so destructors are on the normal C++ unwind path when we throw
   // from the setjmp handler (longjmp would skip destructors of objects
   // constructed *between* setjmp and longjmp — these live outside that window).
+  std::unique_ptr<SinkStream> sink_stream;
   std::unique_ptr<HtmlBuffer> html_buffer;
   std::unique_ptr<jpeg_destination_mgr> destmgr;
   JSAMPROW row_pointer[1];
   int row_stride;
-  bool is_http = (filepath == "HTTP");
 
   jpeg_create_compress(&cinfo);  // errors → longjmp → setjmp handler below
 
@@ -1115,8 +1103,9 @@ void SipiIOJpeg::write(SipiImage *img, const std::string &filepath, const SipiCo
     throw SipiImageError("JPEG write failed: " + std::string(jerr.error_message));
   }
 
-  if (is_http) {
-    html_buffer = std::make_unique<HtmlBuffer>(img->connection());
+  if (streaming) {
+    sink_stream = std::make_unique<SinkStream>(sink);
+    html_buffer = std::make_unique<HtmlBuffer>(sink_stream.get());
     destmgr = std::make_unique<jpeg_destination_mgr>();
     jpeg_html_dest(&cinfo, html_buffer.get(), destmgr.get());
   } else {

--- a/src/formats/SipiIOPng.cpp
+++ b/src/formats/SipiIOPng.cpp
@@ -13,6 +13,7 @@
 #include <cstdio>
 #include <fstream>
 #include <iostream>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -424,7 +425,7 @@ void create_text_chunk(PngTextPtr *png_textptr, char *key, char *str, unsigned i
  */
 struct PngHttpCtx
 {
-  shttps::Connection *conn;
+  SinkStream *sink;
   bool client_aborted;
 };
 
@@ -432,39 +433,34 @@ static void conn_write_data(png_structp png_ptr, png_bytep data, png_size_t leng
 {
   auto *ctx = static_cast<PngHttpCtx *>(png_get_io_ptr(png_ptr));
 
-  try {
-    ctx->conn->sendAndFlush(data, length);
-  } catch (...) {
-    // Any throw out of sendAndFlush — bare shttps::OUTPUT_WRITE_FAIL or
-    // shttps::Error — means the response stream is no longer usable. We mark
-    // the abort here unconditionally because peerConnected()'s POLLRDHUP poll
-    // misses RST/timeout aborts. We can't narrow the catch (e.g. to `int`)
-    // without re-introducing C++-exception-through-libpng-C-frame UB.
+  // A non-zero sink return means the response stream (the HTTP socket) is no
+  // longer usable. No C++ exception crosses libpng's C frames — the sink
+  // callback returns a status code, which we route to libpng's error path.
+  if (ctx->sink->write(data, length) != 0) {
     ctx->client_aborted = true;
-    // Signal error via libpng's error mechanism → sipi_error_fn → longjmp
-    png_error(png_ptr, "HTTP write failed");
+    png_error(png_ptr, "HTTP write failed");// → sipi_error_fn → longjmp
   }
 }
 
 /*==========================================================================*/
 
-static void conn_flush_data(png_structp png_ptr)
+static void conn_flush_data(png_structp /*png_ptr*/)
 {
-  auto *ctx = static_cast<PngHttpCtx *>(png_get_io_ptr(png_ptr));
-
-  try {
-    ctx->conn->flush();
-  } catch (...) {
-    ctx->client_aborted = true;
-    png_error(png_ptr, "HTTP flush failed");
-  }
+  // No-op: the per-chunk SinkStream write already pushed bytes downstream, and
+  // the HTTP framing/terminator is flushed by the request handler after write()
+  // returns (SipiHttpServer serve_iiif). libpng requires a non-null flush fn.
 }
 
 /*==========================================================================*/
 
-void SipiIOPng::write(SipiImage *img, const std::string &filepath, const SipiCompressionParams *params)
+void SipiIOPng::write(SipiImage *img, const OutputSink &sink, const SipiCompressionParams *params)
 {
   SIPI_ZONE_N("SipiIOPng::write");
+  // A streamed sink (callback/tee) is driven through SinkStream via libpng's
+  // write callback; a FilePath uses libpng's native file/stdout writer.
+  const bool streaming = is_streaming_sink(sink);
+  const std::string filepath = streaming ? std::string("<http response>") : std::get<FilePath>(sink).path;
+
   FILE *outfile = nullptr;
   png_structp png_ptr;
 
@@ -472,14 +468,18 @@ void SipiIOPng::write(SipiImage *img, const std::string &filepath, const SipiCom
     throw SipiImageError("Error writing PNG file \"" + filepath + "\": png_create_write_struct failed !");
   }
 
-  // HTTP write context: kept on the stack so its address is valid for the
-  // lifetime of SipiIOPng::write. The address is stable across longjmp.
-  PngHttpCtx http_ctx{ img->connection(), false };
+  // Streamed-write context: SinkStream and http_ctx are kept alive for the
+  // whole of SipiIOPng::write so their addresses stay valid across longjmp.
+  // For a FilePath we leave them unused and let libpng's native file writer run.
+  std::unique_ptr<SinkStream> sink_stream;
+  PngHttpCtx http_ctx{ nullptr, false };
 
-  if (filepath == "stdout:") {
-    outfile = stdout;
-  } else if (filepath == "HTTP") {
+  if (streaming) {
+    sink_stream = std::make_unique<SinkStream>(sink);
+    http_ctx.sink = sink_stream.get();
     png_set_write_fn(png_ptr, &http_ctx, conn_write_data, conn_flush_data);
+  } else if (filepath == "stdout:") {
+    outfile = stdout;
   } else {
     if (!(outfile = fopen(filepath.c_str(), "wb"))) {
       png_free_data(png_ptr, nullptr, PNG_FREE_ALL, -1);

--- a/src/formats/SipiIOTiff.cpp
+++ b/src/formats/SipiIOTiff.cpp
@@ -18,8 +18,6 @@
 
 #include <cerrno>
 
-#include "shttps/transport/Connection.h"
-
 #include "logging/logger.h"
 #include "SipiError.h"
 #include "SipiImage.h"
@@ -1618,13 +1616,19 @@ void SipiIOTiff::write_basic_tags(const SipiImage &img,
   TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, img.photo);
 }
 
-void SipiIOTiff::write(SipiImage *img, const std::string &filepath, const SipiCompressionParams *params)
+void SipiIOTiff::write(SipiImage *img, const OutputSink &sink, const SipiCompressionParams *params)
 {
   SIPI_ZONE_N("SipiIOTiff::write");
+  // A streamed sink (callback/tee) and stdout both need an in-memory TIFF
+  // (libtiff requires a seekable target); a real FilePath is written directly.
+  // `filepath` is derived only for the file branch and the error messages.
+  const bool streaming = is_streaming_sink(sink);
+  const std::string filepath = streaming ? std::string("<http response>") : std::get<FilePath>(sink).path;
+
   TIFF *tif;
   MEMTIFF *memtif = nullptr;
   auto rowsperstrip = (uint32_t)-1;
-  if ((filepath == "stdout:") || (filepath == "HTTP")) {
+  if (streaming || (filepath == "stdout:")) {
     memtif = memTiffOpen();
     tif = TIFFClientOpen("MEMTIFF",
       "w",
@@ -1859,7 +1863,7 @@ void SipiIOTiff::write(SipiImage *img, const std::string &filepath, const SipiCo
   TIFFClose(tif);
 
   if (memtif != nullptr) {
-    if (filepath == "stdout:") {
+    if (!streaming && filepath == "stdout:") {
       size_t n = 0;
 
       while (n < memtif->flen) {
@@ -1867,13 +1871,12 @@ void SipiIOTiff::write(SipiImage *img, const std::string &filepath, const SipiCo
       }
 
       fflush(stdout);
-    } else if (filepath == "HTTP") {
-      try {
-        img->connection()->sendAndFlush(memtif->data, memtif->flen);
-      } catch (int i) {
-        // Catches shttps::OUTPUT_WRITE_FAIL — by definition a socket-write
-        // failure. peerConnected()'s POLLRDHUP poll misses RST/timeout, so the
-        // throw itself is the abort signal.
+    } else if (streaming) {
+      // The whole in-memory TIFF is broadcast to the sink in one write. A
+      // non-zero return is a body-write failure (the socket is gone) — the
+      // equivalent of the old OUTPUT_WRITE_FAIL abort signal.
+      SinkStream stream{ sink };
+      if (stream.write(memtif->data, memtif->flen) != 0) {
         memTiffFree(memtif);
         throw Sipi::SipiImageClientAbortError("Client aborted HTTP response during TIFF write");
       }

--- a/src/formats/output_sink.cpp
+++ b/src/formats/output_sink.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2016 - 2024 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+ * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "formats/output_sink.h"
+
+#include <fstream>
+
+namespace Sipi {
+
+bool is_streaming_sink(const OutputSink &sink) { return !std::holds_alternative<FilePath>(sink); }
+
+SinkStream::SinkStream(const OutputSink &sink) { flatten(sink); }
+
+void SinkStream::flatten(const OutputSink &sink)
+{
+  std::visit(
+    [this](const auto &alt) {
+      using T = std::decay_t<decltype(alt)>;
+      if constexpr (std::is_same_v<T, CallbackSink>) {
+        leaves_.push_back(Leaf{ alt.write, alt.ctx, nullptr, /*fatal=*/true });
+      } else if constexpr (std::is_same_v<T, FilePath>) {
+        // A FilePath leaf only reaches SinkStream as part of a tee (the cache
+        // file). Open it for streaming; an open failure leaves the leaf inert,
+        // matching shttps's best-effort cache (a bad cache write never aborts
+        // the response).
+        auto file = std::make_shared<std::ofstream>(alt.path, std::ios::binary | std::ios::trunc);
+        leaves_.push_back(Leaf{ nullptr, nullptr, std::move(file), /*fatal=*/false });
+      } else if constexpr (std::is_same_v<T, TeeSink>) {
+        for (const auto &child : alt.sinks) flatten(child);
+      }
+    },
+    sink);
+}
+
+int SinkStream::write(const uint8_t *data, size_t len)
+{
+  int rc = 0;
+  for (auto &leaf : leaves_) {
+    if (leaf.fn != nullptr) {
+      const int r = leaf.fn(leaf.ctx, data, len);
+      if (r != 0 && leaf.fatal) rc = r;
+    } else if (leaf.file) {
+      // Best-effort: a failed cache write sets failbit and is silently
+      // dropped, exactly as shttps does for its tee'd cache file.
+      leaf.file->write(reinterpret_cast<const char *>(data), static_cast<std::streamsize>(len));
+    }
+  }
+  return rc;
+}
+
+}// namespace Sipi

--- a/test/unit/output_sink/BUILD.bazel
+++ b/test/unit/output_sink/BUILD.bazel
@@ -1,0 +1,12 @@
+"""OutputSink / SinkStream unit tests (ADR-0006 write-destination types)."""
+
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "output_sink_test",
+    srcs = ["output_sink_test.cpp"],
+    deps = [
+        "//src:sipi_lib",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/test/unit/output_sink/output_sink_test.cpp
+++ b/test/unit/output_sink/output_sink_test.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2016 - 2024 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+ * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "formats/output_sink.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+namespace {
+
+// A CallbackSink ctx that records the bytes it receives and replays a
+// caller-chosen return code (0 = ok, non-zero = write failure).
+struct CaptureCtx
+{
+  std::vector<uint8_t> bytes;
+  int return_code{ 0 };
+};
+
+extern "C" int capture_write(void *ctx, const uint8_t *data, size_t len)
+{
+  auto *c = static_cast<CaptureCtx *>(ctx);
+  c->bytes.insert(c->bytes.end(), data, data + len);
+  return c->return_code;
+}
+
+std::vector<uint8_t> read_all(const std::string &path)
+{
+  std::ifstream in(path, std::ios::binary);
+  return { std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>() };
+}
+
+std::string temp_path(const std::string &name)
+{
+  const char *dir = std::getenv("TEST_TMPDIR");
+  return (dir != nullptr ? std::string(dir) : std::string("/tmp")) + "/" + name;
+}
+
+const std::vector<uint8_t> kHello{ 'h', 'e', 'l', 'l', 'o' };
+const std::vector<uint8_t> kWorld{ 'w', 'o', 'r', 'l', 'd' };
+
+TEST(OutputSink, IsStreamingSink)
+{
+  EXPECT_FALSE(Sipi::is_streaming_sink(Sipi::FilePath{ "/tmp/x" }));
+  EXPECT_TRUE(Sipi::is_streaming_sink(Sipi::CallbackSink{ &capture_write, nullptr }));
+  EXPECT_TRUE(Sipi::is_streaming_sink(Sipi::TeeSink{ { Sipi::FilePath{ "/tmp/x" } } }));
+}
+
+TEST(OutputSink, CallbackSinkReceivesAllChunks)
+{
+  CaptureCtx ctx;
+  Sipi::SinkStream stream{ Sipi::CallbackSink{ &capture_write, &ctx } };
+
+  EXPECT_EQ(0, stream.write(kHello.data(), kHello.size()));
+  EXPECT_EQ(0, stream.write(kWorld.data(), kWorld.size()));
+
+  const std::vector<uint8_t> expected{ 'h', 'e', 'l', 'l', 'o', 'w', 'o', 'r', 'l', 'd' };
+  EXPECT_EQ(expected, ctx.bytes);
+}
+
+TEST(OutputSink, CallbackSinkFailureIsFatal)
+{
+  CaptureCtx ctx;
+  ctx.return_code = 7;
+  Sipi::SinkStream stream{ Sipi::CallbackSink{ &capture_write, &ctx } };
+
+  EXPECT_NE(0, stream.write(kHello.data(), kHello.size()));
+}
+
+TEST(OutputSink, TeeBroadcastsToCallbackAndFile)
+{
+  CaptureCtx ctx;
+  const std::string path = temp_path("output_sink_tee.bin");
+
+  Sipi::TeeSink tee{ { Sipi::CallbackSink{ &capture_write, &ctx }, Sipi::FilePath{ path } } };
+  {
+    Sipi::SinkStream stream{ tee };
+    EXPECT_EQ(0, stream.write(kHello.data(), kHello.size()));
+    EXPECT_EQ(0, stream.write(kWorld.data(), kWorld.size()));
+  }// SinkStream destruction flushes/closes the file leaf
+
+  const std::vector<uint8_t> expected{ 'h', 'e', 'l', 'l', 'o', 'w', 'o', 'r', 'l', 'd' };
+  EXPECT_EQ(expected, ctx.bytes);
+  EXPECT_EQ(expected, read_all(path));
+}
+
+TEST(OutputSink, CacheFileFailureIsBestEffortNotFatal)
+{
+  CaptureCtx ctx;
+  // An unopenable cache path (missing directory) must not abort the response:
+  // the socket callback still succeeds and write() returns 0.
+  Sipi::TeeSink tee{ { Sipi::CallbackSink{ &capture_write, &ctx },
+    Sipi::FilePath{ "/nonexistent-dir-xyz/cache.bin" } } };
+  Sipi::SinkStream stream{ tee };
+
+  EXPECT_EQ(0, stream.write(kHello.data(), kHello.size()));
+  EXPECT_EQ(kHello, ctx.bytes);
+}
+
+}// namespace


### PR DESCRIPTION
Fixes DEV-6382, DEV-6393

## Motivation
SIPI is being rewritten from C++ to Rust via a strangler fig ([DEV-5970](https://linear.app/dasch/issue/DEV-5970)). The single hard modularization gate is the image write path's coupling to `shttps::Connection`: all four codecs ultimately call `conobj->sendAndFlush`, and `SipiImage` carries a `Connection*` purely to reach it (routed by the `"HTTP"` magic-string filepath sentinel). Until the engine can write bytes to an opaque sink, a Rust HTTP shell cannot own the socket. **Phase A cuts exactly that coupling and nothing else** — it is the prerequisite for the Phase B FFI core.

## Summary
- Encoded image bytes flow to a typed `OutputSink` (`std::variant<FilePath, CallbackSink, TeeSink>`, ADR-0006) instead of `shttps::Connection`. No behaviour change — approval bytes are identical and the full e2e suite passes.
- `src/formats/` and `SipiImage` carry **zero** `shttps` dependency; the socket+cache dual-write tee moves out of `shttps::Connection` into the write loop (ADR-0007).
- The `CallbackSink` C-ABI write callback is the durable seam reused verbatim by the Phase B/C FFI.

## Key Changes
### OutputSink seam
- `include/formats/output_sink.h` + `src/formats/output_sink.cpp`: the variant, the `SipiWriteFn` C-ABI callback typedef, and a `SinkStream` streaming writer. Co-located unit test in `test/unit/output_sink/`.

### Codec conversion
- All **four** codecs (JPEG `HtmlBuffer`, PNG `png_io_context`, J2k `J2kHttpStream`, TIFF mem-buffer dump) route their old `"HTTP"` branch through `SinkStream`; native file/stdout writers are untouched. Codecs check the sink callback's return code instead of catching an shttps throw through their C frames.

### Request-handler + Lua call sites
- `serve_iiif` builds `TeeSink{CallbackSink(socket), FilePath(cachefile)}` and drops `openCacheFile`/`closeCacheFile`. A pre-write probe preserves the prior "cache unwritable → 500".
- The Lua `SipiImage:write`/`:send` bindings build a `CallbackSink` over the request connection (Lua stays C++ behind the seam per the plan).

### Decoupling cleanup
- `SipiIO::write` / `SipiImage::write` take `const OutputSink&`; a thin `write(ftype, std::string, …)` overload keeps all file/stdout callers unchanged. `SipiImage::conobj`, the `connection()` accessors, and the `shttps/Connection.h` include are removed.

## Challenges and Decisions
### The cache-tee lived inside shttps::Connection
**Problem:** the socket+cache dual-write was not in the request handler — `Connection::sendAndFlush` wrote each chunk to both the socket and an `openCacheFile`-registered `ofstream`. Naively wrapping `sendAndFlush` in a `CallbackSink` would double-write the cache.
**Solution:** stop opening the cache on the connection and let a `TeeSink{CallbackSink(socket), FilePath(cachefile)}` own the dual-write (ADR-0007). The `FilePath` cache leaf is best-effort; a pre-write `ofstream` probe reproduces `openCacheFile`'s "unwritable → 500" check.

### The plan's prose undercounted the codecs
**Problem:** the plan named three codecs (JPEG/PNG/J2k). Grounding the code showed **TIFF** also writes to `"HTTP"` (`SipiIOTiff.cpp` memtif dump) and is in the IIIF dispatch.
**Solution:** converted TIFF too. TIFF can't stream (libtiff needs a seekable target), so it builds the full in-memory TIFF and broadcasts it to the sink in one write.

### No C++ exception may cross the codec's C frames
**Problem:** the old code threw `shttps::OUTPUT_WRITE_FAIL` out of `sendAndFlush` up through libjpeg's `setjmp`/libpng/Kakadu C frames — UB the codecs carefully caught.
**Solution:** the sink callback returns a status code; codecs check it and trigger their native abort (`ERREXIT`/`png_error`/`return false`). This also pre-establishes the Phase B/C "no exception across the FFI boundary" rule. RAII objects are declared before `setjmp` so they unwind correctly on the throw path.

### A clean OutputSink-only API vs ~40 file-path callers
**Problem:** flipping `write` to `OutputSink` would churn ~40 CLI/test call sites that just write to a path.
**Solution:** a thin `write(ftype, std::string, …)` overload wrapping `FilePath`. A string now always means a filesystem path (the `"HTTP"` sentinel is gone), so this is an honest ergonomic overload, not a deprecated shim.

### The encode microbench was noise-dominated
**Problem:** before/after `just bench encode` showed a ~3% geomean delta with "significant" U-tests.
**Solution:** the benchmark exercises the `FilePath`→native-writer path, which is code-identical (only ~2 trivial string copies added vs a 100s-of-ms encode). Comparing the *same binary against itself* showed a far larger noise floor (+35% geomean, JpegQ75 +153%) — a concurrent build was saturating the CPU. The delta is machine noise. The real `CallbackSink` indirection is on the HTTP path, covered by the green e2e `latency` test.

## Gotchas
- **`output_sink.h` lives in `include/formats/`,** not `src/formats/` as the plan diagram shows — that co-located layout is the post-include-flip shape (modularization Y+8). It moves with the other headers when that flip lands.
- **Lua keeps its own `"HTTP"` sentinel:** `img:write("HTTP")` in Lua scripts is the *Lua API* contract (the binding maps it to a `CallbackSink`). Only the C++ `SipiImage`/codec sentinel is gone (Lua → mlua is D+).
- **Cache write is best-effort (two known pre-existing edges, deferred — [DEV-6660](https://linear.app/dasch/issue/DEV-6660)):** a short cache write (disk full) registers a truncated file that's served on later hits, and a HEAD request registers an empty file. Both are carried in unchanged from the old shttps tee. Deliberately **not** fixed here — `serve_iiif` is deleted at the Phase C cutover, so the guard belongs where `cache->add` lands behind the FFI in Phase B (DEV-6660 is retargeted there).

## Test Plan
- [x] `bazel test //test/unit/...` — incl. the new `output_sink_test`
- [x] `bazel test //test/approval:approvaltests` — byte-identical image output (primary gate)
- [x] `bazel test //test/e2e-rust/...` — e2e green (cache, connection, range, iiif_compliance, upload, security)
- [x] Grep gate: zero `shttps::Connection` in `src/formats/` and `src/SipiImage.*`
- [x] Rebased onto post-Phase-0 `main` (shttps module carve); conflicts resolved, full suite re-run green
- [x] `cpp` / `code-simplicity` / `security` reviewers — no critical findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)