### PR TITLE
refactor(lua): Phase B-L — Lua preflight connection-less behind the FFI seam

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ localdev config in one step.
 | Caching | `include/SipiCache.h` | File-based LRU cache with dual-limit eviction (size + file count), crash recovery |
 | Metrics | `src/observability/metrics.h` | Prometheus metrics singleton (`Sipi::observability::Metrics`) — cache counters/gauges exposed at `GET /metrics` |
 | Memory Budget | `include/SipiMemoryBudget.h` | Lock-free decode memory budget with RAII guard — prevents OOM from concurrent large decodes |
-| Lua Integration | `include/SipiLua.h` | Lua bindings for image manipulation, HTTP handling, config/routes |
+| Lua Integration | `src/ffi/SipiLua.h` | Lua bindings for image manipulation, HTTP handling, config/routes |
 
 ### Image Processing Pipeline
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -23,7 +23,7 @@ ignore:
   - "config/**"
   - "docs/**"
   - "include/**"
-  - "src/SipiLua.cpp"
+  - "src/ffi/SipiLua.cpp"
 
 parsers:
   gcov:

--- a/docs/adr/0007-sipiimage-decomposition.md
+++ b/docs/adr/0007-sipiimage-decomposition.md
@@ -63,7 +63,7 @@ We accept this for five reasons.
 
 - **Approval-test surface unchanged**. Behaviour preservation is intended throughout the decomposition. Approval goldens stay valid.
 
-- **Lua-binding surface ([SipiLua.cpp](../../src/SipiLua.cpp))** — Probe 6 resolves. Potentially the Lua API exposes `image:crop(...)` as method-style calls; if so, the Lua binding layer absorbs the C++-method-to-free-function translation transparently. Probe 6 outcome may add facade methods on `Image` purely for binding convenience.
+- **Lua-binding surface ([SipiLua.cpp](../../src/ffi/SipiLua.cpp))** — Probe 6 resolves. Potentially the Lua API exposes `image:crop(...)` as method-style calls; if so, the Lua binding layer absorbs the C++-method-to-free-function translation transparently. Probe 6 outcome may add facade methods on `Image` purely for binding convenience.
 
 - **Glossary deltas land in [`UBIQUITOUS_LANGUAGE.md`](../../UBIQUITOUS_LANGUAGE.md)** in the batched edit pass: add **Image processing** (umbrella for the free-function module). Sharpen **Image** (the code-level class becomes a narrow value type; domain term stays correct).
 

