### PR TITLE
build: key the -Wl,-z,now linkopt on the target OS, not the host

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -105,10 +105,12 @@ build --copt=-D_FORTIFY_SOURCE=2
 # contains the string "libmagic".
 build --per_file_copt=libmagic@-U_FORTIFY_SOURCE
 
-# Linux-only: stack-clash-protection is a clang-on-Linux feature (warns on
-# darwin); `-Wl,-z,now` is ELF/GNU-ld syntax not understood by ld64.
+# Linux-only: stack-clash-protection is a clang-on-Linux feature (warns
+# harmlessly on a darwin cross-compile). Its companion `-Wl,-z,now` linkopt
+# lives in //src:sipi_lib's (and :engine's) target-keyed linkopts select
+# instead: a linkopt must key on the TARGET os, not the host, or a Linux-host
+# cross-compile to darwin hands `-z` to ld64.lld, which rejects it.
 build:linux --copt=-fstack-clash-protection
-build:linux --linkopt=-Wl,-z,now
 
 # ── macOS ──────────────────────────────────────────────────────────────────
 # Pin the deployment target so Bazel-built binaries are portable across macOS

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -299,6 +299,10 @@ cc_library(
         "@platforms//os:linux": [
             "-ldl",
             "-lpthread",
+            # ELF/GNU-ld eager binding (full RELRO); keyed on the TARGET os
+            # (not the host-keyed `build:linux`) so a Linux→darwin cross-compile
+            # doesn't pass `-z` to ld64.lld, which rejects it.
+            "-Wl,-z,now",
         ],
         "@platforms//os:macos": [
             "-liconv",
@@ -410,6 +414,10 @@ cc_library(
         "@platforms//os:linux": [
             "-ldl",
             "-lpthread",
+            # ELF/GNU-ld eager binding (full RELRO); keyed on the TARGET os
+            # (not the host-keyed `build:linux`) so a Linux→darwin cross-compile
+            # doesn't pass `-z` to ld64.lld, which rejects it.
+            "-Wl,-z,now",
         ],
         # System frameworks/libs required by transitive deps:
         #   * `-liconv` — exiv2's convert.cpp uses iconv() on macOS for


### PR DESCRIPTION
## What

Moves the `-Wl,-z,now` linkopt out of the host-keyed `build:linux` config (in `.bazelrc`) and into `//src:sipi_lib`'s and `:engine`'s existing target-keyed `linkopts` select, alongside `-ldl`/`-lpthread`.

## Why

`build:linux` is activated by `--enable_platform_specific_config`, which keys on the **host** OS. That's correct when host == target, but it's wrong for cross-compilation: a Linux-host cross-compile to a darwin target then applies `-Wl,-z,now` (ELF/GNU-ld syntax) to the Mach-O link, and `ld64.lld` rejects it:

```
ld64.lld: error: unknown argument '-z'
clang++: error: linker command failed with exit code 1
```

A linkopt that depends on the target ABI must key on the **target** OS. `sipi_lib`/`engine`'s `linkopts` select is the right home — it already carries the other target-conditional link flags, and it propagates to every binary/test that links them.

## Verification

- `aquery` on the `//src/cli:sipi` link action: `-Wl,-z,now` **present** for `--platforms=//platforms:linux_x86_64`, **absent** for `//platforms:darwin_aarch64`.
- Native `bazel build //src/cli:sipi` (darwin) green.
- **No behavior change for non-cross builds:** a Linux *target* still gets the flag (via the select, exactly as `build:linux` did); a darwin native build never received it. Only the previously-broken Linux-host→darwin-target cross-compile changes — from "fails at link" to "links". The `-fstack-clash-protection` copt stays in `build:linux` (it only warns, harmlessly, on a darwin cross-compile).

## Context

A latent bug — the repo never cross-compiled before, so host always equaled target. Surfaced by a BuildBuddy RBE trial, where a Linux executor cross-compiles to darwin. Independent of the bin2c change (#694).

🤖 Generated with [Claude Code](https://claude.com/claude-code)