--- a/include/BUILD.bazel
+++ b/include/BUILD.bazel
@@ -1,9 +1,9 @@
 """Sipi public + private headers as a header-only `cc_library`.
 
 The `include/` directory holds the server-side / config headers that are NOT
-owned by a dedicated module: the Lua config surface (`SipiConf.h`,
-`SipiLua.h`), the offline report (`SipiReport.h`), the embedded favicon, the
-generated-config templates, and the ICC profile binaries.
+owned by a dedicated module: the Lua config surface (`SipiConf.h`), the offline
+report (`SipiReport.h`), the embedded favicon, the generated-config templates,
+and the ICC profile binaries.
 
 Per-module packages NOT bundled here (consumers depend on the dedicated
 target directly):

--- a/include/SipiLua.h
+++ b/include/SipiLua.h
@@ -27,7 +27,7 @@ namespace Sipi {
 
 extern char sipiserver[];
 
-extern void sipiGlobals(lua_State *L, shttps::Connection &conn, void *user_data);
+extern void sipiGlobals(lua_State *L, shttps::RequestContext &ctx, void *user_data);
 
 }// namespace Sipi
 

--- a/src/SipiHttpServer.cpp
+++ b/src/SipiHttpServer.cpp
@@ -51,7 +51,10 @@
 #include "observability/sentry.h"
 #include "favicon.h"
 #include "ffi/engine_context.h"
+#include "ffi/preflight.h"
 #include "ffi/sipi_ffi.h"
+#include "shttps/lua/request_context.h"
+#include "shttps/transport/connection_request_context.h"
 #include "handlers/iiif_handler.h"
 #include "jansson.h"
 
@@ -351,226 +354,71 @@ static std::string resolve_client_id(Connection &conn_obj)
 
 //=========================================================================
 
+// emit_kv target for the preflight adapters below: fold the seam's open
+// key/value channel (infile + restrict extras: watermark/size/cookieUrl/…) back
+// into the string-keyed map the existing handlers consume.
+static void preflight_collect_kv(void *ctx, const char *key, const char *value)
+{
+  static_cast<std::unordered_map<std::string, std::string> *>(ctx)->insert_or_assign(key, value);
+}
+
 /*!
- * Gets the IIIF prefix, IIIF identifier, and cookie from the HTTP request, and passes them to the Lua pre-flight
- * function (whose name is given by the constant pre_flight_func_name).
+ * Runs the Lua `pre_flight` hook for an IIIF request through the C-ABI seam
+ * (`::sipi_preflight`) and returns the permission + file path (+ any restrict
+ * extras) as the string-keyed map the handlers consume.
  *
- * Returns the return values of the pre-flight function as a std::pair containing a permission string and (optionally) a
- * file path. Throws SipiError if an error occurs.
+ * The Lua VM is built behind the FFI from the engine Lua config, bound to a
+ * RequestContext snapshot of conn_obj (so `server.header` / `server.cookies`
+ * resolve from the real request) — the path the Rust shell drives in Phase C.
+ * The caller still gates on `luaserver.luaFunctionExists(pre_flight)`; only the
+ * execution moved behind the seam. Throws SipiError if the hook fails (the
+ * detail is logged engine-side; only the status crosses the seam).
  *
- * \param conn_obj the server connection.
- * \param luaserver the Lua server that will be used to call the function.
+ * \param conn_obj the server connection (request fields + response sink).
  * \param prefix the IIIF prefix.
  * \param identifier the IIIF identifier.
- * \return Pair of permission string and filepath
+ * \return permission map (type + infile + any restrict extras)
  */
-static std::unordered_map<std::string, std::string> call_iiif_preflight(Connection &conn_obj,
-  shttps::LuaServer &luaserver,
-  const std::string &prefix,
-  const std::string &identifier)
+static std::unordered_map<std::string, std::string>
+  call_iiif_preflight(Connection &conn_obj, const std::string &prefix, const std::string &identifier)
 {
-  // The permission and optional file path that the pre_fight function returns.
   std::unordered_map<std::string, std::string> preflight_info;
-  // std::string permission;
-  // std::string infile;
-
-  // The paramters to be passed to the pre-flight function.
-  std::vector<std::shared_ptr<LuaValstruct>> lvals;
-
-  // The first parameter is the IIIF prefix.
-  std::shared_ptr<LuaValstruct> iiif_prefix_param = std::make_shared<LuaValstruct>();
-  iiif_prefix_param->type = LuaValstruct::STRING_TYPE;
-  iiif_prefix_param->value.s = prefix;
-  lvals.push_back(iiif_prefix_param);
-
-  // The second parameter is the IIIF identifier.
-  std::shared_ptr<LuaValstruct> iiif_identifier_param = std::make_shared<LuaValstruct>();
-  iiif_identifier_param->type = LuaValstruct::STRING_TYPE;
-  iiif_identifier_param->value.s = identifier;
-  lvals.push_back(iiif_identifier_param);
-
-  // The third parameter is the HTTP cookie.
-  std::shared_ptr<LuaValstruct> cookie_param = std::make_shared<LuaValstruct>();
-  std::string cookie = conn_obj.header("cookie");
-  cookie_param->type = LuaValstruct::STRING_TYPE;
-  cookie_param->value.s = cookie;
-  lvals.push_back(cookie_param);
-
-  // Call the pre-flight function.
-  std::vector<std::shared_ptr<LuaValstruct>> rvals = luaserver.executeLuafunction(iiif_preflight_funcname, lvals);
-
-  // If it returned nothing, that's an error.
-  if (rvals.empty()) {
-    std::ostringstream err_msg;
-    err_msg << "Lua function " << iiif_preflight_funcname << " must return at least one value";
-    throw SipiError(err_msg.str());
-  }
-
-  // The first return value is the permission code.
-  auto permission_return_val = rvals.at(0);
-
-  // The permission code can be a string or a table
-  if (permission_return_val->type == LuaValstruct::STRING_TYPE) {
-    preflight_info["type"] = permission_return_val->value.s;
-  } else if (permission_return_val->type == LuaValstruct::TABLE_TYPE) {
-    std::shared_ptr<LuaValstruct> tmpv;
-    try {
-      tmpv = permission_return_val->value.table.at("type");
-    } catch (const std::out_of_range &err) {
-      std::ostringstream err_msg;
-      err_msg << "The permission value returned by Lua function " << iiif_preflight_funcname << " has no type field!";
-      throw SipiError(err_msg.str());
-    }
-    if (tmpv->type != LuaValstruct::STRING_TYPE) { throw SipiError("String value expected!"); }
-    preflight_info["type"] = tmpv->value.s;
-    for (const auto &keyval : permission_return_val->value.table) {
-      if (keyval.first == "type") continue;
-      if (keyval.second->type != LuaValstruct::STRING_TYPE) { throw SipiError("String value expected!"); }
-      preflight_info[keyval.first] = keyval.second->value.s;
-    }
-  } else {
-    std::ostringstream err_msg;
-    err_msg << "The permission value returned by Lua function " << iiif_preflight_funcname << " was not valid";
-    throw SipiError(err_msg.str());
-  }
-
-  //
-  // check if permission type is valid
-  //
-  if ((preflight_info["type"] != "allow") && (preflight_info["type"] != "login")
-      && (preflight_info["type"] != "clickthrough") && (preflight_info["type"] != "kiosk")
-      && (preflight_info["type"] != "external") && (preflight_info["type"] != "restrict")
-      && (preflight_info["type"] != "deny")) {
-    std::ostringstream err_msg;
-    err_msg << "The permission returned by Lua function " << iiif_preflight_funcname
-            << " is not valid: " << preflight_info["type"];
-    throw SipiError(err_msg.str());
-  }
-
-  if (preflight_info["type"] == "deny") {
-    preflight_info["infile"] = "";
-  } else {
-    if (rvals.size() < 2) {
-      std::ostringstream err_msg;
-      err_msg << "Lua function " << iiif_preflight_funcname
-              << " returned other permission than 'deny', but it did not return a file path";
-      throw SipiError(err_msg.str());
-    }
-
-    auto infile_return_val = rvals.at(1);
-
-    // The file path must be a string.
-    if (infile_return_val->type == LuaValstruct::STRING_TYPE) {
-      preflight_info["infile"] = infile_return_val->value.s;
-    } else {
-      std::ostringstream err_msg;
-      err_msg << "The file path returned by Lua function " << iiif_preflight_funcname << " was not a string";
-      throw SipiError(err_msg.str());
-    }
-  }
-
-  // Return the permission code and file path, if any, as a std::pair.
+  SipiPermType perm{};
+  shttps::ConnectionResponseSink sink(conn_obj);
+  shttps::RequestContext ctx = shttps::make_request_context(conn_obj, sink);
+  const int rc = ::sipi_preflight(prefix.c_str(),
+    identifier.c_str(),
+    reinterpret_cast<SipiRequestContext *>(&ctx),
+    &perm,
+    preflight_collect_kv,
+    &preflight_info);
+  if (rc != 0) { throw SipiError("pre_flight failed"); }
+  preflight_info["type"] = Sipi::ffi::perm_type_to_string(perm);
   return preflight_info;
 }
 
 //=========================================================================
 
+/*!
+ * Runs the Lua `file_pre_flight` hook for the `/file` media-serving path
+ * (audio / video / PDF / any non-IIIF file) through `::sipi_file_preflight`.
+ * Same contract as call_iiif_preflight; narrower permission set.
+ *
+ * \param conn_obj the server connection (request fields + response sink).
+ * \param filepath the resolved on-disk file path.
+ * \return permission map (type + infile)
+ */
 static std::unordered_map<std::string, std::string>
-  call_file_preflight(Connection &conn_obj, shttps::LuaServer &luaserver, const std::string &filepath)
+  call_file_preflight(Connection &conn_obj, const std::string &filepath)
 {
-  // The permission and optional file path that the pre_fight function returns.
   std::unordered_map<std::string, std::string> preflight_info;
-  // std::string permission;
-  // std::string infile;
-
-  // The paramters to be passed to the pre-flight function.
-  std::vector<std::shared_ptr<LuaValstruct>> lvals;
-
-  // The first parameter is the filepath.
-  std::shared_ptr<LuaValstruct> file_path_param = std::make_shared<LuaValstruct>();
-  file_path_param->type = LuaValstruct::STRING_TYPE;
-  file_path_param->value.s = filepath;
-  lvals.push_back(file_path_param);
-
-  // The second parameter is the HTTP cookie.
-  std::shared_ptr<LuaValstruct> cookie_param = std::make_shared<LuaValstruct>();
-  std::string cookie = conn_obj.header("cookie");
-  cookie_param->type = LuaValstruct::STRING_TYPE;
-  cookie_param->value.s = cookie;
-  lvals.push_back(cookie_param);
-
-  // Call the pre-flight function.
-  std::vector<std::shared_ptr<LuaValstruct>> rvals = luaserver.executeLuafunction(file_preflight_funcname, lvals);
-
-  // If it returned nothing, that's an error.
-  if (rvals.empty()) {
-    std::ostringstream err_msg;
-    err_msg << "Lua function " << file_preflight_funcname << " must return at least one value";
-    throw SipiError(err_msg.str());
-  }
-
-  // The first return value is the permission code.
-  auto permission_return_val = rvals.at(0);
-
-  // The permission code must be a string or a table.
-  if (permission_return_val->type == LuaValstruct::STRING_TYPE) {
-    preflight_info["type"] = permission_return_val->value.s;
-  } else if (permission_return_val->type == LuaValstruct::TABLE_TYPE) {
-    std::shared_ptr<LuaValstruct> tmpv;
-    try {
-      tmpv = permission_return_val->value.table.at("type");
-    } catch (const std::out_of_range &err) {
-      std::ostringstream err_msg;
-      err_msg << "The permission value returned by Lua function " << file_preflight_funcname << " has no type field!";
-      throw SipiError(err_msg.str());
-    }
-    if (tmpv->type != LuaValstruct::STRING_TYPE) { throw SipiError("String value expected!"); }
-    preflight_info["type"] = tmpv->value.s;
-    for (const auto &keyval : permission_return_val->value.table) {
-      if (keyval.first == "type") continue;
-      if (keyval.second->type != LuaValstruct::STRING_TYPE) { throw SipiError("String value expected!"); }
-      preflight_info[keyval.first] = keyval.second->value.s;
-    }
-  } else {
-    std::ostringstream err_msg;
-    err_msg << "The permission value returned by Lua function " << file_preflight_funcname << " was not valid";
-    throw SipiError(err_msg.str());
-  }
-
-  //
-  // check if permission type is valid
-  //
-  if ((preflight_info["type"] != "allow") && (preflight_info["type"] != "login")
-      && (preflight_info["type"] != "restrict") && (preflight_info["type"] != "deny")) {
-    std::ostringstream err_msg;
-    err_msg << "The permission returned by Lua function " << file_preflight_funcname
-            << " is not valid: " << preflight_info["type"];
-    throw SipiError(err_msg.str());
-  }
-
-  if (preflight_info["type"] == "deny") {
-    preflight_info["infile"] = "";
-  } else {
-    if (rvals.size() < 2) {
-      std::ostringstream err_msg;
-      err_msg << "Lua function " << file_preflight_funcname
-              << " returned other permission than 'deny', but it did not return a file path";
-      throw SipiError(err_msg.str());
-    }
-
-    auto infile_return_val = rvals.at(1);
-
-    // The file path must be a string.
-    if (infile_return_val->type == LuaValstruct::STRING_TYPE) {
-      preflight_info["infile"] = infile_return_val->value.s;
-    } else {
-      std::ostringstream err_msg;
-      err_msg << "The file path returned by Lua function " << file_preflight_funcname << " was not a string";
-      throw SipiError(err_msg.str());
-    }
-  }
-
-  // Return the permission code and file path, if any, as a std::pair.
+  SipiPermType perm{};
+  shttps::ConnectionResponseSink sink(conn_obj);
+  shttps::RequestContext ctx = shttps::make_request_context(conn_obj, sink);
+  const int rc = ::sipi_file_preflight(
+    filepath.c_str(), reinterpret_cast<SipiRequestContext *>(&ctx), &perm, preflight_collect_kv, &preflight_info);
+  if (rc != 0) { throw SipiError("file_pre_flight failed"); }
+  preflight_info["type"] = Sipi::ffi::perm_type_to_string(perm);
   return preflight_info;
 }
 
@@ -617,7 +465,6 @@ static std::unordered_map<std::string, std::string> check_file_access(Connection
   std::unordered_map<std::string, std::string> pre_flight_info;
   if (luaserver.luaFunctionExists(iiif_preflight_funcname)) {
     pre_flight_info = call_iiif_preflight(conn_obj,
-      luaserver,
       urldecode(params[iiif_prefix]),
       sid.getIdentifier());// may throw SipiError
     infile = pre_flight_info["infile"];
@@ -1237,7 +1084,7 @@ static void serve_file_download(Connection &conn_obj,
   if (luaserver.luaFunctionExists(file_preflight_funcname)) {
     std::unordered_map<std::string, std::string> pre_flight_info;
     try {
-      pre_flight_info = call_file_preflight(conn_obj, luaserver, requested_file);
+      pre_flight_info = call_file_preflight(conn_obj, requested_file);
     } catch (SipiError &err) {
       send_error(conn_obj, Connection::INTERNAL_SERVER_ERROR, err);
       return;
@@ -1360,7 +1207,7 @@ static void serve_iiif(Connection &conn_obj,
   if (luaserver.luaFunctionExists(iiif_preflight_funcname)) {
     std::unordered_map<std::string, std::string> pre_flight_info;
     try {
-      pre_flight_info = call_iiif_preflight(conn_obj, luaserver, params[iiif_prefix], sid.getIdentifier());
+      pre_flight_info = call_iiif_preflight(conn_obj, params[iiif_prefix], sid.getIdentifier());
     } catch (SipiError &err) {
       send_error(conn_obj, Connection::INTERNAL_SERVER_ERROR, err);
       return;

--- a/src/SipiLua.cpp
+++ b/src/SipiLua.cpp
@@ -7,7 +7,7 @@
 #include <iostream>
 #include <set>
 
-#include "shttps/transport/Connection.h"
+#include "shttps/lua/request_context.h"
 #include "shttps/util/Error.h"
 #include "shttps/util/Parsing.h"
 
@@ -56,14 +56,13 @@ typedef struct
   std::string *filename;
 } SImage;
 
-// Bridges a Lua-bound shttps::Connection to the OutputSink body-write callback
-// (ADR-0006). An shttps throw (OUTPUT_WRITE_FAIL / shttps::Error) must not cross
-// into the codec, so it becomes a non-zero return.
+// Bridges the Lua response sink to the OutputSink body-write callback
+// (ADR-0006). A sink write failure becomes a non-zero return so no exception
+// crosses into the codec's C frames.
 static int lua_conn_write(void *ctx, const uint8_t *data, size_t len)
 {
   try {
-    static_cast<shttps::Connection *>(ctx)->sendAndFlush(data, len);
-    return 0;
+    return static_cast<shttps::ResponseSink *>(ctx)->write(data, len);
   } catch (...) {
     return 1;
   }
@@ -168,8 +167,8 @@ static SImage *pushSImage(lua_State *L, const SImage &simage)
  */
 static int SImage_new(lua_State *L)
 {
-  lua_getglobal(L, shttps::luaconnection);
-  auto *conn = (shttps::Connection *)lua_touserdata(L, -1);
+  lua_getglobal(L, shttps::lua_request_context);
+  auto *ctx = (shttps::RequestContext *)lua_touserdata(L, -1);
   lua_remove(L, -1);// remove from stacks
   int top = lua_gettop(L);
 
@@ -187,7 +186,7 @@ static int SImage_new(lua_State *L)
   std::string imgpath;
 
   if (lua_isinteger(L, 1)) {
-    std::vector<shttps::Connection::UploadedFile> uploads = conn->uploads();
+    const std::vector<shttps::UploadedFile> &uploads = ctx->uploads;
     int tmpfile_id = static_cast<int>(lua_tointeger(L, 1));
     try {
       imgpath = uploads.at(tmpfile_id - 1).tmpname;// In Lua, indexes are 1-based.
@@ -1582,12 +1581,12 @@ static int SImage_write(lua_State *L)
   }
 
   if ((basename == "http") || (basename == "HTTP")) {
-    lua_getglobal(L, shttps::luaconnection);// push onto stack
-    auto *conn = (shttps::Connection *)lua_touserdata(L, -1);// does not change the stack
+    lua_getglobal(L, shttps::lua_request_context);// push onto stack
+    auto *ctx = (shttps::RequestContext *)lua_touserdata(L, -1);// does not change the stack
     lua_remove(L, -1);// remove from stack
     try {
       img->image->write(
-        ftype, CallbackSink{ lua_conn_write, conn }, comp_params.size() > 0 ? &comp_params : nullptr);
+        ftype, CallbackSink{ lua_conn_write, ctx->response }, comp_params.size() > 0 ? &comp_params : nullptr);
     } catch (SipiImageError &err) {
       lua_pop(L, lua_gettop(L));
       lua_pushboolean(L, false);
@@ -1652,12 +1651,12 @@ static int SImage_send(lua_State *L)
     return lua_error(L);
   }
 
-  lua_getglobal(L, shttps::luaconnection);// push onto stack
-  auto *conn = (shttps::Connection *)lua_touserdata(L, -1);// does not change the stack
+  lua_getglobal(L, shttps::lua_request_context);// push onto stack
+  auto *ctx = (shttps::RequestContext *)lua_touserdata(L, -1);// does not change the stack
   lua_remove(L, -1);// remove from stack
 
   try {
-    img->image->write(ftype, CallbackSink{ lua_conn_write, conn });
+    img->image->write(ftype, CallbackSink{ lua_conn_write, ctx->response });
   } catch (SipiImageError &err) {
     lua_pushboolean(L, false);
     lua_pushstring(L, err.to_string().c_str());
@@ -1716,7 +1715,7 @@ static const luaL_Reg SImage_meta[] = { { "__gc", SImage_gc },
 //=========================================================================
 
 
-void sipiGlobals(lua_State *L, shttps::Connection &conn, void *user_data)
+void sipiGlobals(lua_State *L, shttps::RequestContext &ctx, void *user_data)
 {
   auto *server = (SipiHttpServer *)user_data;
 

--- a/src/cli/sipi.cpp
+++ b/src/cli/sipi.cpp
@@ -50,7 +50,7 @@
 #include "SipiIO.h"
 #include "SipiImage.h"
 #include "SipiImageError.h"
-#include "SipiLua.h"
+#include "ffi/SipiLua.h"
 #include "SipiReport.h"
 #include "observability/sentry.h"
 #include "formats/SipiIOTiff.h"
@@ -1201,7 +1201,7 @@ int main(int argc, char *argv[])
       server.luaRoutes(sipiConf.getRoutes());
       server.add_lua_globals_func(sipiConfGlobals, &sipiConf);
       server.add_lua_globals_func(shttps::sqliteGlobals);
-      server.add_lua_globals_func(Sipi::sipiGlobals, &server);
+      server.add_lua_globals_func(Sipi::sipiGlobals);
       server.prefix_as_path(sipiConf.getPrefixAsPath());
       server.dirs_to_exclude(sipiConf.getSubdirExcludes());
       server.scaling_quality(sipiConf.getScalingQuality());

--- a/src/cli/sipi.cpp
+++ b/src/cli/sipi.cpp
@@ -51,6 +51,7 @@
 #include "SipiImage.h"
 #include "SipiImageError.h"
 #include "ffi/SipiLua.h"
+#include "ffi/lua_config.h"
 #include "SipiReport.h"
 #include "observability/sentry.h"
 #include "formats/SipiIOTiff.h"
@@ -1295,6 +1296,31 @@ int main(int argc, char *argv[])
       server.queue_timeout(sipiConf.getQueueTimeout());
       server.docroot(sipiConf.getDocRoot());
       server.wwwroute(sipiConf.getWWWRoute());
+
+      // Install the engine-held Lua config the connection-less FFI entries
+      // (sipi_preflight / sipi_run_lua_route) build their per-call VM from. It
+      // mirrors the per-request VM shttps::Server builds: same init-script
+      // source, scriptdir, JWT secret, and globals installers in registration
+      // order. Phase B-L parity install; sipi_init takes it over at the Phase C
+      // cutover (this block and the server both go away then).
+      {
+        std::ifstream initscript_in(sipiConf.getInitScript());
+        if (initscript_in.fail()) {
+          throw shttps::Error("initscript \"" + sipiConf.getInitScript() + "\" not found!");
+        }
+        std::string initscript_src(
+          (std::istreambuf_iterator<char>(initscript_in)), std::istreambuf_iterator<char>());
+        Sipi::ffi::set_lua_config(Sipi::ffi::LuaConfig{
+          .init_script = std::move(initscript_src),
+          .script_dir = sipiConf.getScriptDir(),
+          .jwt_secret = sipiConf.getJwtSecret(),
+          .globals = {
+            { sipiConfGlobals, &sipiConf },
+            { shttps::sqliteGlobals, nullptr },
+            { Sipi::sipiGlobals, nullptr },
+          },
+        });
+      }
 
       // start the server
       log_info("SIPI server starting on port %d...", sipiConf.getPort());

--- a/src/cli/sipi.cpp
+++ b/src/cli/sipi.cpp
@@ -203,7 +203,7 @@
  *
  */
 
-static void sipiConfGlobals(lua_State *L, shttps::Connection &conn, void *user_data)
+static void sipiConfGlobals(lua_State *L, shttps::RequestContext &ctx, void *user_data)
 {
   auto *conf = (Sipi::SipiConf *)user_data;
 

--- a/src/ffi/BUILD.bazel
+++ b/src/ffi/BUILD.bazel
@@ -14,8 +14,9 @@ self-sufficiently (ADR-0003), the same shape as `//src/shttps/util`. Siblings
 within the package use the bare quote form (`#include "sipi_ffi.h"`).
 
 The target hosts the C++ side of the seam; its `srcs` grow as the engine is
-carved behind the FFI (today: `sipi_serve_file`, the raw `/file` Range/206
-passthrough).
+carved behind the FFI (today: `sipi_serve_file` / `sipi_serve_image` /
+`sipi_metrics_snapshot` and the Lua preflight `sipi_preflight` /
+`sipi_file_preflight`).
 """
 
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
@@ -38,6 +39,8 @@ cc_library(
         # SipiHttpServer (the dead `__sipiserver` light-userdata was dropped).
         "SipiLua.cpp",
         "engine_context.cpp",
+        "lua_config.cpp",
+        "preflight.cpp",
         "serve_image.cpp",
         "serve_response.cpp",
         "sipi_ffi.cpp",
@@ -45,6 +48,8 @@ cc_library(
     hdrs = [
         "SipiLua.h",
         "engine_context.h",
+        "lua_config.h",
+        "preflight.h",
         "metrics_snapshot.h",
         "serve_image.h",
         "serve_response.h",

--- a/src/ffi/BUILD.bazel
+++ b/src/ffi/BUILD.bazel
@@ -31,13 +31,19 @@ cc_library(
         # engine_context.{h,cpp} holds the engine services/config the pipeline
         # reads; sipi_ffi.cpp is the thin extern "C" surface (incl.
         # sipi_metrics_snapshot, which fills the SipiMetricsSnapshot layout
-        # defined in metrics_snapshot.h).
+        # defined in metrics_snapshot.h). SipiLua.cpp is the SipiImage Lua
+        # bindings (the `sipi.*` globals installer), relocated here from
+        # //src:sipi_lib so the engine-held config VM behind sipi_preflight /
+        # sipi_run_lua_route can install them — it no longer names
+        # SipiHttpServer (the dead `__sipiserver` light-userdata was dropped).
+        "SipiLua.cpp",
         "engine_context.cpp",
         "serve_image.cpp",
         "serve_response.cpp",
         "sipi_ffi.cpp",
     ],
     hdrs = [
+        "SipiLua.h",
         "engine_context.h",
         "metrics_snapshot.h",
         "serve_image.h",
@@ -64,6 +70,14 @@ cc_library(
         # MIME sniff) + shttps::urldecode. Generic SIPI-domain utilities, not the
         # HTTP transport, so this is no SIPI -> shttps-transport coupling.
         "//src/shttps/util",
+        # The connection-less LuaServer + RequestContext the SipiLua `sipi.*`
+        # bindings install into. //src/shttps/lua is transport-free (transport
+        # deps lua, never the reverse), so this is no SIPI -> shttps-transport
+        # coupling — it is exactly the Phase B-L dep the seam needs to reach the
+        # Lua runtime connection-less.
+        "//src/shttps/lua",
+        # The Lua C API the SipiImage bindings call directly (lua_State, luaL_*).
+        "@lua",
     ],
 )
 

--- a/src/ffi/SipiLua.cpp
+++ b/src/ffi/SipiLua.cpp
@@ -13,7 +13,6 @@
 
 #include "SipiCache.h"
 #include "SipiFilenameHash.h"
-#include "SipiHttpServer.h"
 #include "SipiImage.h"
 #include "SipiImageError.h"
 #include "SipiLua.h"
@@ -45,8 +44,6 @@ typedef enum {
 } Exiv2DataType;
 
 typedef std::pair<std::string, Exiv2DataType> Exiv2Valinfo;
-
-char sipiserver[] = "__sipiserver";
 
 static const char SIMAGE[] = "SipiImage";
 
@@ -1717,8 +1714,6 @@ static const luaL_Reg SImage_meta[] = { { "__gc", SImage_gc },
 
 void sipiGlobals(lua_State *L, shttps::RequestContext &ctx, void *user_data)
 {
-  auto *server = (SipiHttpServer *)user_data;
-
   lua_newtable(L);// table
   luaL_setfuncs(L, helper_methods, 0);
   lua_setglobal(L, "helper");
@@ -1760,9 +1755,6 @@ void sipiGlobals(lua_State *L, shttps::RequestContext &ctx, void *user_data)
 
   lua_setglobal(L, SIMAGE);
   // stack: empty
-
-  lua_pushlightuserdata(L, server);
-  lua_setglobal(L, sipiserver);
 }
 
 //=========================================================================

--- a/src/ffi/SipiLua.cpp
+++ b/src/ffi/SipiLua.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 - 2024 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+ * Copyright © 2016 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
  * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
  */
 

--- a/src/ffi/SipiLua.h
+++ b/src/ffi/SipiLua.h
@@ -25,8 +25,6 @@
  */
 namespace Sipi {
 
-extern char sipiserver[];
-
 extern void sipiGlobals(lua_State *L, shttps::RequestContext &ctx, void *user_data);
 
 }// namespace Sipi

--- a/src/ffi/SipiLua.h
+++ b/src/ffi/SipiLua.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 - 2024 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+ * Copyright © 2016 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
  * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
  */
 

--- a/src/ffi/lua_config.cpp
+++ b/src/ffi/lua_config.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2016 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+ * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "ffi/lua_config.h"
+
+#include <utility>
+
+namespace Sipi::ffi {
+namespace {
+  // Process-wide engine Lua config. Set once at startup (Phase B-L: by the
+  // server; Phase C: by sipi_init) and only read thereafter, so the per-call VM
+  // factory needs no synchronization on the config itself. (Each call still gets
+  // its own LuaServer — the Lua VM is never shared across threads.)
+  LuaConfig g_lua_config;
+}// namespace
+
+void set_lua_config(LuaConfig cfg) { g_lua_config = std::move(cfg); }
+
+const LuaConfig &lua_config() { return g_lua_config; }
+
+std::unique_ptr<shttps::LuaServer> make_lua_server(shttps::RequestContext &ctx)
+{
+  const LuaConfig &cfg = g_lua_config;
+  ctx.jwt_secret = cfg.jwt_secret;
+
+  // Mirror Server::process_request: package.path base, then the init script
+  // (createGlobals installs server.* and the script defines the preflight
+  // hooks), then the remaining globals in registration order.
+  const std::string lua_scriptdir = cfg.script_dir + "/?.lua";
+  auto vm = std::make_unique<shttps::LuaServer>(ctx, cfg.init_script, /*iscode=*/true, lua_scriptdir);
+  for (const auto &g : cfg.globals) { g.func(vm->lua(), ctx, g.user_data); }
+  return vm;
+}
+
+}// namespace Sipi::ffi

--- a/src/ffi/lua_config.h
+++ b/src/ffi/lua_config.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2016 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+ * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/*!
+ * The engine-owned Lua configuration the connection-less FFI entry points read.
+ *
+ * `sipi_preflight` / `sipi_run_lua_route` are C ABIs that carry no LuaServer and
+ * no config — they need a fully-configured Lua VM but have no socket and no
+ * `shttps::Server` to build one from. `LuaConfig` is that durable Lua state: the
+ * init-script source (which defines `pre_flight` / `file_pre_flight`), the Lua
+ * package path, the JWT secret, and the `config.*` / `db` / `sipi.*` globals
+ * installers — the engine-held parallel to `shttps::Server`'s `_initscript` /
+ * `_scriptdir` / `jwt_secret` + `lua_globals`.
+ *
+ * `make_lua_server` rebuilds, connection-less, exactly the per-request VM
+ * `Server::process_request` constructs: the init script runs (installing
+ * `server.*` and defining the preflight hooks), then the remaining globals are
+ * applied. In Phase C `sipi_init` constructs and installs the `LuaConfig`; in the
+ * Phase B-L parity window the still-living server installs it via
+ * `set_lua_config` — the same throwaway-installer shape as `set_engine_context`,
+ * gone with the server at the cutover.
+ */
+#ifndef SIPI_FFI_LUA_CONFIG_H
+#define SIPI_FFI_LUA_CONFIG_H
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "shttps/lua/LuaServer.h"// shttps::LuaServer, LuaSetGlobalsFunc, RequestContext
+
+namespace Sipi::ffi {
+
+/*! One Lua globals installer + its user_data, mirroring an entry of
+ *  `shttps::Server`'s per-request `lua_globals` list
+ *  (`sipiConfGlobals`/`sqliteGlobals`/`sipiGlobals`). */
+struct LuaGlobalsInstaller
+{
+  shttps::LuaSetGlobalsFunc func = nullptr;
+  void *user_data = nullptr;
+};
+
+/*! Engine-held Lua configuration. The globals installers are applied in order
+ *  after the init script runs (matching the registration order in the parity
+ *  path). The `user_data` pointers and installer functions are non-owning and
+ *  must outlive every Lua call (the installer outlives all requests). */
+struct LuaConfig
+{
+  std::string init_script;//!< init-script SOURCE (defines pre_flight / file_pre_flight)
+  std::string script_dir;//!< Lua package.path base (the `/?.lua` suffix is added by the factory)
+  std::string jwt_secret;//!< server.generate_jwt / server.decode_jwt secret
+  std::vector<LuaGlobalsInstaller> globals;//!< config.* / db / sipi.* installers, applied in order
+};
+
+/*! Install the engine Lua config (copied into a file-static). Called once at
+ *  server startup in the Phase B-L parity path; superseded by `sipi_init` in
+ *  Phase C. */
+void set_lua_config(LuaConfig cfg);
+
+/*! The installed Lua config. Returns a default-constructed (empty) config if
+ *  `set_lua_config` was never called. */
+[[nodiscard]] const LuaConfig &lua_config();
+
+/*! Build a fully-configured, connection-less `LuaServer` for one request: runs
+ *  the init script (so `server.*` is installed and the preflight hooks are
+ *  defined), then applies the `config.*` / `db` / `sipi.*` globals — exactly the
+ *  per-request VM `Server::process_request` builds, minus the `Connection`. Sets
+ *  `ctx.jwt_secret` from the config. `ctx` MUST outlive the returned VM
+ *  (`createGlobals` stores `&ctx` as a light-userdata global). Throws
+ *  `shttps::Error` if the init script fails to load (caught by the caller's
+ *  `sipi_guard`). */
+[[nodiscard]] std::unique_ptr<shttps::LuaServer> make_lua_server(shttps::RequestContext &ctx);
+
+}// namespace Sipi::ffi
+
+#endif// SIPI_FFI_LUA_CONFIG_H

--- a/src/ffi/preflight.cpp
+++ b/src/ffi/preflight.cpp
@@ -1,0 +1,211 @@
+/*
+ * Copyright © 2016 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+ * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "ffi/preflight.h"
+
+#include <exception>
+#include <memory>
+#include <optional>
+
+#include "ffi/lua_config.h"
+#include "logging/logger.h"
+#include "shttps/lua/LuaServer.h"
+#include "shttps/lua/request_context.h"
+
+namespace Sipi::ffi {
+namespace {
+
+  using shttps::LuaServer;
+  using shttps::LuaValstruct;
+  using shttps::RequestContext;
+
+  // Deliberate FFI-boundary normalization: the seam's char* inputs are
+  // contractually non-null, but this is a C ABI surface (Phase C feeds it from
+  // Rust), so a null collapses to an empty Lua arg rather than UB.
+  std::shared_ptr<LuaValstruct> string_param(const char *s)
+  {
+    auto v = std::make_shared<LuaValstruct>();
+    v->type = LuaValstruct::STRING_TYPE;
+    v->value.s = (s != nullptr) ? s : "";
+    return v;
+  }
+
+  std::shared_ptr<LuaValstruct> string_param(const std::string &s)
+  {
+    auto v = std::make_shared<LuaValstruct>();
+    v->type = LuaValstruct::STRING_TYPE;
+    v->value.s = s;
+    return v;
+  }
+
+  // The raw `Cookie` header value, the Lua preflight hooks' `cookie` argument.
+  // Snapshotted into ctx.headers (lower-cased) by make_request_context, matching
+  // the legacy conn_obj.header("cookie").
+  std::string cookie_header(const RequestContext &ctx)
+  {
+    const auto it = ctx.headers.find("cookie");
+    return it != ctx.headers.end() ? it->second : std::string{};
+  }
+
+  std::optional<SipiPermType> perm_from_string(const std::string &s, bool extended)
+  {
+    if (s == "allow") { return SIPI_ALLOW; }
+    if (s == "login") { return SIPI_LOGIN; }
+    if (s == "restrict") { return SIPI_RESTRICT; }
+    if (s == "deny") { return SIPI_DENY; }
+    if (extended) {
+      if (s == "clickthrough") { return SIPI_CLICKTHROUGH; }
+      if (s == "kiosk") { return SIPI_KIOSK; }
+      if (s == "external") { return SIPI_EXTERNAL; }
+    }
+    return std::nullopt;
+  }
+
+  // Parse the Lua return values into a PreflightDecision, mirroring the legacy
+  // call_{iiif,file}_preflight parsing exactly. The permission is either a bare
+  // string or a table carrying `type` plus extra string keys (watermark, size,
+  // cookieUrl, …). `extended` adds the IIIF-only permissions
+  // (clickthrough/kiosk/external) to the base allow/login/restrict/deny set.
+  // Every failure logs the detail (the status alone crosses the C ABI) and maps
+  // to 500, matching the legacy handler.
+  std::expected<PreflightDecision, SipiStatus> parse_preflight(
+    const std::vector<std::shared_ptr<LuaValstruct>> &rvals,
+    const std::string &funcname,
+    bool extended)
+  {
+    if (rvals.empty()) {
+      log_err("Lua function %s must return at least one value", funcname.c_str());
+      return std::unexpected(SipiStatus::InternalError);
+    }
+
+    PreflightDecision decision;
+    std::string type_str;
+
+    const auto &perm_val = rvals.at(0);
+    if (perm_val->type == LuaValstruct::STRING_TYPE) {
+      type_str = perm_val->value.s;
+    } else if (perm_val->type == LuaValstruct::TABLE_TYPE) {
+      const auto it = perm_val->value.table.find("type");
+      if (it == perm_val->value.table.end()) {
+        log_err("The permission value returned by Lua function %s has no type field!", funcname.c_str());
+        return std::unexpected(SipiStatus::InternalError);
+      }
+      if (it->second->type != LuaValstruct::STRING_TYPE) {
+        log_err("The permission 'type' returned by Lua function %s must be a string", funcname.c_str());
+        return std::unexpected(SipiStatus::InternalError);
+      }
+      type_str = it->second->value.s;
+      for (const auto &[key, val] : perm_val->value.table) {
+        if (key == "type") { continue; }
+        if (val->type != LuaValstruct::STRING_TYPE) {
+          log_err("The '%s' value returned by Lua function %s must be a string", key.c_str(), funcname.c_str());
+          return std::unexpected(SipiStatus::InternalError);
+        }
+        decision.kv.emplace_back(key, val->value.s);
+      }
+    } else {
+      log_err("The permission value returned by Lua function %s was not valid", funcname.c_str());
+      return std::unexpected(SipiStatus::InternalError);
+    }
+
+    const auto perm = perm_from_string(type_str, extended);
+    if (!perm) {
+      log_err("The permission returned by Lua function %s is not valid: %s", funcname.c_str(), type_str.c_str());
+      return std::unexpected(SipiStatus::InternalError);
+    }
+    decision.type = *perm;
+
+    if (decision.type == SIPI_DENY) {
+      decision.kv.emplace_back("infile", "");
+    } else {
+      if (rvals.size() < 2) {
+        log_err("Lua function %s returned other permission than 'deny', but it did not return a file path",
+          funcname.c_str());
+        return std::unexpected(SipiStatus::InternalError);
+      }
+      const auto &infile_val = rvals.at(1);
+      if (infile_val->type != LuaValstruct::STRING_TYPE) {
+        log_err("The file path returned by Lua function %s was not a string", funcname.c_str());
+        return std::unexpected(SipiStatus::InternalError);
+      }
+      decision.kv.emplace_back("infile", infile_val->value.s);
+    }
+
+    return decision;
+  }
+
+  // Build a per-call VM from the engine Lua config bound to the caller's request
+  // context, run the named hook, and parse its result. The init script defines
+  // the hook; createGlobals (bound to ctx) + the config.*/db/sipi.* installers
+  // give it server.*/config/db/sipi reading the real request.
+  std::expected<PreflightDecision, SipiStatus> run_preflight(
+    RequestContext &ctx,
+    const std::string &funcname,
+    const std::vector<std::shared_ptr<LuaValstruct>> &lvals,
+    bool extended)
+  {
+    std::vector<std::shared_ptr<LuaValstruct>> rvals;
+    try {
+      auto vm = make_lua_server(ctx);
+      rvals = vm->executeLuafunction(funcname, lvals);
+    } catch (const std::exception &e) {
+      log_err("Lua function %s failed: %s", funcname.c_str(), e.what());
+      return std::unexpected(SipiStatus::InternalError);
+    }
+    return parse_preflight(rvals, funcname, extended);
+  }
+
+}// namespace
+
+std::expected<PreflightDecision, SipiStatus>
+  build_preflight(const char *prefix, const char *identifier, RequestContext &ctx)
+{
+  const std::vector<std::shared_ptr<LuaValstruct>> lvals = {
+    string_param(prefix),
+    string_param(identifier),
+    string_param(cookie_header(ctx)),
+  };
+  return run_preflight(ctx, "pre_flight", lvals, /*extended=*/true);
+}
+
+std::expected<PreflightDecision, SipiStatus> build_file_preflight(const char *filepath, RequestContext &ctx)
+{
+  const std::vector<std::shared_ptr<LuaValstruct>> lvals = {
+    string_param(filepath),
+    string_param(cookie_header(ctx)),
+  };
+  return run_preflight(ctx, "file_pre_flight", lvals, /*extended=*/false);
+}
+
+void apply_preflight(PreflightDecision &&decision, SipiPermType *type, SipiKVFn emit_kv, void *kv_ctx)
+{
+  if (type != nullptr) { *type = decision.type; }
+  if (emit_kv != nullptr) {
+    for (const auto &[key, value] : decision.kv) { emit_kv(kv_ctx, key.c_str(), value.c_str()); }
+  }
+}
+
+const char *perm_type_to_string(SipiPermType type)
+{
+  switch (type) {
+  case SIPI_ALLOW:
+    return "allow";
+  case SIPI_LOGIN:
+    return "login";
+  case SIPI_CLICKTHROUGH:
+    return "clickthrough";
+  case SIPI_KIOSK:
+    return "kiosk";
+  case SIPI_EXTERNAL:
+    return "external";
+  case SIPI_RESTRICT:
+    return "restrict";
+  case SIPI_DENY:
+    return "deny";
+  }
+  return "deny";// unreachable; the enum is exhaustively handled above
+}
+
+}// namespace Sipi::ffi

--- a/src/ffi/preflight.h
+++ b/src/ffi/preflight.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2016 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+ * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/*!
+ * The connection-less preflight builders behind `sipi_preflight` /
+ * `sipi_file_preflight` (`ffi/sipi_ffi.h`).
+ *
+ * Same misuse-resistant shape as `serve_response.h`: a `build_*` step runs the
+ * Lua hook and returns a pure value (`std::expected<PreflightDecision,
+ * SipiStatus>`) — every fallible step (VM construction, Lua execution, result
+ * validation) happens here, before anything is committed — and a single `apply`
+ * drives the C output channel (the permission-type out-param + the key/value
+ * callback). Both are wrapped by `sipi_guard` at the `extern "C"` entry.
+ *
+ * `PreflightDecision` is a clean value type (a permission enum + an open kv map)
+ * so it ports 1:1 to the future Rust `PreFlight` trait return type (decision #9
+ * in the plan): the C++ Lua hook is just one producer of it.
+ */
+#ifndef SIPI_FFI_PREFLIGHT_H
+#define SIPI_FFI_PREFLIGHT_H
+
+#include <expected>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "ffi/serve_response.h"// SipiStatus
+#include "ffi/sipi_ffi.h"// SipiPermType, SipiKVFn
+#include "shttps/lua/request_context.h"// shttps::RequestContext
+
+namespace Sipi::ffi {
+
+/*! The parsed result of a Lua preflight hook: the permission type plus the open
+ *  key/value channel the hook returned (`infile` + any extras: `watermark`,
+ *  `size`, `cookieUrl`, `tokenUrl`, `logoutUrl`, service pass-through). The
+ *  caller compares the type and reads the kv it needs. `type` is the enum, so
+ *  the kv never carries a `"type"` key. */
+struct PreflightDecision
+{
+  SipiPermType type{};
+  std::vector<std::pair<std::string, std::string>> kv;
+};
+
+/*! Run the IIIF `pre_flight(prefix, identifier, cookie)` Lua hook against the
+ *  caller-supplied request context: build a per-call VM from the engine Lua
+ *  config bound to `ctx` (so `server.header` / `server.cookies` / `server.get`
+ *  resolve from the real request), run the hook, validate the result, return the
+ *  decision. The `cookie` Lua argument is taken from `ctx` (the `cookie`
+ *  header). `ctx` must outlive the call. Pure of the C output channel. Returns
+ *  `SipiStatus::InternalError` (logged) on any Lua / validation failure, matching
+ *  the legacy handler's 500. */
+[[nodiscard]] std::expected<PreflightDecision, SipiStatus> build_preflight(const char *prefix,
+  const char *identifier,
+  shttps::RequestContext &ctx);
+
+/*! Run the `file_pre_flight(filepath, cookie)` Lua hook — the `/file`
+ *  media-serving path (audio / video / PDF / any non-IIIF file). Narrower valid
+ *  permission set than `build_preflight` (allow / login / restrict / deny). */
+[[nodiscard]] std::expected<PreflightDecision, SipiStatus> build_file_preflight(const char *filepath,
+  shttps::RequestContext &ctx);
+
+/*! The single place that drives the preflight C output channel: write the
+ *  permission type, then emit each kv pair. */
+void apply_preflight(PreflightDecision &&decision, SipiPermType *type, SipiKVFn emit_kv, void *kv_ctx);
+
+/*! The Lua-facing permission string for a type (`SIPI_ALLOW` → `"allow"`, …).
+ *  Used by the Phase B-L parity adapters in `SipiHttpServer.cpp` to rebuild the
+ *  string-keyed `preflight_info` map the existing handlers consume. */
+[[nodiscard]] const char *perm_type_to_string(SipiPermType type);
+
+}// namespace Sipi::ffi
+
+#endif// SIPI_FFI_PREFLIGHT_H

--- a/src/ffi/sipi_ffi.cpp
+++ b/src/ffi/sipi_ffi.cpp
@@ -10,9 +10,11 @@
 
 #include "ffi/engine_context.h"
 #include "ffi/metrics_snapshot.h"
+#include "ffi/preflight.h"
 #include "ffi/serve_image.h"
 #include "ffi/serve_response.h"
 #include "observability/metrics.h"
+#include "shttps/lua/request_context.h"// shttps::RequestContext (the opaque SipiRequestContext)
 
 extern "C" {
 
@@ -41,6 +43,45 @@ int sipi_serve_image(const SipiServeRequest *req, const SipiResponse *resp)
     auto result = Sipi::ffi::build_image_response(*req, Sipi::ffi::engine_context(), cancelled);
     if (!result) { return static_cast<int>(result.error()); }
     Sipi::ffi::apply(std::move(*result), *resp);
+    return static_cast<int>(Sipi::ffi::SipiStatus::Ok);
+  });
+}
+
+int sipi_preflight(const char *prefix,
+  const char *identifier,
+  SipiRequestContext *ctx,
+  SipiPermType *type,
+  SipiKVFn emit_kv,
+  void *kv_ctx)
+{
+  // Same build/apply/guard shape as the serve entries: build_preflight runs the
+  // Lua hook against the caller's request context and every fallible step (VM
+  // build, execution, result validation) before anything is committed;
+  // apply_preflight is the only code that touches the C output channel (the type
+  // out-param + the kv callback); all under the no-throw guard. The opaque
+  // SipiRequestContext is the C++ shttps::RequestContext the caller built.
+  return Sipi::ffi::sipi_guard([&] {
+    auto &rc = *reinterpret_cast<shttps::RequestContext *>(ctx);
+    auto result = Sipi::ffi::build_preflight(prefix, identifier, rc);
+    if (!result) { return static_cast<int>(result.error()); }
+    Sipi::ffi::apply_preflight(std::move(*result), type, emit_kv, kv_ctx);
+    return static_cast<int>(Sipi::ffi::SipiStatus::Ok);
+  });
+}
+
+int sipi_file_preflight(const char *filepath,
+  SipiRequestContext *ctx,
+  SipiPermType *type,
+  SipiKVFn emit_kv,
+  void *kv_ctx)
+{
+  // The /file media-serving preflight; identical shape to sipi_preflight, runs
+  // the file_pre_flight hook over a resolved filepath.
+  return Sipi::ffi::sipi_guard([&] {
+    auto &rc = *reinterpret_cast<shttps::RequestContext *>(ctx);
+    auto result = Sipi::ffi::build_file_preflight(filepath, rc);
+    if (!result) { return static_cast<int>(result.error()); }
+    Sipi::ffi::apply_preflight(std::move(*result), type, emit_kv, kv_ctx);
     return static_cast<int>(Sipi::ffi::SipiStatus::Ok);
   });
 }

--- a/src/ffi/sipi_ffi.h
+++ b/src/ffi/sipi_ffi.h
@@ -163,10 +163,13 @@ typedef struct
   int is_head; /* 1 = HEAD: emit status + headers, no body, no cache write */
 } SipiServeRequest;
 
-/* ── Preflight (C++ LuaServer pre_flight) ───────────────────────────────────
+/* ── Preflight (C++ LuaServer pre_flight / file_pre_flight) ──────────────────
  * A fixed permission TYPE plus an open key/value channel (infile, watermark,
  * size, cookie_url, token_url, logout_url, service pass-through) — the real
- * preflight returns an unordered_map, not a flat struct. */
+ * preflight returns an unordered_map, not a flat struct. Two hooks, same
+ * shape: the IIIF image preflight (prefix + identifier) and the `/file`
+ * media-serving preflight (a resolved filepath; audio / video / PDF / any
+ * non-IIIF file). */
 typedef enum {
   SIPI_ALLOW = 0,
   SIPI_LOGIN = 1,
@@ -187,6 +190,15 @@ typedef void (*SipiKVFn)(void *ctx, const char *key, const char *value);
 typedef struct SipiServerConfig SipiServerConfig;
 typedef struct SipiMetricsSnapshot SipiMetricsSnapshot;
 
+/* The whole HTTP request the Lua subsystem reads (method/uri/host/secure +
+ * headers, cookies, GET/POST params, uploads, body). Opaque because the Lua
+ * runtime stays C++ behind the seam (it wraps the C++ `shttps::RequestContext`);
+ * the Lua hooks can read ANY request field via `server.*`, so preflight and
+ * configured routes carry the full request, not the narrow IIIF `SipiServeRequest`.
+ * Built by the caller — the transport in the Phase B-L parity path, the Rust
+ * shell (via a builder) in Phase C. */
+typedef struct SipiRequestContext SipiRequestContext;
+
 /* ── Entry points ───────────────────────────────────────────────────────────
  * All return 0 on success / an error code on failure; none let a C++ exception
  * cross the boundary. */
@@ -204,10 +216,24 @@ SIPI_FFI_NODISCARD int sipi_serve_image(const SipiServeRequest *req, const SipiR
  *  so the caller can render its own error response. */
 SIPI_FFI_NODISCARD int sipi_serve_file(const char *resolved_path, const char *range, const SipiResponse *resp);
 
-/*! C++ LuaServer `pre_flight()`: returns a permission type + key/value channel. */
+/*! C++ LuaServer `pre_flight()`: returns a permission type + key/value channel.
+ *  The IIIF image preflight (serve_iiif / info.json). The hook reads the request
+ *  through `ctx` (`server.header` / `server.cookies` / …) and gets prefix +
+ *  identifier + the cookie header as its Lua arguments. Valid permission types:
+ *  allow / login / clickthrough / kiosk / external / restrict / deny. */
 SIPI_FFI_NODISCARD int sipi_preflight(const char *prefix,
   const char *identifier,
-  const char *cookie,
+  SipiRequestContext *ctx,
+  SipiPermType *type,
+  SipiKVFn emit_kv,
+  void *kv_ctx);
+
+/*! C++ LuaServer `file_pre_flight()`: the `/file` media-serving path (audio /
+ *  video / PDF / any non-IIIF file). Same shape as sipi_preflight but takes a
+ *  resolved filepath; narrower valid permission set: allow / login / restrict /
+ *  deny. */
+SIPI_FFI_NODISCARD int sipi_file_preflight(const char *filepath,
+  SipiRequestContext *ctx,
   SipiPermType *type,
   SipiKVFn emit_kv,
   void *kv_ctx);

--- a/src/shttps/BUILD.bazel
+++ b/src/shttps/BUILD.bazel
@@ -10,11 +10,13 @@ module boundary is a build-graph fact rather than a naming convention:
   - `jwt/`       — JWT verify/sign
   - `lua_sqlite/`— SQLite-backed Lua bindings
 
-`transport` and `lua` are mutually dependent (Server holds a LuaServer;
-LuaServer needs the full Connection type), so they share this package
-(`:shttps_headers` + `:shttps`); util/jwt/lua_sqlite are separate leaf
-packages. util and jwt are leaves; lua_sqlite depends one-directionally
-on `:shttps`.
+This package holds the `transport/` layer (`:shttps_headers` + `:shttps`).
+`lua/` is its own `//src/shttps/lua` package: the request_context decoupling
+severed `LuaServer`'s dependency on `shttps::Connection`, so the edge is now
+one-directional — `transport` depends on `lua` (Server constructs a LuaServer
+per request), never the reverse, which also lets `//src/ffi` link `lua`
+directly. util, jwt, lua, and lua_sqlite are separate packages; util and jwt
+are leaves, lua depends on util + jwt, lua_sqlite depends on lua.
 
 Strict SIPI → shttps one-way dependency direction: only `//src/...` may
 depend on `//src/shttps:shttps`, and shttps declares no `//src/...` deps
@@ -45,31 +47,27 @@ package(default_visibility = [
 ])
 
 # ── //src/shttps:shttps_headers ────────────────────────────────────────────────
-# Header-only surface of the transport + lua modules. Split out so
+# Header-only surface of the transport module. Split out so
 # `//fuzz/handlers:fuzz_subset` can compile its transport-cpp slice with the
 # full include graph available (`#include "Server.h"` chains pull
 # LuaServer.h, ConnectionMetrics.h, etc.) without linking shttps's compiled
 # archive — only the explicitly-listed cpps end up in the fuzz binary.
 #
-# `includes = [".", "transport", "lua"]` + `include_prefix = "shttps"` give
-# three include forms: external consumers reach the headers as
-# `#include "shttps/transport/X.h"` / `#include "shttps/lua/X.h"` (prefix
-# form); same-directory siblings keep working as `#include "X.h"` (the
-# `transport`/`lua` entries put each module dir on the quote path); and the
-# cross-module edges between the two dirs are written in the explicit
-# `shttps/transport/…` / `shttps/lua/…` form. The generic utilities live in
-# `//src/shttps/util`, reached as `#include "shttps/util/X.h"`, so util is a
-# direct dep.
+# `includes = [".", "transport"]` + `include_prefix = "shttps"` give two
+# include forms: external consumers reach the headers as
+# `#include "shttps/transport/X.h"` (prefix form); same-directory siblings keep
+# working as `#include "X.h"` (the `transport` entry puts the module dir on the
+# quote path). Server.h includes `#include "shttps/lua/LuaServer.h"` and
+# `lua.hpp`, so the `//src/shttps/lua` package + `@lua` are deps here to carry
+# those headers to every consumer of this surface.
 cc_library(
     name = "shttps_headers",
     hdrs = glob([
         "transport/*.h",
-        "lua/*.h",
     ]),
     includes = [
         ".",
         "transport",
-        "lua",
     ],
     include_prefix = "shttps",
     deps = [
@@ -77,12 +75,12 @@ cc_library(
         # this package as a shared support library.
         "//src/logging:logging",
         "//src/shttps/util",
-        "@curl",
-        "@jansson//:jansson",
+        # Server.h pulls in shttps/lua/LuaServer.h.
+        "//src/shttps/lua",
+        # Server.h includes lua.hpp directly.
         "@lua",
         "@openssl//:crypto",
         "@openssl//:ssl",
-        "@sqlite3",
         "@zlib",
     ],
 )
@@ -92,29 +90,25 @@ cc_library(
     srcs = glob(
         [
             "transport/*.cpp",
-            "lua/*.cpp",
         ],
         exclude = [
             "transport/Shttp.cpp",  # standalone test driver, not part of the library
             "transport/*_test.cpp",  # co-located unit tests (see :transport_test)
-            "lua/*_test.cpp",
         ],
     ),
     deps = [
         ":shttps_headers",
-        # Generic SIPI-domain utilities; the transport/lua sources here
+        # Generic SIPI-domain utilities; the transport sources here
         # `#include "shttps/util/X.h"`.
         "//src/shttps/util",
-        # JWT verify/sign; LuaServer.cpp's `server.jwt` bindings
-        # `#include "shttps/jwt/jwt.h"`.
-        "//src/shttps/jwt",
-        # sole — r-lyeh's single-header UUID lib; LuaServer.cpp's server.uuid*
-        # Lua bindings (incl. the DSP base62 IRI scheme).
-        "@sole//:sole",
+        # Server constructs a LuaServer per request and registers the
+        # LuaSetGlobalsFunc installers; the Lua runtime is its own package
+        # since the request_context decoupling (transport -> lua, one-way).
+        "//src/shttps/lua",
         # Server.cpp names the pool's worker threads for the Tracy timeline
         # (`tracy::SetThreadName`). Inert unless `--config=tracy`.
         "@tracy//:tracy",
-        # Both are external deps, so neither breaches the SIPI -> shttps one-way rule.
+        # All external/SIPI deps respect the SIPI -> shttps one-way rule.
     ],
 )
 

--- a/src/shttps/lua/BUILD.bazel
+++ b/src/shttps/lua/BUILD.bazel
@@ -1,0 +1,43 @@
+"""shttps/lua — the per-request Lua interpreter (LuaServer).
+
+LuaServer drives the Lua VM behind the preflight hook, the configured Lua
+routes, and the init script. Since the request_context decoupling it no longer
+names shttps::Connection: it reads request fields and writes the response
+through the connection-less RequestContext / ResponseSink seam
+(`request_context.h`). It therefore carries no transport dependency and can be
+built below `//src/ffi` — `transport` depends on `lua`, never the reverse.
+
+`strip_include_prefix = "/src"` exposes the headers at the path-prefixed form
+`#include "shttps/lua/LuaServer.h"` / `#include "shttps/lua/request_context.h"`
+(ADR-0003).
+"""
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//src:__subpackages__"])
+
+cc_library(
+    name = "lua",
+    srcs = glob(
+        ["*.cpp"],
+        exclude = ["*_test.cpp"],
+    ),
+    hdrs = glob(["*.h"]),
+    strip_include_prefix = "/src",
+    deps = [
+        # Levelled logging primitive (server.log).
+        "//src/logging:logging",
+        # server.jwt bindings (generate/decode).
+        "//src/shttps/jwt",
+        # Generic helpers: Error, Global, Parsing, Hash.
+        "//src/shttps/util",
+        # server.http client (CurlConnection).
+        "@curl",
+        # server.table_to_json / json_to_table.
+        "@jansson//:jansson",
+        # the Lua C API.
+        "@lua",
+        # server.uuid* — r-lyeh's base62 UUID (DSP IRI scheme).
+        "@sole//:sole",
+    ],
+)

--- a/src/shttps/lua/LuaServer.cpp
+++ b/src/shttps/lua/LuaServer.cpp
@@ -23,13 +23,10 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include "shttps/transport/Connection.h"
 #include "shttps/util/Error.h"
 #include "shttps/util/Global.h"
 #include "LuaServer.h"
 #include "shttps/util/Parsing.h"
-#include "shttps/transport/Server.h"
-#include "shttps/transport/SockStream.h"
 #include "curl/curl.h"
 
 #include "logging/logger.h"
@@ -44,7 +41,7 @@ static const char servertablename[] = "server";
 
 namespace shttps {
 
-char luaconnection[] = "__shttpsconnection";
+char lua_request_context[] = "__shttps_request_context";
 
 /*!
  * Dumps the Lua stack to a string.
@@ -225,13 +222,13 @@ LuaServer::LuaServer()
 /*!
  * Instantiates a Lua server
  */
-LuaServer::LuaServer(Connection &conn)
+LuaServer::LuaServer(RequestContext &ctx)
 {
   if ((L = luaL_newstate()) == nullptr) { throw Error("Couldn't start lua interpreter"); }
 
   lua_atpanic(L, dont_panic);
   luaL_openlibs(L);
-  createGlobals(conn);
+  createGlobals(ctx);
 }
 //=========================================================================
 
@@ -265,13 +262,13 @@ LuaServer::LuaServer(const std::string &luafile, bool iscode)
  *
  * \param[in] luafile A file containing a Lua script or a Lua code chunk
  */
-LuaServer::LuaServer(Connection &conn, const std::string &luafile, bool iscode, const std::string &lua_scriptdir)
+LuaServer::LuaServer(RequestContext &ctx, const std::string &luafile, bool iscode, const std::string &lua_scriptdir)
 {
   if ((L = luaL_newstate()) == nullptr) { throw Error("Couldn't start lua interpreter"); }
 
   lua_atpanic(L, dont_panic);
   luaL_openlibs(L);
-  createGlobals(conn);
+  createGlobals(ctx);
 
   // add the script directory to the standard search path for lua packages
   // this allows for the inclusion of Lua scripts contained in the Lua script directory
@@ -333,17 +330,11 @@ static int lua_setbuffer(lua_State *L)
   }
 
   lua_pop(L, top);
-  lua_getglobal(L, luaconnection);// push onto stack
-  Connection *conn = (Connection *)lua_touserdata(L, -1);// does not change the stack
+  lua_getglobal(L, lua_request_context);// push onto stack
+  RequestContext *ctx = (RequestContext *)lua_touserdata(L, -1);// does not change the stack
   lua_remove(L, -1);// remove from stack
 
-  if ((bufsize > 0) && (incsize > 0)) {
-    conn->setBuffer(bufsize, incsize);
-  } else if (bufsize > 0) {
-    conn->setBuffer(bufsize);
-  } else {
-    conn->setBuffer();
-  }
+  ctx->response->set_buffer(bufsize, incsize);
 
   lua_pushboolean(L, true);
   lua_pushnil(L);
@@ -890,8 +881,8 @@ static int lua_fs_copyfile(lua_State *L)
  */
 static int lua_fs_mvfile(lua_State *L)
 {
-  lua_getglobal(L, shttps::luaconnection);
-  shttps::Connection *conn = (shttps::Connection *)lua_touserdata(L, -1);
+  lua_getglobal(L, shttps::lua_request_context);
+  shttps::RequestContext *ctx = (shttps::RequestContext *)lua_touserdata(L, -1);
   lua_remove(L, -1);// remove from stacks
   int top = lua_gettop(L);
 
@@ -904,7 +895,7 @@ static int lua_fs_mvfile(lua_State *L)
 
   std::string infile;
   if (lua_isinteger(L, 1)) {
-    std::vector<shttps::Connection::UploadedFile> uploads = conn->uploads();
+    const std::vector<shttps::UploadedFile> &uploads = ctx->uploads;
     int tmpfile_id = static_cast<int>(lua_tointeger(L, 1));
     try {
       infile = uploads.at(tmpfile_id - 1).tmpname;// In Lua, indexes are 1-based.
@@ -1072,8 +1063,8 @@ static int lua_base62_to_uuid(lua_State *L)
  */
 static int lua_print(lua_State *L)
 {
-  lua_getglobal(L, luaconnection);// push onto stack
-  Connection *conn = (Connection *)lua_touserdata(L, -1);// does not change the stack
+  lua_getglobal(L, lua_request_context);// push onto stack
+  RequestContext *ctx = (RequestContext *)lua_touserdata(L, -1);// does not change the stack
   lua_remove(L, -1);// remove from stack
   int top = lua_gettop(L);
 
@@ -1082,17 +1073,10 @@ static int lua_print(lua_State *L)
     const char *str = lua_tolstring(L, i, &len);
 
     if (str != nullptr) {
-      try {
-        conn->send(str, len);
-      } catch (int ierr) {
+      if (ctx->response->write(str, len) != 0) {
         lua_settop(L, 0);// clear stack
         lua_pushboolean(L, false);
         lua_pushstring(L, "Sending data to connection failed");
-        return 2;
-      } catch (Error &err) {
-        lua_settop(L, 0);// clear stack
-        lua_pushboolean(L, false);
-        lua_pushstring(L, err.to_string().c_str());
         return 2;
       }
     }
@@ -1107,12 +1091,13 @@ static int lua_print(lua_State *L)
 
 static int lua_require_auth(lua_State *L)
 {
-  lua_getglobal(L, luaconnection);// push onto stack
-  Connection *conn = (Connection *)lua_touserdata(L, -1);// does not change the stack
+  lua_getglobal(L, lua_request_context);// push onto stack
+  RequestContext *ctx = (RequestContext *)lua_touserdata(L, -1);// does not change the stack
   lua_remove(L, -1);// remove from stack
   lua_pushboolean(L, true);
 
-  std::string auth = conn->header("authorization");
+  auto auth_it = ctx->headers.find("authorization");
+  std::string auth = auth_it != ctx->headers.end() ? auth_it->second : std::string();
   lua_createtable(L, 0, 3);// table
 
   if (auth.empty()) {
@@ -1124,7 +1109,7 @@ static int lua_require_auth(lua_State *L)
 
     if ((npos = auth.find(" ")) != std::string::npos) {
       std::string auth_type = auth.substr(0, npos);
-      asciitolower(auth_type);
+      std::transform(auth_type.begin(), auth_type.end(), auth_type.begin(), ::tolower);
 
       if (auth_type == "basic") {
         std::string auth_secret = auth.substr(npos + 1);
@@ -1800,10 +1785,10 @@ static int lua_json_to_table(lua_State *L)
  */
 static int lua_exitserver(lua_State *L)
 {
-  lua_getglobal(L, luaconnection);// push onto stack
-  Connection *conn = (Connection *)lua_touserdata(L, -1);// does not change the stack
+  lua_getglobal(L, lua_request_context);// push onto stack
+  RequestContext *ctx = (RequestContext *)lua_touserdata(L, -1);// does not change the stack
   lua_remove(L, -1);// remove from stack
-  conn->server()->stop();
+  if (ctx->shutdown_hook) { ctx->shutdown_hook(); }
   return 0;
 }
 //=========================================================================
@@ -1814,8 +1799,8 @@ static int lua_exitserver(lua_State *L)
  */
 static int lua_send_header(lua_State *L)
 {
-  lua_getglobal(L, luaconnection);
-  Connection *conn = (Connection *)lua_touserdata(L, -1);
+  lua_getglobal(L, lua_request_context);
+  RequestContext *ctx = (RequestContext *)lua_touserdata(L, -1);
   lua_remove(L, -1);// remove from stack
   int top = lua_gettop(L);
 
@@ -1829,7 +1814,7 @@ static int lua_send_header(lua_State *L)
   const char *hkey = lua_tostring(L, 1);
   const char *hval = lua_tostring(L, 2);
   lua_pop(L, top);
-  conn->header(hkey, hval);
+  ctx->response->add_header(hkey, hval);
   lua_pushboolean(L, true);
   lua_pushnil(L);
   return 2;
@@ -1849,8 +1834,8 @@ static int lua_send_header(lua_State *L)
  */
 static int lua_send_cookie(lua_State *L)
 {
-  lua_getglobal(L, luaconnection);
-  Connection *conn = (Connection *)lua_touserdata(L, -1);
+  lua_getglobal(L, lua_request_context);
+  RequestContext *ctx = (RequestContext *)lua_touserdata(L, -1);
   lua_remove(L, -1);// remove from stack
 
   int top = lua_gettop(L);
@@ -1865,7 +1850,9 @@ static int lua_send_cookie(lua_State *L)
   const char *ckey = lua_tostring(L, 1);
   const char *cval = lua_tostring(L, 2);
 
-  Cookie cookie(ckey, cval);
+  ResponseCookie cookie;
+  cookie.name = ckey;
+  cookie.value = cval;
 
   if (top == 3) {
     if (!lua_istable(L, 3)) {
@@ -1896,35 +1883,36 @@ static int lua_send_cookie(lua_State *L)
         if (optname == "path") {
           if (lua_isstring(L, -1)) {
             std::string path = lua_tostring(L, -1);
-            cookie.path(path);
+            cookie.path = path;
           } else {
             throw std::string("'server.sendCookie(name, value[, options])': path is not string");
           }
         } else if (optname == "domain") {
           if (lua_isstring(L, -1)) {
             std::string domain = lua_tostring(L, -1);
-            cookie.domain(domain);
+            cookie.domain = domain;
           } else {
             throw std::string("'server.sendCookie(name, value[, options])': domain is not string");
           }
         } else if (optname == "expires") {
           if (lua_isinteger(L, -1)) {
             int expires = lua_tointeger(L, -1);
-            cookie.expires(expires);
+            cookie.expires_seconds = expires;
+            cookie.expires_set = true;
           } else {
             throw std::string("'server.sendCookie(name, value[, options])': expires is not integer");
           }
         } else if (optname == "secure") {
           if (lua_isboolean(L, -1)) {
             bool secure = lua_toboolean(L, -1);
-            if (secure) cookie.secure(secure);
+            if (secure) cookie.secure = secure;
           } else {
             throw std::string("'server.sendCookie(name, value[, options])': secure is not boolean");
           }
         } else if (optname == "http_only") {
           if (lua_isboolean(L, -1)) {
             bool http_only = lua_toboolean(L, -1);
-            if (http_only) cookie.httpOnly(http_only);
+            if (http_only) cookie.http_only = http_only;
           } else {
             throw std::string("'server.sendCookie(name, value[, options])': http_only is not boolean");
           }
@@ -1943,7 +1931,7 @@ static int lua_send_cookie(lua_State *L)
   }
 
   lua_settop(L, 0);// clear stack
-  conn->cookies(cookie);
+  ctx->response->add_cookie(cookie);
   lua_pushboolean(L, true);
   lua_pushnil(L);
   return 2;
@@ -1952,8 +1940,8 @@ static int lua_send_cookie(lua_State *L)
 
 static int lua_send_status(lua_State *L)
 {
-  lua_getglobal(L, luaconnection);
-  Connection *conn = (Connection *)lua_touserdata(L, -1);
+  lua_getglobal(L, lua_request_context);
+  RequestContext *ctx = (RequestContext *)lua_touserdata(L, -1);
   lua_remove(L, -1);// remove from stack
 
   int top = lua_gettop(L);
@@ -1964,8 +1952,7 @@ static int lua_send_status(lua_State *L)
     lua_pop(L, 1);
   }
 
-  Connection::StatusCodes status = static_cast<Connection::StatusCodes>(istatus);
-  conn->status(status);
+  ctx->response->set_status(istatus);
   return 0;
 }
 //=========================================================================
@@ -1984,8 +1971,8 @@ static int lua_send_status(lua_State *L)
  */
 static int lua_copytmpfile(lua_State *L)
 {
-  lua_getglobal(L, luaconnection);
-  Connection *conn = (Connection *)lua_touserdata(L, -1);
+  lua_getglobal(L, lua_request_context);
+  RequestContext *ctx = (RequestContext *)lua_touserdata(L, -1);
   lua_remove(L, -1);// remove from stack
   int top = lua_gettop(L);
 
@@ -2003,7 +1990,7 @@ static int lua_copytmpfile(lua_State *L)
     return 2;
   }
 
-  std::vector<Connection::UploadedFile> uploads = conn->uploads();
+  const std::vector<UploadedFile> &uploads = ctx->uploads;
   int tmpfile_id = static_cast<int>(lua_tointeger(L, 1));
   std::string infile;
 
@@ -2070,8 +2057,8 @@ static int lua_copytmpfile(lua_State *L)
 //
 static int lua_generate_jwt(lua_State *L)
 {
-  lua_getglobal(L, luaconnection);
-  Connection *conn = (Connection *)lua_touserdata(L, -1);
+  lua_getglobal(L, lua_request_context);
+  RequestContext *ctx = (RequestContext *)lua_touserdata(L, -1);
   lua_remove(L, -1);// remove from stack
 
   jwt_t *jwt;
@@ -2103,7 +2090,7 @@ static int lua_generate_jwt(lua_State *L)
   }
 
   jwt_set_alg(
-    jwt, JWT_ALG_HS256, (unsigned char *)conn->server()->jwt_secret().c_str(), conn->server()->jwt_secret().size());
+    jwt, JWT_ALG_HS256, (unsigned char *)ctx->jwt_secret.c_str(), ctx->jwt_secret.size());
   jwt_add_grants_json(jwt, jsonstr);
 
   char *token = jwt_encode_str(jwt);
@@ -2118,8 +2105,8 @@ static int lua_generate_jwt(lua_State *L)
 
 static int lua_decode_jwt(lua_State *L)
 {
-  lua_getglobal(L, luaconnection);
-  Connection *conn = (Connection *)lua_touserdata(L, -1);
+  lua_getglobal(L, lua_request_context);
+  RequestContext *ctx = (RequestContext *)lua_touserdata(L, -1);
   lua_remove(L, -1);// remove from stack
 
   int top = lua_gettop(L);
@@ -2145,8 +2132,8 @@ static int lua_decode_jwt(lua_State *L)
 
   if ((err = jwt_decode(&jwt,
          token.c_str(),
-         (unsigned char *)conn->server()->jwt_secret().c_str(),
-         conn->server()->jwt_secret().size()))
+         (unsigned char *)ctx->jwt_secret.c_str(),
+         ctx->jwt_secret.size()))
       != 0) {
     lua_pushboolean(L, false);
     lua_pushstring(L, "'server.decode_jwt(token)': Error in decoding token! (1)");
@@ -2301,8 +2288,8 @@ static int lua_parse_mimetype(lua_State *L)
  */
 static int lua_file_mimetype(lua_State *L)
 {
-  lua_getglobal(L, luaconnection);
-  Connection *conn = (Connection *)lua_touserdata(L, -1);
+  lua_getglobal(L, lua_request_context);
+  RequestContext *ctx = (RequestContext *)lua_touserdata(L, -1);
   lua_remove(L, -1);// remove from stack
   int top = lua_gettop(L);
 
@@ -2315,7 +2302,7 @@ static int lua_file_mimetype(lua_State *L)
 
   std::string path;
   if (lua_isinteger(L, 1)) {
-    std::vector<shttps::Connection::UploadedFile> uploads = conn->uploads();
+    const std::vector<shttps::UploadedFile> &uploads = ctx->uploads;
     int tmpfile_id = static_cast<int>(lua_tointeger(L, 1));
     try {
       path = uploads.at(tmpfile_id - 1).tmpname;// In Lua, indexes are 1-based.
@@ -2357,8 +2344,8 @@ static int lua_file_mimetype(lua_State *L)
  */
 static int lua_file_mimeconsistency(lua_State *L)
 {
-  lua_getglobal(L, luaconnection);
-  Connection *conn = (Connection *)lua_touserdata(L, -1);
+  lua_getglobal(L, lua_request_context);
+  RequestContext *ctx = (RequestContext *)lua_touserdata(L, -1);
   lua_remove(L, -1);// remove from stack
   int top = lua_gettop(L);
 
@@ -2373,7 +2360,7 @@ static int lua_file_mimeconsistency(lua_State *L)
   std::string filename;
   std::string expected_mimetype = "";
   if (lua_isinteger(L, 1)) {
-    std::vector<shttps::Connection::UploadedFile> uploads = conn->uploads();
+    const std::vector<shttps::UploadedFile> &uploads = ctx->uploads;
     int tmpfile_id = static_cast<int>(lua_tointeger(L, 1));
     try {
       path = uploads.at(tmpfile_id - 1).tmpname;// In Lua, indexes are 1-based.
@@ -2444,39 +2431,39 @@ void LuaServer::setLuaPath(const std::string &path)
 /*!
  * This function registers all variables and functions in the server table
  */
-void LuaServer::createGlobals(Connection &conn)
+void LuaServer::createGlobals(RequestContext &ctx)
 {
   lua_createtable(L, 0, 33);// table1
   // lua_newtable(L); // table1
 
-  Connection::HttpMethod method = conn.method();
+  HttpMethod method = ctx.method;
   lua_pushstring(L, "method");// table1 - "index_L1"
   switch (method) {
-  case Connection::OPTIONS:
+  case HttpMethod::OPTIONS:
     lua_pushstring(L, "OPTIONS");
     break;// table1 - "index_L1" - "value_L1"
-  case Connection::GET:
+  case HttpMethod::GET:
     lua_pushstring(L, "GET");
     break;
-  case Connection::HEAD:
+  case HttpMethod::HEAD:
     lua_pushstring(L, "HEAD");
     break;
-  case Connection::POST:
+  case HttpMethod::POST:
     lua_pushstring(L, "POST");
     break;
-  case Connection::PUT:
+  case HttpMethod::PUT:
     lua_pushstring(L, "PUT");
     break;
-  case Connection::DELETE:
+  case HttpMethod::DELETE:
     lua_pushstring(L, "DELETE");
     break;
-  case Connection::TRACE:
+  case HttpMethod::TRACE:
     lua_pushstring(L, "TRACE");
     break;
-  case Connection::CONNECT:
+  case HttpMethod::CONNECT:
     lua_pushstring(L, "CONNECT");
     break;
-  case Connection::OTHER:
+  case HttpMethod::OTHER:
     lua_pushstring(L, "OTHER");
     break;
   }
@@ -2489,31 +2476,29 @@ void LuaServer::createGlobals(Connection &conn)
   lua_rawset(L, -3);// table1
 
   lua_pushstring(L, "client_ip");// table1 - "index_L1"
-  lua_pushstring(L, conn.peer_ip().c_str());// table1 - "index_L1" - "value_L1"
+  lua_pushstring(L, ctx.client_ip.c_str());// table1 - "index_L1" - "value_L1"
   lua_rawset(L, -3);// table1
 
   lua_pushstring(L, "client_port");// table1 - "index_L1"
-  lua_pushinteger(L, conn.peer_port());// table1 - "index_L1" - "value_L1"
+  lua_pushinteger(L, ctx.client_port);// table1 - "index_L1" - "value_L1"
   lua_rawset(L, -3);// table1
 
   lua_pushstring(L, "secure");// table1 - "index_L1"
-  lua_pushboolean(L, conn.secure());// table1 - "index_L1" - "value_L1"
+  lua_pushboolean(L, ctx.secure);// table1 - "index_L1" - "value_L1"
   lua_rawset(L, -3);// table1
 
   lua_pushstring(L, "header");// table1 - "index_L1"
-  std::vector<std::string> headers = conn.header();
-  lua_createtable(L, 0, headers.size());// table1 - "index_L1" - table2
+  lua_createtable(L, 0, ctx.headers.size());// table1 - "index_L1" - table2
 
-  for (unsigned i = 0; i < headers.size(); i++) {
-    lua_pushstring(L, headers[i].c_str());// table1 - "index_L1" - table2 - "index_L2"
-    lua_pushstring(L,
-      conn.header(headers[i]).c_str());// table1 - "index_L1" - table2 - "index_L2" - "value_L2"
+  for (const auto &header : ctx.headers) {
+    lua_pushstring(L, header.first.c_str());// table1 - "index_L1" - table2 - "index_L2"
+    lua_pushstring(L, header.second.c_str());// table1 - "index_L1" - table2 - "index_L2" - "value_L2"
     lua_rawset(L, -3);// table1 - "index_L1" - table2
   }
 
   lua_rawset(L, -3);// table1
 
-  std::unordered_map<std::string, std::string> cookies = conn.cookies();
+  const std::unordered_map<std::string, std::string> &cookies = ctx.cookies;
   lua_pushstring(L, "cookies");// table1 - "index_L1"
   lua_createtable(L, 0, cookies.size());// table1 - "index_L1" - table2
 
@@ -2525,48 +2510,42 @@ void LuaServer::createGlobals(Connection &conn)
 
   lua_rawset(L, -3);// table1
 
-  std::string host = conn.host();
+  const std::string &host = ctx.host;
   lua_pushstring(L, "host");// table1 - "index_L1"
   lua_pushstring(L, host.c_str());// table1 - "index_L1" - "value_L1"
   lua_rawset(L, -3);// table1
 
-  std::string uri = conn.uri();
+  const std::string &uri = ctx.uri;
   lua_pushstring(L, "uri");// table1 - "index_L1"
   lua_pushstring(L, uri.c_str());// table1 - "index_L1" - "value_L1"
   lua_rawset(L, -3);// table1
 
-  std::vector<std::string> get_params = conn.getParams();
-
-  if (get_params.size() > 0) {
+  if (!ctx.get_params.empty()) {
     lua_pushstring(L, "get");// table1 - "index_L1"
-    lua_createtable(L, 0, get_params.size());// table1 - "index_L1" - table2
+    lua_createtable(L, 0, ctx.get_params.size());// table1 - "index_L1" - table2
 
-    for (unsigned i = 0; i < get_params.size(); i++) {
-      (void)lua_pushstring(L, get_params[i].c_str());// table1 - "index_L1" - table2 - "index_L2"
-      (void)lua_pushstring(
-        L, conn.getParams(get_params[i]).c_str());// table1 - "index_L1" - table2 - "index_L2" - "value_L2"
+    for (const auto &param : ctx.get_params) {
+      (void)lua_pushstring(L, param.first.c_str());// table1 - "index_L1" - table2 - "index_L2"
+      (void)lua_pushstring(L, param.second.c_str());// table1 - "index_L1" - table2 - "index_L2" - "value_L2"
       lua_settable(L, -3);// table1 - "index_L1" - table2
     }
 
     lua_settable(L, -3);// table1
   }
 
-  std::vector<std::string> post_params = conn.postParams();
-
-  if (post_params.size() > 0) {
+  if (!ctx.post_params.empty()) {
     lua_pushstring(L, "post");// table1 - "index_L1"
-    lua_createtable(L, 0, post_params.size());// table1 - "index_L1" - table2
+    lua_createtable(L, 0, ctx.post_params.size());// table1 - "index_L1" - table2
 
-    for (unsigned i = 0; i < post_params.size(); i++) {
-      lua_pushstring(L, post_params[i].c_str());// table1 - "index_L1" - table2 - "index_L2"
-      lua_pushstring(
-        L, conn.postParams(post_params[i]).c_str());// table1 - "index_L1" - table2 - "index_L2" - "value_L2"
+    for (const auto &param : ctx.post_params) {
+      lua_pushstring(L, param.first.c_str());// table1 - "index_L1" - table2 - "index_L2"
+      lua_pushstring(L, param.second.c_str());// table1 - "index_L1" - table2 - "index_L2" - "value_L2"
       lua_settable(L, -3);// table1 - "index_L1" - table2
     }
     lua_settable(L, -3);// table1
   }
 
-  std::vector<Connection::UploadedFile> uploads = conn.uploads();
+  const std::vector<UploadedFile> &uploads = ctx.uploads;
 
   if (uploads.size() > 0) {
     lua_pushstring(L, "uploads");// table1 - "index_L1"
@@ -2616,29 +2595,26 @@ void LuaServer::createGlobals(Connection &conn)
     lua_rawset(L, -3);// table1
   }
 
-  std::vector<std::string> request_params = conn.requestParams();
-
-  if (request_params.size() > 0) {
+  if (!ctx.request_params.empty()) {
     lua_pushstring(L, "request");// table1 - "index_L1"
-    lua_createtable(L, 0, request_params.size());// table1 - "index_L1" - table2
+    lua_createtable(L, 0, ctx.request_params.size());// table1 - "index_L1" - table2
 
-    for (unsigned i = 0; i < request_params.size(); i++) {
-      lua_pushstring(L, request_params[i].c_str());// table1 - "index_L1" - table2 - "index_L2"
-      lua_pushstring(
-        L, conn.requestParams(request_params[i]).c_str());// table1 - "index_L1" - table2 - "index_L2" - "value_L2"
+    for (const auto &param : ctx.request_params) {
+      lua_pushstring(L, param.first.c_str());// table1 - "index_L1" - table2 - "index_L2"
+      lua_pushstring(L, param.second.c_str());// table1 - "index_L1" - table2 - "index_L2" - "value_L2"
       lua_rawset(L, -3);// table1 - "index_L1" - table2
     }
 
     lua_rawset(L, -3);// table1
   }
 
-  if (conn.contentLength() > 0) {
+  if (!ctx.content.empty()) {
     lua_pushstring(L, "content");
-    lua_pushlstring(L, conn.content(), conn.contentLength());
+    lua_pushlstring(L, ctx.content.data(), ctx.content.size());
     lua_rawset(L, -3);// table1 - "index_L1" - table2
 
     lua_pushstring(L, "content_type");
-    lua_pushstring(L, conn.contentType().c_str());
+    lua_pushstring(L, ctx.content_type.c_str());
     lua_rawset(L, -3);// table1 - "index_L1" - table2
   }
 
@@ -2785,8 +2761,8 @@ void LuaServer::createGlobals(Connection &conn)
 
   lua_setglobal(L, servertablename);
 
-  lua_pushlightuserdata(L, &conn);
-  lua_setglobal(L, luaconnection);
+  lua_pushlightuserdata(L, &ctx);
+  lua_setglobal(L, lua_request_context);
 }
 //=========================================================================
 
@@ -3067,21 +3043,21 @@ std::vector<LuaRoute> LuaServer::configRoute(const std::string &routetable) cons
       case 0:
         method = lua_tostring(L, -1);
         if (method == "GET") {
-          route.method = Connection::HttpMethod::GET;
+          route.method = HttpMethod::GET;
         } else if (method == "PUT") {
-          route.method = Connection::HttpMethod::PUT;
+          route.method = HttpMethod::PUT;
         } else if (method == "POST") {
-          route.method = Connection::HttpMethod::POST;
+          route.method = HttpMethod::POST;
         } else if (method == "DELETE") {
-          route.method = Connection::HttpMethod::DELETE;
+          route.method = HttpMethod::DELETE;
         } else if (method == "OPTIONS") {
-          route.method = Connection::HttpMethod::OPTIONS;
+          route.method = HttpMethod::OPTIONS;
         } else if (method == "CONNECT") {
-          route.method = Connection::HttpMethod::CONNECT;
+          route.method = HttpMethod::CONNECT;
         } else if (method == "HEAD") {
-          route.method = Connection::HttpMethod::HEAD;
+          route.method = HttpMethod::HEAD;
         } else if (method == "OTHER") {
-          route.method = Connection::HttpMethod::OTHER;
+          route.method = HttpMethod::OTHER;
         } else {
           throw Error(std::string("Unknown HTTP method") + method);
         }

--- a/src/shttps/lua/LuaServer.h
+++ b/src/shttps/lua/LuaServer.h
@@ -17,7 +17,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include "shttps/transport/Connection.h"
+#include "shttps/lua/request_context.h"
 #include "shttps/util/Error.h"
 
 #include "lua.hpp"
@@ -40,16 +40,16 @@ typedef struct _LuaValstruct
 
 typedef struct _LuaRoute
 {
-  Connection::HttpMethod method;
+  HttpMethod method;
   std::string route;
   std::string script;
 } LuaRoute;
 
 typedef std::unordered_map<std::string, LuaValstruct> LuaKeyValStore;
 
-typedef void (*LuaSetGlobalsFunc)(lua_State *L, Connection &, void *);
+typedef void (*LuaSetGlobalsFunc)(lua_State *L, RequestContext &, void *);
 
-extern char luaconnection[];
+extern char lua_request_context[];
 
 class LuaServer
 {
@@ -63,11 +63,11 @@ public:
   LuaServer();
 
   /*!
-   * Instantiates a lua interpreter which has access to the HTTP connection
+   * Instantiates a lua interpreter which has access to the HTTP request
    *
-   * \param[in] conn HTTP Connection object
+   * \param[in] ctx Connection-less request/response context
    */
-  explicit LuaServer(Connection &conn);
+  explicit LuaServer(RequestContext &ctx);
 
 
   /*!
@@ -81,12 +81,12 @@ public:
   /*!
    * Instantiates a lua interpreter an executes the given lua script
    *
-   * \param[in] conn HTTP Connection object
+   * \param[in] ctx Connection-less request/response context
    * \param[in] luafile A script containing lua commands
    * \param[in] iscode If true, the string contains lua-code to be executed directly
    * \param[in] lua_scriptdir Pattern to be added to the Lua package.path (directory with Lua scripts)
    */
-  LuaServer(Connection &conn, const std::string &luafile, bool iscode, const std::string &lua_scriptdir);
+  LuaServer(RequestContext &ctx, const std::string &luafile, bool iscode, const std::string &lua_scriptdir);
 
   /*!
    * Copy constructor throws error (not allowed!)
@@ -134,9 +134,9 @@ public:
   /*!
    * Create the global values and functions
    *
-   * \param[in] conn HTTP connection object
+   * \param[in] ctx Connection-less request/response context
    */
-  void createGlobals(Connection &conn);
+  void createGlobals(RequestContext &ctx);
 
 
   std::string configString(std::string table, std::string variable, std::string defval);

--- a/src/shttps/lua/request_context.h
+++ b/src/shttps/lua/request_context.h
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2016 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+ * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/*!
+ * \brief Connection-less request/response view for the Lua runtime.
+ *
+ * `RequestContext` is the buffered, transport-free view of an HTTP request and
+ * its response sink that drives the C++ `LuaServer` without an
+ * `shttps::Connection`. The caller populates the request fields, points
+ * `response` at a concrete `ResponseSink`, and runs the Lua VM; the `server.*`
+ * bindings read the request fields and write through the sink.
+ *
+ * The `ResponseSink` is the in-layer adapter to the single response seam (the
+ * Phase A `OutputSink` pattern): the FFI seam supplies a `SipiResponse`-backed
+ * implementation, the transport supplies a `Connection`-backed one for the
+ * parity path. The Lua module therefore names no transport or FFI type, which
+ * is what lets `lua/` be built below `//src/ffi` without depending on
+ * `transport/`.
+ *
+ * Kept deliberately thin — the whole Lua runtime is reimplemented in mlua in a
+ * later strangler slice.
+ */
+#ifndef SHTTPS_LUA_REQUEST_CONTEXT_H
+#define SHTTPS_LUA_REQUEST_CONTEXT_H
+
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace shttps {
+
+/*!
+ * HTTP method understood by the Lua route table. Lua-module-local so the module
+ * carries no transport (`Connection`) type; the transport maps its own
+ * `Connection::HttpMethod` onto this at the boundary.
+ */
+enum class HttpMethod { OPTIONS, GET, HEAD, POST, PUT, DELETE, TRACE, CONNECT, OTHER };
+
+/*!
+ * An uploaded file as seen by Lua (`server.uploads`, `server.copyTmpfile`),
+ * decoupled from `shttps::Connection::UploadedFile`.
+ */
+struct UploadedFile
+{
+  std::string fieldname;//!< Name of the HTTP field
+  std::string origname;//!< Original name of the file
+  std::string tmpname;//!< Temporary on-disk name
+  std::string mimetype;//!< MIME type of the file
+  std::size_t filesize{};//!< Size of the file in bytes
+};
+
+/*!
+ * A cookie set by Lua (`server.sendCookie`), decoupled from `shttps::Cookie`.
+ * The concrete `ResponseSink` renders it to a `Set-Cookie` header. Defaults
+ * mirror `shttps::Cookie` (secure by default, not http-only).
+ */
+struct ResponseCookie
+{
+  std::string name;
+  std::string value;
+  std::string path;//!< empty = unset
+  std::string domain;//!< empty = unset
+  int expires_seconds{};//!< seconds from now; only honoured when `expires_set`
+  bool expires_set = false;
+  bool secure = true;
+  bool http_only = false;
+};
+
+/*!
+ * Abstract response sink: where the Lua `server.sendStatus` / `sendHeader` /
+ * `sendCookie` / `print` / `setBuffer` bindings and the SIPI `img:write`
+ * binding deliver the response. The single concrete sink for the transport
+ * parity path forwards to `shttps::Connection`; the FFI seam supplies one that
+ * forwards to the C `SipiResponse` callbacks.
+ */
+struct ResponseSink
+{
+  virtual ~ResponseSink() = default;
+
+  virtual void set_status(int status) = 0;
+  virtual void add_header(const std::string &name, const std::string &value) = 0;
+  virtual void add_cookie(const ResponseCookie &cookie) = 0;
+
+  /*!
+   * Body bytes (`server.print` and the `img:write` codec callback). Returns 0
+   * on success, mirroring the `SipiWriteFn` C-ABI contract.
+   */
+  virtual int write(const void *data, std::size_t len) = 0;
+
+  /*!
+   * Output-buffering hint (`server.setBuffer`). A size of 0 means "sink
+   * default". Defaults to a no-op — body framing is the transport's call.
+   */
+  virtual void set_buffer(std::size_t buf_size, std::size_t buf_inc) { (void)buf_size, (void)buf_inc; }
+};
+
+/*!
+ * Buffered, connection-less view of an HTTP request and its response sink.
+ */
+struct RequestContext
+{
+  // --- request inputs (populated by the caller before running Lua) ---
+  HttpMethod method = HttpMethod::OTHER;
+  std::string client_ip;
+  int client_port = 0;
+  bool secure = false;
+  std::string host;
+  std::string uri;
+  std::unordered_map<std::string, std::string> headers;//!< name -> value (server.header, requireAuth)
+  std::unordered_map<std::string, std::string> cookies;//!< incoming cookies
+  std::vector<std::pair<std::string, std::string>> get_params;
+  std::vector<std::pair<std::string, std::string>> post_params;
+  std::vector<std::pair<std::string, std::string>> request_params;
+  std::vector<UploadedFile> uploads;
+  std::string content;//!< request body (POST)
+  std::string content_type;
+  std::string jwt_secret;//!< secret for server.generate_jwt / server.decode_jwt
+
+  // --- response sink (caller-owned; must outlive the Lua run) ---
+  ResponseSink *response = nullptr;
+
+  /*!
+   * `server.shutdown()` hook. The transport path stops the server; the FFI path
+   * may leave it empty (unsupported there).
+   */
+  std::function<void()> shutdown_hook;
+};
+
+}// namespace shttps
+
+#endif

--- a/src/shttps/lua_sqlite/BUILD.bazel
+++ b/src/shttps/lua_sqlite/BUILD.bazel
@@ -1,9 +1,8 @@
 """shttps/lua_sqlite — Lua `server.db` bindings backed by SQLite.
 
 Registers a SQLite-backed table API into the Lua VM (`sqliteGlobals` is a
-`LuaSetGlobalsFunc`). Depends one-directionally on the core `:shttps` for
-the `LuaServer` / `Connection` surface it binds against, plus SQLite and
-the Lua C API directly.
+`LuaSetGlobalsFunc`). Depends one-directionally on `//src/shttps/lua` for the
+`LuaServer` surface it binds against, plus SQLite and the Lua C API directly.
 
 `strip_include_prefix = "/src"` exposes the header at the path-prefixed
 form `#include "shttps/lua_sqlite/LuaSqlite.h"` (ADR-0003).
@@ -19,8 +18,9 @@ cc_library(
     hdrs = ["LuaSqlite.h"],
     strip_include_prefix = "/src",
     deps = [
-        # LuaServer.h / Connection.h surface + their link symbols.
-        "//src/shttps:shttps",
+        # LuaServer.h surface + its link symbols (connection-less since the
+        # request_context decoupling).
+        "//src/shttps/lua",
         "@lua",
         "@sqlite3",
     ],

--- a/src/shttps/lua_sqlite/LuaSqlite.cpp
+++ b/src/shttps/lua_sqlite/LuaSqlite.cpp
@@ -434,7 +434,7 @@ static int Sqlite_new(lua_State *L)
 //=========================================================================
 
 
-void sqliteGlobals(lua_State *L, shttps::Connection &conn, void *user_data)
+void sqliteGlobals(lua_State *L, shttps::RequestContext &ctx, void *user_data)
 {
 
   //

--- a/src/shttps/lua_sqlite/LuaSqlite.h
+++ b/src/shttps/lua_sqlite/LuaSqlite.h
@@ -12,7 +12,7 @@
 #include "shttps/lua/LuaServer.h"
 
 namespace shttps {
-extern void sqliteGlobals(lua_State *L, shttps::Connection &conn, void *user_data);
+extern void sqliteGlobals(lua_State *L, shttps::RequestContext &ctx, void *user_data);
 };
 
 #endif// SIPI_LUASQLITE_H

--- a/src/shttps/transport/Server.cpp
+++ b/src/shttps/transport/Server.cpp
@@ -47,6 +47,45 @@ static std::mutex debugio;// mutex to protect debugging messages from threads
 
 namespace shttps {
 
+namespace {
+
+// The Lua route table carries the connection-less shttps::HttpMethod; the
+// transport's handler map is keyed by Connection::HttpMethod. These map between
+// the two enums at the boundary (both go away with the transport in Phase C).
+HttpMethod to_request_method(Connection::HttpMethod method)
+{
+  switch (method) {
+  case Connection::OPTIONS: return HttpMethod::OPTIONS;
+  case Connection::GET: return HttpMethod::GET;
+  case Connection::HEAD: return HttpMethod::HEAD;
+  case Connection::POST: return HttpMethod::POST;
+  case Connection::PUT: return HttpMethod::PUT;
+  case Connection::DELETE: return HttpMethod::DELETE;
+  case Connection::TRACE: return HttpMethod::TRACE;
+  case Connection::CONNECT: return HttpMethod::CONNECT;
+  case Connection::OTHER: return HttpMethod::OTHER;
+  }
+  return HttpMethod::OTHER;
+}
+
+Connection::HttpMethod to_connection_method(HttpMethod method)
+{
+  switch (method) {
+  case HttpMethod::OPTIONS: return Connection::OPTIONS;
+  case HttpMethod::GET: return Connection::GET;
+  case HttpMethod::HEAD: return Connection::HEAD;
+  case HttpMethod::POST: return Connection::POST;
+  case HttpMethod::PUT: return Connection::PUT;
+  case HttpMethod::DELETE: return Connection::DELETE;
+  case HttpMethod::TRACE: return Connection::TRACE;
+  case HttpMethod::CONNECT: return Connection::CONNECT;
+  case HttpMethod::OTHER: return Connection::OTHER;
+  }
+  return Connection::OTHER;
+}
+
+}// namespace
+
 /*!
  * Starts a thread just to catch all signals sent to the server process.
  * If it receives SIGINT or SIGTERM, tells the server to stop.
@@ -939,7 +978,7 @@ void Server::run()
   //
   for (auto &route : _lua_routes) {
     route.script = _scriptdir + "/" + route.script;
-    add_route(route.method, route.route, script_handler, &(route.script));
+    add_route(to_connection_method(route.method), route.route, script_handler, &(route.script));
 
     log_info("Added route %s with script %s", route.route.c_str(), route.script.c_str());
   }
@@ -1286,6 +1325,89 @@ void Server::add_route(Connection::HttpMethod method_p,
 //=========================================================================
 
 
+// ── Lua request-context parity glue (transport-only; deleted at the Phase C cutover) ──
+// The Lua runtime no longer takes an shttps::Connection — it drives the
+// connection-less RequestContext / ResponseSink seam. These helpers let the
+// existing C++ transport keep running the Lua VM: the sink forwards back onto the
+// live Connection and the request fields are snapshotted exactly as
+// LuaServer::createGlobals used to read them directly off the Connection.
+namespace {
+
+class ConnectionResponseSink : public ResponseSink
+{
+public:
+  explicit ConnectionResponseSink(Connection &conn) : conn_(conn) {}
+
+  void set_status(int status) override { conn_.status(static_cast<Connection::StatusCodes>(status)); }
+
+  void add_header(const std::string &name, const std::string &value) override { conn_.header(name, value); }
+
+  void add_cookie(const ResponseCookie &c) override
+  {
+    Cookie cookie(c.name, c.value);
+    if (!c.path.empty()) { cookie.path(c.path); }
+    if (!c.domain.empty()) { cookie.domain(c.domain); }
+    if (c.expires_set) { cookie.expires(c.expires_seconds); }
+    cookie.secure(c.secure);
+    cookie.httpOnly(c.http_only);
+    conn_.cookies(cookie);
+  }
+
+  int write(const void *data, std::size_t len) override
+  {
+    try {
+      conn_.send(data, len);
+      return 0;
+    } catch (...) {
+      return 1;
+    }
+  }
+
+  void set_buffer(std::size_t buf_size, std::size_t buf_inc) override
+  {
+    if (buf_size > 0 && buf_inc > 0) {
+      conn_.setBuffer(buf_size, buf_inc);
+    } else if (buf_size > 0) {
+      conn_.setBuffer(buf_size);
+    } else {
+      conn_.setBuffer();
+    }
+  }
+
+private:
+  Connection &conn_;
+};
+
+RequestContext make_request_context(Connection &conn, ResponseSink &sink)
+{
+  RequestContext ctx;
+  ctx.method = to_request_method(conn.method());
+  ctx.client_ip = conn.peer_ip();
+  ctx.client_port = conn.peer_port();
+  ctx.secure = conn.secure();
+  ctx.host = conn.host();
+  ctx.uri = conn.uri();
+  for (const auto &name : conn.header()) { ctx.headers[name] = conn.header(name); }
+  ctx.cookies = conn.cookies();
+  for (const auto &name : conn.getParams()) { ctx.get_params.emplace_back(name, conn.getParams(name)); }
+  for (const auto &name : conn.postParams()) { ctx.post_params.emplace_back(name, conn.postParams(name)); }
+  for (const auto &name : conn.requestParams()) { ctx.request_params.emplace_back(name, conn.requestParams(name)); }
+  for (const auto &upload : conn.uploads()) {
+    ctx.uploads.push_back(
+      UploadedFile{ upload.fieldname, upload.origname, upload.tmpname, upload.mimetype, upload.filesize });
+  }
+  if (conn.contentLength() > 0) {
+    ctx.content.assign(conn.content(), conn.contentLength());
+    ctx.content_type = conn.contentType();
+  }
+  ctx.jwt_secret = conn.server()->jwt_secret();
+  ctx.shutdown_hook = [server = conn.server()] { server->stop(); };
+  ctx.response = &sink;
+  return ctx;
+}
+
+}// namespace
+
 // Starts an instance of the LUA server and selects and hands over to the correct
 // request handler for the incoming request.
 shttps::ThreadStatus Server::process_request(std::istream *ins,
@@ -1327,9 +1449,12 @@ shttps::ThreadStatus Server::process_request(std::istream *ins,
     // includes Lua files in the Lua script directory
     std::string lua_scriptdir = _scriptdir + "/?.lua";
 
-    LuaServer luaserver(conn, _initscript, true, lua_scriptdir);
+    ConnectionResponseSink lua_sink(conn);
+    RequestContext lua_ctx = make_request_context(conn, lua_sink);
 
-    for (auto &global_func : lua_globals) { global_func.func(luaserver.lua(), conn, global_func.func_dataptr); }
+    LuaServer luaserver(lua_ctx, _initscript, true, lua_scriptdir);
+
+    for (auto &global_func : lua_globals) { global_func.func(luaserver.lua(), lua_ctx, global_func.func_dataptr); }
 
     void *hd = nullptr;
 

--- a/src/shttps/transport/Server.cpp
+++ b/src/shttps/transport/Server.cpp
@@ -36,6 +36,7 @@
 #include "shttps/util/Parsing.h"
 #include "Server.h"
 #include "SockStream.h"
+#include "connection_request_context.h"
 #include "shttps/util/makeunique.h"
 
 // Tracy thread naming. shttps sits below //src/observability in the dependency
@@ -1326,58 +1327,12 @@ void Server::add_route(Connection::HttpMethod method_p,
 
 
 // ── Lua request-context parity glue (transport-only; deleted at the Phase C cutover) ──
-// The Lua runtime no longer takes an shttps::Connection — it drives the
-// connection-less RequestContext / ResponseSink seam. These helpers let the
-// existing C++ transport keep running the Lua VM: the sink forwards back onto the
-// live Connection and the request fields are snapshotted exactly as
-// LuaServer::createGlobals used to read them directly off the Connection.
-namespace {
-
-class ConnectionResponseSink : public ResponseSink
-{
-public:
-  explicit ConnectionResponseSink(Connection &conn) : conn_(conn) {}
-
-  void set_status(int status) override { conn_.status(static_cast<Connection::StatusCodes>(status)); }
-
-  void add_header(const std::string &name, const std::string &value) override { conn_.header(name, value); }
-
-  void add_cookie(const ResponseCookie &c) override
-  {
-    Cookie cookie(c.name, c.value);
-    if (!c.path.empty()) { cookie.path(c.path); }
-    if (!c.domain.empty()) { cookie.domain(c.domain); }
-    if (c.expires_set) { cookie.expires(c.expires_seconds); }
-    cookie.secure(c.secure);
-    cookie.httpOnly(c.http_only);
-    conn_.cookies(cookie);
-  }
-
-  int write(const void *data, std::size_t len) override
-  {
-    try {
-      conn_.send(data, len);
-      return 0;
-    } catch (...) {
-      return 1;
-    }
-  }
-
-  void set_buffer(std::size_t buf_size, std::size_t buf_inc) override
-  {
-    if (buf_size > 0 && buf_inc > 0) {
-      conn_.setBuffer(buf_size, buf_inc);
-    } else if (buf_size > 0) {
-      conn_.setBuffer(buf_size);
-    } else {
-      conn_.setBuffer();
-    }
-  }
-
-private:
-  Connection &conn_;
-};
-
+// ConnectionResponseSink + make_request_context adapt a live Connection to the
+// connection-less RequestContext / ResponseSink seam. They live in
+// connection_request_context.h so this file (the per-request VM) and
+// SipiHttpServer.cpp (the Lua FFI parity adapters) share one snapshot
+// implementation. ConnectionResponseSink is header-defined; make_request_context
+// is defined here because it uses the file-local to_request_method.
 RequestContext make_request_context(Connection &conn, ResponseSink &sink)
 {
   RequestContext ctx;
@@ -1405,8 +1360,6 @@ RequestContext make_request_context(Connection &conn, ResponseSink &sink)
   ctx.response = &sink;
   return ctx;
 }
-
-}// namespace
 
 // Starts an instance of the LUA server and selects and hands over to the correct
 // request handler for the incoming request.

--- a/src/shttps/transport/connection_request_context.h
+++ b/src/shttps/transport/connection_request_context.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2016 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+ * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/*!
+ * \brief Connection ↔ RequestContext parity glue (transport-only).
+ *
+ * Adapts a live `shttps::Connection` to the connection-less `RequestContext` /
+ * `ResponseSink` seam the Lua runtime drives since the request_context
+ * decoupling. The transport uses these to run the per-request Lua VM, and the
+ * `SipiHttpServer` parity adapters use them to drive the Lua FFI entries
+ * (`sipi_preflight`, `sipi_run_lua_route`) connection-less — both share this one
+ * snapshot implementation so the FFI path sees exactly what the live VM sees.
+ *
+ * The whole file is deleted at the Phase C cutover, when the Rust shell builds
+ * the `RequestContext` directly and the C++ transport goes away.
+ */
+#ifndef SHTTPS_TRANSPORT_CONNECTION_REQUEST_CONTEXT_H
+#define SHTTPS_TRANSPORT_CONNECTION_REQUEST_CONTEXT_H
+
+#include <cstddef>
+#include <string>
+
+#include "shttps/lua/request_context.h"
+#include "shttps/transport/Connection.h"
+
+namespace shttps {
+
+/*!
+ * A `ResponseSink` that forwards the Lua response back onto a live `Connection`.
+ */
+class ConnectionResponseSink : public ResponseSink
+{
+public:
+  explicit ConnectionResponseSink(Connection &conn) : conn_(conn) {}
+
+  void set_status(int status) override { conn_.status(static_cast<Connection::StatusCodes>(status)); }
+
+  void add_header(const std::string &name, const std::string &value) override { conn_.header(name, value); }
+
+  void add_cookie(const ResponseCookie &c) override
+  {
+    Cookie cookie(c.name, c.value);
+    if (!c.path.empty()) { cookie.path(c.path); }
+    if (!c.domain.empty()) { cookie.domain(c.domain); }
+    if (c.expires_set) { cookie.expires(c.expires_seconds); }
+    cookie.secure(c.secure);
+    cookie.httpOnly(c.http_only);
+    conn_.cookies(cookie);
+  }
+
+  int write(const void *data, std::size_t len) override
+  {
+    try {
+      conn_.send(data, len);
+      return 0;
+    } catch (...) {
+      return 1;
+    }
+  }
+
+  void set_buffer(std::size_t buf_size, std::size_t buf_inc) override
+  {
+    if (buf_size > 0 && buf_inc > 0) {
+      conn_.setBuffer(buf_size, buf_inc);
+    } else if (buf_size > 0) {
+      conn_.setBuffer(buf_size);
+    } else {
+      conn_.setBuffer();
+    }
+  }
+
+private:
+  Connection &conn_;
+};
+
+/*!
+ * Snapshot a `Connection`'s request fields into a connection-less
+ * `RequestContext` whose response points at `sink` (which must outlive the
+ * returned context). Mirrors exactly what `LuaServer::createGlobals` reads.
+ */
+RequestContext make_request_context(Connection &conn, ResponseSink &sink);
+
+}// namespace shttps
+
+#endif// SHTTPS_TRANSPORT_CONNECTION_REQUEST_CONTEXT_H


### PR DESCRIPTION
Fixes [DEV-6668](https://linear.app/dasch/issue/DEV-6668)

## Motivation
Phase B-L of the SIPI Rust strangler ([ADR-0013](https://github.com/dasch-swiss/sipi/blob/main/docs/adr/0013-shttps-as-internal-module.md)) makes the C++ Lua subsystem reachable **connection-less** behind the narrow C-ABI seam, so the Phase C Rust shell can drive it without an `shttps::Connection`. This PR delivers the **preflight** half: the IIIF `pre_flight` and the `/file` media `file_pre_flight` hooks now run behind the seam, and `//src/shttps/lua` no longer link-depends on `transport`. Behaviour is preserved — existing user Lua scripts (including JWT auth) run unchanged.

## Summary
- Lua **preflight** (IIIF + `/file` audio/video/PDF) runs connection-less behind the seam via `sipi_preflight` / `sipi_file_preflight`, built from an engine-held config VM.
- `SipiLua` relocated to `//src/ffi`; `//src/shttps/lua` proven transport-free (`bazel query`).
- No behaviour change: approval byte-identical, full e2e green (incl. the JWT/restrict/watermark preflight paths), 3-platform CI + sanitizer green.

## Key Changes
### request_context decoupling + Bazel carve (`53a612a`, `aebcbb1`)
`LuaServer` + `SipiLua` no longer name `shttps::Connection`; they drive the connection-less `RequestContext` / `ResponseSink` seam (`src/shttps/lua/request_context.h`). `//src/shttps/lua` is its own transport-free `cc_library` (`transport`→`lua` is the one-way edge).

### SipiLua relocation (`6754822`)
`SipiLua.{cpp,h}` moved from `//src:sipi_lib` to `//src/ffi` so the engine-held config VM can install the `sipi.*` globals. The dead `__sipiserver` / `SipiHttpServer` coupling (a light-userdata global set from `user_data` but never read) was dropped. `//src/ffi:sipi_ffi` gains `//src/shttps/lua` + `@lua` (both transport-free).

### Lua preflight FFI (`06e9eb4`)
- **Engine-held config VM** (`src/ffi/lua_config.{h,cpp}`): `LuaConfig` holds the init-script source + scriptdir + JWT secret + the `config.*`/`db`/`sipi.*` globals installers; `make_lua_server(ctx)` rebuilds, connection-less, exactly the per-request VM `Server::process_request` constructs. Parity-installed at startup via `set_lua_config` (superseded by `sipi_init` at the Phase C cutover).
- **`build_preflight` / `build_file_preflight`** (`src/ffi/preflight.{h,cpp}`): run the hook, validate the result (build/apply/guard, mirroring the serve entries), return a `PreflightDecision` value type (permission enum + open kv map) that ports 1:1 to the future Rust `PreFlight` trait.
- **`sipi_preflight` + `sipi_file_preflight`** (`src/ffi/sipi_ffi.{h,cpp}`): the C-ABI entries; the request crosses as an **opaque `SipiRequestContext` handle** (= C++ `shttps::RequestContext`).
- **Parity:** `call_iiif_preflight` / `call_file_preflight` rewritten as thin adapters over the seam; the `Connection`→`RequestContext` glue (`ConnectionResponseSink` + `make_request_context`) extracted to `src/shttps/transport/connection_request_context.h`, shared by the transport per-request VM and the adapters.

## Challenges and Decisions

### The seam must carry the full request, not just a cookie
**Problem:** The original seam sketch was `sipi_preflight(prefix, identifier, cookie)`. With that shape the `jwt_expired_token` e2e failed: the `auth`-prefix `pre_flight` reads `server.header['authorization']` and `server.cookies[...]`, i.e. arbitrary request fields, not just the cookie. A minimal/empty request context silently dropped the `Authorization` header.
**Tried:** Passing only the cookie string as a Lua arg, and a fresh minimal `RequestContext` with a no-op response sink.
**Solution:** Pass the **whole request** as an opaque `SipiRequestContext` handle (the existing connection-less `shttps::RequestContext`). Lua hooks can read any field via `server.*`, so the full handle is fundamental, not incidental. It is also *more* faithful parity — preflight runs with the real connection response sink, as it did before. And it is the guarantee that existing user Lua scripts need no migration (a narrowed flat struct would be a silent migration trap).

### `sipi_run_lua_route` + complete `sipi_init` deferred to Phase C
**Problem:** Both remaining B-L tasks need the *shell/SIPI layer* to own what the transport owns. Configured routes are dispatched by the transport's generic `script_handler`; routing it through the SIPI FFI would invert layering (`transport` → `//src/ffi`) — the same inversion the plan already refuses for `file_handler`. And the complete `sipi_init` is the from-scratch config/engine install that *replaces* the B-L parity installers, so it is never called in B-L (implementing it now = dead code).
**Solution:** Close B-L at preflight; move `sipi_run_lua_route` + complete `sipi_init` to Phase C, where the Rust shell owns route dispatch + init cleanly (transport deleted → Rust → FFI, the correct direction). The plan + exit criteria were updated; a new **Phase T** (between C and D+) was added for the `pre_flight`/`file_pre_flight` Rust trait (SIPI-as-library).

### Commit history rewrite after a staging mishap
**Problem:** An early `git add` listed a path that no longer existed after a `git mv`; git aborted the whole `add`, so the first commits captured only file renames, not the content edits — the intermediate commits did not build (only the working tree was correct).
**Solution:** The commits were unpushed, so `git reset` + re-commit into two clean, individually-building commits (relocation; preflight FFI), each verified (`6754822` built in isolation; `06e9eb4` + full suite green).

## Gotchas
- **Preflight needs the full `RequestContext`, never a narrowed struct.** Any Lua hook can read any request field via `server.*`; a flat subset is a silent migration trap for user scripts. The seam carries the whole request as an opaque handle for exactly this reason.
- **The opaque `SipiRequestContext` is `reinterpret_cast` to `shttps::RequestContext`** in the C++ TU; it is forward-declared incomplete in the C header (no C++ type leaks into the seam). The pointer is non-null by contract (same trust model as the serve entries); add a uniform fail-closed null-check when the Rust caller lands in Phase C.
- **`make_request_context` lives in `connection_request_context.h`** so the transport per-request VM and the FFI parity adapters share *one* request-snapshot implementation — keep them on the same source to avoid divergence.

## Test Plan
- [x] `just bazel-build`, `just bazel-test-unit`, `just bazel-test-approval` (byte-identical), `just bazel-test-e2e` (23/23) — green locally
- [x] Each commit builds in isolation
- [x] 3-platform CI (`ci`) + `sanitizer` green on this PR
- [x] Reviewed by cpp / security / consistency reviewers; no fail-open auth regression; stale-ref fixes applied
