### PR TITLE
test(e2e): differential parity harness (Phase C step 4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,40 @@ jobs:
           fi
           nix develop --command bash -c "just bazel-test $REMOTE $BES"
 
+      # Drift guard: the differential corpus must keep covering the e2e
+      # surface. Pure shell (grep), so it runs before the heavy gate and fails
+      # fast if an e2e test was added/removed without updating the corpus.
+      - name: Check differential coverage (drift guard)
+        if: matrix.arch == 'amd64'
+        run: bash tools/differential_coverage_check.sh
+
+      # The differential parity gate (Rust shell vs the retained C++ oracle)
+      # is `manual`-tagged, so the `just bazel-test` wildcard above and
+      # `bazel-coverage` skip it — it needs its own explicit invocation, like
+      # `docker_smoke`. Run on linux-amd64 only (mirroring the rustfmt gate):
+      # Rust↔C++ divergences are code-level, not platform-specific, so one
+      # platform catches them and keeps the per-PR cost of the heavy two-binary
+      # spawn bounded.
+      - name: Run differential parity gate (Rust shell vs C++ oracle)
+        if: matrix.arch == 'amd64'
+        env:
+          GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
+          BAZEL_CACHE_PASSWORD: ${{ secrets.BAZEL_CACHE_PASSWORD }}
+          BUILDBUDDY_ORG_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
+        run: |
+          if [ -n "$BAZEL_CACHE_PASSWORD" ]; then
+            CACHE_HOST=bazel-cache-proxy-pbjdzenira-uc.a.run.app
+            REMOTE="--remote_cache=grpcs://$CACHE_HOST:443 --experimental_remote_downloader=grpcs://$CACHE_HOST:443 --experimental_remote_downloader_local_fallback --credential_helper=$CACHE_HOST=$GITHUB_WORKSPACE/tools/bazel-cred-helper.sh --remote_upload_local_results=true"
+          else
+            REMOTE=""
+          fi
+          if [ -n "$BUILDBUDDY_ORG_API_KEY" ]; then
+            BES="--bes_backend=grpcs://dasch.buildbuddy.io --bes_results_url=https://dasch.buildbuddy.io/invocation/ --bes_header=x-buildbuddy-api-key=$BUILDBUDDY_ORG_API_KEY --build_metadata=ROLE=CI"
+          else
+            BES=""
+          fi
+          nix develop --command bash -c "just bazel-test-differential $REMOTE $BES"
+
       # Docker steps run on Linux only because they `docker load` the image
       # into a local Linux Docker daemon (absent on the macOS runner) — not
       # because the image can't be built on macOS. //src:image is gated on the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ just bazel-test-unit             # bazel test //test/unit/...  (12 components)
 just bazel-test-approval         # bazel test //test/approval:approvaltests
 just bazel-test-e2e              # Rust e2e tests via rules_rust
 just bazel-test-smoke            # Docker smoke test (OCI tarball loaded by the test)
+just bazel-test-differential     # differential parity gate vs the C++ oracle (manual; spawns both binaries)
 
 # Coverage (canonical CI build — what ci.yml invokes on every PR)
 just bazel-coverage              # unit + approval + e2e under instrumentation; lcov
@@ -161,6 +162,7 @@ For test framework details (how to run tests, directory layout, adding tests), s
 - **Approval tests** (`test/approval/`): snapshot-based regression — `just bazel-test-approval` (or via `bazel-coverage` in CI). `SOURCE_DATE_EPOCH=946684800` and `SIPI_WORKSPACE_ROOT="."` are injected by `test/approval/BUILD.bazel`.
 - **E2E tests** (`test/e2e/`): Rust (reqwest + `rules_rust`'s hermetic rustc). Run via `just bazel-test-e2e`, or a single target with `bazel test //test/e2e:<name> --test_output=streamed`.
 - **Smoke tests** (`test/e2e/tests/docker_smoke.rs`): against Docker image. Run via `just bazel-test-smoke` — the `:docker_smoke` rust_test consumes the OCI tarball from `//src:image_load` and `docker load`s it before probing endpoints.
+- **Differential parity** (`test/e2e/tests/differential.rs`): THE strangler parity gate — replays a deduped corpus of every replayable e2e request against both the Rust shell (subject, `$SIPI_BIN`) and the retained C++ server (reference, `$SIPI_BIN_REF`) and asserts they agree modulo the §5 allowlist; intentional/known divergences are per-`Case` `gap`s. Run via `just bazel-test-differential` — `manual`-tagged, so it stays out of `:all_e2e` and coverage; CI runs it as a dedicated linux-amd64 step. `just differential-coverage-check` guards the corpus against drift as e2e tests are added.
 
 Run a single unit-test target with `bazel test //test/unit/<component>:<component>_test --test_output=streamed`.
 

--- a/docs/src/development/building.md
+++ b/docs/src/development/building.md
@@ -129,6 +129,8 @@ groups:
 | `bazel-test-approval` | `bazel test //test/approval:approvaltests` |
 | `bazel-test-e2e [*FLAGS]` | All Rust e2e `rust_test` targets |
 | `bazel-test-smoke [*FLAGS]` | Docker smoke test (consumes Bazel-built image tarball) |
+| `bazel-test-differential [*FLAGS]` | Differential parity gate: full e2e corpus, Rust shell vs C++ oracle; `manual`-tagged; dedicated linux-amd64 CI step |
+| `differential-coverage-check` | Drift guard: assert the differential corpus still covers the e2e surface (pure shell) |
 | `bazel-build-sanitized [*FLAGS]` | `bazel build --config=asan --config=ubsan //src/cli:sipi` |
 | `bazel-build-fuzz [*FLAGS]` | libFuzzer harness (linux-x86_64 in CI, darwin-aarch64 local) |
 | `bazel-run-fuzz corpus duration [seed]` | Run libFuzzer harness against a corpus |

--- a/docs/src/development/testing-strategy.md
+++ b/docs/src/development/testing-strategy.md
@@ -779,6 +779,8 @@ insta::assert_json_snapshot!(info_json, {
 | Rust e2e tests (CI) | `just nix-test-e2e` | PR CI | Pre-built binaries from `.#e2e-tests` (crane); reads `$SIPI_BIN` |
 | Rust e2e tests (inner-loop) | `bazel test //test/e2e:<name>` | local | Same hermetic toolchain as CI |
 | Docker smoke (CI) | `just bazel-test-smoke` | PR + tag CI | Bazel-built OCI tarball, `docker load`ed by the test |
+| Differential parity (CI) | `just bazel-test-differential` | PR CI (linux-amd64) | THE strangler parity gate: full deduped e2e request corpus, Rust shell (subject) vs C++ oracle (`SIPI_BIN_REF`); dedicated step, `manual`-tagged (out of `:all_e2e`/coverage) |
+| Differential drift guard | `just differential-coverage-check` | PR CI (linux-amd64) | Pins the e2e `#[test]` count so the differential corpus can't silently lag (pure shell) |
 | Hurl contract tests | *(retired)* | — | Folded into Rust e2e (`tests/http_contracts.rs` + `iiif_compliance.rs`) |
 | Python e2e tests | *(retired)* | — | Replaced by Rust e2e tests |
 | Fuzz testing | `.github/workflows/fuzz.yml` | Nightly | libFuzzer corpus growth |

--- a/justfile
+++ b/justfile
@@ -157,6 +157,22 @@ bazel-test-e2e *FLAGS='':
 bazel-test-smoke *FLAGS='':
     bazel test --stamp --verbose_failures {{FLAGS}} //test/e2e:docker_smoke
 
+# Run the differential parity gate: spawns the Rust shell (subject) and the
+# retained C++ server (reference, via `$SIPI_BIN_REF`) and diffs their
+# responses across the plan §5 allowlist. `manual`-tagged so it stays out of
+# `:all_e2e` and `bazel-coverage`'s `//test/e2e/...` wildcard — run it
+# explicitly here. The two-binary spawn is `exclusive`/`local` with
+# `--test-threads=1` (set by the test macro). CI runs it as a dedicated
+# linux-amd64 step.
+bazel-test-differential *FLAGS='':
+    bazel test --stamp --verbose_failures {{FLAGS}} //test/e2e:differential
+
+# Drift guard: assert the differential corpus still covers the e2e surface
+# (pins the e2e #[test] count; trips when a test is added/removed so the
+# corpus is reviewed). Pure shell — no Bazel/Nix needed.
+differential-coverage-check:
+    bash tools/differential_coverage_check.sh
+
 # Sanitized build: Debug + ASan + UBSan via Bazel
 # `--config=asan --config=ubsan`. The resulting binary at
 # `bazel-bin/src/cli/sipi` is what `sanitizer.yml`'s e2e step consumes

--- a/test/e2e/BUILD.bazel
+++ b/test/e2e/BUILD.bazel
@@ -9,17 +9,24 @@ Layout:
   * `:sipi_e2e`        `rust_library` exposing the shared helpers
                        (`SipiServer`, `repo_root`, `http_client`, …)
                        consumed by every test binary.
-  * 21 × `rust_test`   one target per non-docker `tests/<name>.rs`,
+  * 24 × `rust_test`   one target per non-docker `tests/<name>.rs`,
                        defined via `sipi_e2e_test()` (see
                        `sipi_e2e_test.bzl`). The macro injects the
                        shared `data`/`env`/`args`/`tags` so the
                        contracts can't drift across targets.
+  * `:differential`    a 25th `sipi_e2e_test()` target that also spawns
+                       the C++ oracle (`SIPI_BIN_REF`) and diffs it
+                       against the Rust shell. `manual`-tagged, so it is
+                       kept OUT of `:all_e2e` and the `//test/e2e/...`
+                       coverage wildcard; run via
+                       `just bazel-test-differential`.
   * `:docker_smoke`    inline `rust_test` — its data shape (OCI image
                        tarball) and tags (`requires-docker`) diverge
                        from the macro's defaults.
-  * `:all_e2e`         `test_suite` aggregating the 21 non-docker
-                       targets. `just bazel-test-e2e` wraps `bazel
-                       test //test/e2e:all_e2e`.
+  * `:all_e2e`         `test_suite` aggregating the 24 non-docker
+                       targets (not `:differential` / `:docker_smoke`).
+                       `just bazel-test-e2e` wraps `bazel test
+                       //test/e2e:all_e2e`.
   * `:sipi_image_tar`  `filegroup` extracting the OCI tarball produced
                        by `//src:image_load` (rules_oci 2.x's
                        `tarball` output group). Consumed by
@@ -69,7 +76,10 @@ filegroup(
 # `normal` set only.
 rust_library(
     name = "sipi_e2e",
-    srcs = ["src/lib.rs"],
+    srcs = [
+        "src/diff.rs",
+        "src/lib.rs",
+    ],
     edition = "2021",
     visibility = ["//visibility:public"],
     deps = all_crate_deps(normal = True),
@@ -137,6 +147,31 @@ sipi_e2e_test(name = "smoke", deps = _e2e_test_deps)
 sipi_e2e_test(name = "toml_config", deps = _e2e_test_deps)
 
 sipi_e2e_test(name = "upload", deps = _e2e_test_deps)
+
+# ── Differential parity gate ────────────────────────────────────────────────
+#
+# Spawns BOTH binaries — the Rust shell under test (`SIPI_BIN`, the macro
+# default) and the retained C++ server as a live oracle (`SIPI_BIN_REF`) — and
+# diffs their responses across the §5 allowlist. Differs from the macro
+# targets in two ways:
+#
+#   1. It pulls a SECOND binary, `//src/cli:sipi`, into `data` and points
+#      `$SIPI_BIN_REF` at it. Only this target carries the oracle; every other
+#      e2e target stays single-binary.
+#   2. `manual` keeps it out of `//test/e2e/...` wildcard expansion, so the
+#      `:all_e2e` matrix step and `bazel-coverage` skip it. CI runs it as its
+#      own step (linux-amd64, like the rustfmt gate) via
+#      `just bazel-test-differential`; the heavy two-binary spawn is
+#      `exclusive`/`local` from the macro.
+#
+# See plan 02 §7 (harness) / §8 (differential.rs placement).
+sipi_e2e_test(
+    name = "differential",
+    deps = _e2e_test_deps,
+    extra_data = ["//src/cli:sipi"],
+    extra_env = {"SIPI_BIN_REF": "$(rootpath //src/cli:sipi)"},
+    extra_tags = ["manual"],
+)
 
 # ── Docker smoke test ──────────────────────────────────────────────────────
 #

--- a/test/e2e/sipi_e2e_test.bzl
+++ b/test/e2e/sipi_e2e_test.bzl
@@ -63,6 +63,15 @@ What the macro injects:
                                  then rejects every IIIF request with
                                  "Invalid IIIF identifier".
 
+The macro DOES cover the `differential` parity target through
+`extra_data` / `extra_env`: that target adds the retained C++ server
+`//src/cli:sipi` to `data` and sets `SIPI_BIN_REF` to its runfiles path,
+so `SipiServer::start_pair` can spawn the reference oracle alongside the
+`SIPI_BIN` subject. It is `manual`-tagged (kept out of `:all_e2e` and the
+`//test/e2e/...` coverage wildcard) and run via
+`just bazel-test-differential` as a dedicated CI step (linux-amd64) and
+locally.
+
 The macro deliberately does NOT cover `docker_smoke` — that target has
 its own data shape (the OCI image tarball, `:sipi_image_tar`) and own
 env (`SIPI_IMAGE_TAR`, `SIPI_IMAGE_TAG`). Defining it inline is clearer

--- a/test/e2e/src/diff.rs
+++ b/test/e2e/src/diff.rs
@@ -1,0 +1,478 @@
+//! Differential comparison between the Rust shell (subject) and the
+//! retained C++ server (reference): replay one request to both, normalise
+//! transport-framing headers and the ephemeral host:port, then compare
+//! status, headers, and body. Anything that differs and is neither ignored
+//! nor allowlisted is a parity failure — that is the regression net (it
+//! catches, e.g., someone silently dropping a CORS header).
+//!
+//! See plan 02 §7 (harness design) and §5 (the divergence allowlist).
+
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::time::Duration;
+
+use image::GenericImageView;
+use reqwest::blocking::Client;
+use reqwest::header::{HeaderMap, CONTENT_TYPE};
+use reqwest::{Method, StatusCode};
+use serde_json::Value;
+
+use crate::SipiServer;
+
+/// Header names (lowercase) excluded from every comparison: pure
+/// transport framing plus the two structural subject/reference
+/// asymmetries (the Rust shell always emits `traceparent` and never
+/// `access-control-allow-credentials`; the C++ transport is the mirror).
+/// `content-length` is framing too — image responses stream chunked on
+/// both sides, so it is absent there and present on buffered JSON. See
+/// plan 02 §5 "always-ignore".
+const ALWAYS_IGNORE: &[&str] = &[
+    "date",
+    "server",
+    "connection",
+    "keep-alive",
+    "transfer-encoding",
+    "content-length",
+    "traceparent",
+    "access-control-allow-credentials",
+];
+
+/// Tolerance for the image byte-length band (jp2 / undecodable bodies).
+const LENGTH_BAND: f64 = 0.10;
+
+/// What to ignore when diffing. Start from `default_transport()` and add
+/// per-test exemptions with `ignoring()` (headers) / `masking_json()` (JSON
+/// fields). Every per-test exemption is a documented §5 divergence — keep
+/// the plan-row reference at the call site.
+#[derive(Clone, Debug)]
+pub struct DiffAllowlist {
+    ignore_headers: HashSet<String>,
+    /// RFC 6901 JSON Pointers masked to null on BOTH sides before JSON
+    /// comparison — for fields that legitimately differ (e.g. a deferred
+    /// knora sidecar field) without suppressing the whole body.
+    json_masks: Vec<String>,
+}
+
+impl DiffAllowlist {
+    /// The transport-framing always-ignore set (plan 02 §5).
+    pub fn default_transport() -> Self {
+        Self {
+            ignore_headers: ALWAYS_IGNORE.iter().map(|h| h.to_string()).collect(),
+            json_masks: Vec::new(),
+        }
+    }
+
+    /// Also ignore `name` (case-insensitive) — for a per-test allowlisted
+    /// header divergence (e.g. an XFP-derived header on a specific path).
+    #[must_use]
+    pub fn ignoring(mut self, name: &str) -> Self {
+        self.ignore_headers.insert(name.to_ascii_lowercase());
+        self
+    }
+
+    /// Also mask the JSON value at `pointer` (RFC 6901, e.g. `/originalFilename`)
+    /// on both sides before comparing — for an allowlisted body-field divergence.
+    #[must_use]
+    pub fn masking_json(mut self, pointer: &str) -> Self {
+        self.json_masks.push(pointer.to_string());
+        self
+    }
+
+    fn is_ignored(&self, name: &str) -> bool {
+        self.ignore_headers.contains(name)
+    }
+}
+
+impl Default for DiffAllowlist {
+    fn default() -> Self {
+        Self::default_transport()
+    }
+}
+
+/// Outcome of comparing the two response bodies.
+#[derive(Debug)]
+pub enum BodyMatch {
+    /// Equal: exact bytes, JSON-equal (port-normalised), or same image dims.
+    Match,
+    /// Differ; the string explains how.
+    Mismatch(String),
+    /// Not compared — a status mismatch short-circuited the check, or the
+    /// shared status is an error whose body is an allowlisted §5 #5 divergence.
+    Skipped,
+}
+
+/// One header that differs after normalisation.
+#[derive(Debug)]
+pub struct HeaderDiff {
+    pub name: String,
+    pub subject: Vec<String>,
+    pub reference: Vec<String>,
+}
+
+/// Result of a single [`diff_request`].
+#[derive(Debug)]
+pub struct DiffResult {
+    pub method: Method,
+    pub path: String,
+    pub subject_status: StatusCode,
+    pub reference_status: StatusCode,
+    pub header_diffs: Vec<HeaderDiff>,
+    pub body_match: BodyMatch,
+}
+
+impl DiffResult {
+    /// True when subject and reference agree modulo the allowlist.
+    pub fn is_parity(&self) -> bool {
+        self.subject_status == self.reference_status
+            && self.header_diffs.is_empty()
+            && matches!(self.body_match, BodyMatch::Match | BodyMatch::Skipped)
+    }
+
+    /// Human-readable description of every divergence (empty when parity).
+    pub fn divergences(&self) -> Vec<String> {
+        let mut out = Vec::new();
+        if self.subject_status != self.reference_status {
+            out.push(format!(
+                "status: subject={} reference={}",
+                self.subject_status, self.reference_status
+            ));
+        }
+        for d in &self.header_diffs {
+            out.push(format!(
+                "header `{}`: subject={:?} reference={:?}",
+                d.name, d.subject, d.reference
+            ));
+        }
+        if let BodyMatch::Mismatch(why) = &self.body_match {
+            out.push(format!("body: {why}"));
+        }
+        out
+    }
+
+    /// Panic with a full report unless subject and reference are at parity.
+    pub fn assert_parity(&self) {
+        let divs = self.divergences();
+        assert!(
+            divs.is_empty(),
+            "differential parity failure on {} {}:\n  {}",
+            self.method,
+            self.path,
+            divs.join("\n  ")
+        );
+    }
+}
+
+/// A captured response from one server.
+struct Captured {
+    status: StatusCode,
+    headers: HeaderMap,
+    body: Vec<u8>,
+}
+
+/// A no-redirect client: 303s are part of the differential surface, so the
+/// harness must observe them rather than follow them.
+fn diff_client() -> Client {
+    Client::builder()
+        .danger_accept_invalid_certs(true)
+        .timeout(Duration::from_secs(30))
+        .pool_max_idle_per_host(0)
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .expect("diff client")
+}
+
+fn send(
+    client: &Client,
+    server: &SipiServer,
+    method: &Method,
+    path: &str,
+    headers: &[(&str, &str)],
+    body: Option<Vec<u8>>,
+) -> Captured {
+    let url = format!("{}{}", server.base_url, path);
+    let mut req = client.request(method.clone(), &url);
+    for (k, v) in headers {
+        req = req.header(*k, *v);
+    }
+    if let Some(b) = body {
+        req = req.body(b);
+    }
+    let resp = req
+        .send()
+        .unwrap_or_else(|e| panic!("{method} {url} failed: {e}"));
+    let status = resp.status();
+    let headers = resp.headers().clone();
+    let body = resp.bytes().expect("response body").to_vec();
+    Captured {
+        status,
+        headers,
+        body,
+    }
+}
+
+/// Replay `method path` (with `headers`/`body`) against both servers and
+/// compare status, headers (modulo `allow`), and body.
+pub fn diff_request(
+    subject: &SipiServer,
+    reference: &SipiServer,
+    method: Method,
+    path: &str,
+    headers: &[(&str, &str)],
+    body: Option<Vec<u8>>,
+    allow: &DiffAllowlist,
+) -> DiffResult {
+    let client = diff_client();
+    let s = send(&client, subject, &method, path, headers, body.clone());
+    let r = send(&client, reference, &method, path, headers, body);
+
+    let status_match = s.status == r.status;
+    // §5 #5: on a shared error status the Rust shell sends a bare status
+    // (empty body, no content-type) while the C++ `send_error` echoes a
+    // `Bad Request: <msg>` text/plain body. That divergence is intentional
+    // (the no-internal-path-leak guarantee holds on both — DEV-6062), so the
+    // harness asserts only the status and framing headers on errors, not the
+    // error body or its content-type.
+    let shared_error = status_match && (s.status.is_client_error() || s.status.is_server_error());
+
+    let effective = if shared_error {
+        allow.clone().ignoring("content-type")
+    } else {
+        allow.clone()
+    };
+    let header_diffs = diff_headers(&s.headers, &r.headers, subject, reference, &effective);
+    let body_match = if status_match && !shared_error {
+        compare_bodies(&s, &r, subject, reference, &effective)
+    } else {
+        BodyMatch::Skipped
+    };
+
+    DiffResult {
+        method,
+        path: path.to_string(),
+        subject_status: s.status,
+        reference_status: r.status,
+        header_diffs,
+        body_match,
+    }
+}
+
+/// `GET path` against both servers with the default transport allowlist.
+pub fn diff_get(subject: &SipiServer, reference: &SipiServer, path: &str) -> DiffResult {
+    diff_request(
+        subject,
+        reference,
+        Method::GET,
+        path,
+        &[],
+        None,
+        &DiffAllowlist::default_transport(),
+    )
+}
+
+/// Collect a header map into lowercased name → sorted values, with the
+/// server's ephemeral location scrubbed (`{BASE}`/`{HOST}`) so port-bearing
+/// headers (`Location`, the canonical `Link`) compare equal across the two
+/// instances.
+fn collect(headers: &HeaderMap, server: &SipiServer) -> BTreeMap<String, Vec<String>> {
+    let mut m: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for (k, v) in headers.iter() {
+        let value = scrub_str(&String::from_utf8_lossy(v.as_bytes()), server);
+        m.entry(k.as_str().to_ascii_lowercase())
+            .or_default()
+            .push(value);
+    }
+    for vals in m.values_mut() {
+        vals.sort();
+    }
+    m
+}
+
+fn diff_headers(
+    s: &HeaderMap,
+    r: &HeaderMap,
+    subject: &SipiServer,
+    reference: &SipiServer,
+    allow: &DiffAllowlist,
+) -> Vec<HeaderDiff> {
+    let sm = collect(s, subject);
+    let rm = collect(r, reference);
+    let names: BTreeSet<&String> = sm.keys().chain(rm.keys()).collect();
+    let mut diffs = Vec::new();
+    for name in names {
+        if allow.is_ignored(name) {
+            continue;
+        }
+        let sv = sm.get(name);
+        let rv = rm.get(name);
+        if sv != rv {
+            diffs.push(HeaderDiff {
+                name: name.clone(),
+                subject: sv.cloned().unwrap_or_default(),
+                reference: rv.cloned().unwrap_or_default(),
+            });
+        }
+    }
+    diffs
+}
+
+fn content_type(headers: &HeaderMap) -> String {
+    headers
+        .get(CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_ascii_lowercase()
+}
+
+fn compare_bodies(
+    s: &Captured,
+    r: &Captured,
+    subject: &SipiServer,
+    reference: &SipiServer,
+    allow: &DiffAllowlist,
+) -> BodyMatch {
+    // Both empty (HEAD, 204, 304, …) → equal; never attempt to parse "" as JSON.
+    if s.body.is_empty() && r.body.is_empty() {
+        return BodyMatch::Match;
+    }
+    let ct = content_type(&s.headers);
+    if ct.contains("json") {
+        compare_json(&s.body, &r.body, subject, reference, allow)
+    } else if ct.starts_with("image/") {
+        compare_image(&s.body, &r.body, &ct)
+    } else {
+        // text / empty / other: exact compare after scrubbing each side's
+        // ephemeral host:port (a 303 Location carries it).
+        let sn = normalize(&s.body, subject);
+        let rn = normalize(&r.body, reference);
+        if sn == rn {
+            BodyMatch::Match
+        } else {
+            BodyMatch::Mismatch(format!(
+                "normalised text differs:\n    subject={sn}\n    reference={rn}"
+            ))
+        }
+    }
+}
+
+/// Scrub a server's ephemeral location to stable tokens: the full base URL
+/// `http://127.0.0.1:<port>` → `{BASE}` and the bare authority
+/// `127.0.0.1:<port>` → `{HOST}`. Covers the scheme-qualified form (info.json
+/// `id`, canonical `Link`, 303 `Location`) and any bare host:port echo, so the
+/// two instances' distinct ports compare equal.
+fn scrub_str(text: &str, server: &SipiServer) -> String {
+    let authority = server
+        .base_url
+        .strip_prefix("http://")
+        .unwrap_or(&server.base_url);
+    text.replace(&server.base_url, "{BASE}")
+        .replace(authority, "{HOST}")
+}
+
+fn normalize(body: &[u8], server: &SipiServer) -> String {
+    scrub_str(&String::from_utf8_lossy(body), server)
+}
+
+fn compare_json(
+    sb: &[u8],
+    rb: &[u8],
+    subject: &SipiServer,
+    reference: &SipiServer,
+    allow: &DiffAllowlist,
+) -> BodyMatch {
+    let sn = normalize(sb, subject);
+    let rn = normalize(rb, reference);
+    let mut sv: Value = match serde_json::from_str(&sn) {
+        Ok(v) => v,
+        Err(e) => return BodyMatch::Mismatch(format!("subject JSON parse error: {e}")),
+    };
+    let mut rv: Value = match serde_json::from_str(&rn) {
+        Ok(v) => v,
+        Err(e) => return BodyMatch::Mismatch(format!("reference JSON parse error: {e}")),
+    };
+    // Mask allowlisted fields on both sides, then canonicalise set-like
+    // (scalar) arrays whose order is unspecified across serde_json vs jansson.
+    for ptr in &allow.json_masks {
+        mask_json(&mut sv, ptr);
+        mask_json(&mut rv, ptr);
+    }
+    sort_scalar_arrays(&mut sv);
+    sort_scalar_arrays(&mut rv);
+    if sv == rv {
+        BodyMatch::Match
+    } else {
+        BodyMatch::Mismatch(format!(
+            "JSON differs:\n    subject={sv}\n    reference={rv}"
+        ))
+    }
+}
+
+/// Replace the value at an RFC 6901 pointer with null on both sides (no-op if
+/// the pointer is absent), so an allowlisted field divergence doesn't fail the
+/// whole-body comparison.
+fn mask_json(value: &mut Value, pointer: &str) {
+    if let Some(slot) = value.pointer_mut(pointer) {
+        *slot = Value::Null;
+    }
+}
+
+/// Recursively sort arrays whose elements are all scalars (strings/numbers/
+/// bools) — these are set-like IIIF fields (extraFeatures, extraFormats, …)
+/// whose order is unspecified and differs across the two JSON writers. Arrays
+/// containing objects/arrays keep their order (it may be significant).
+fn sort_scalar_arrays(value: &mut Value) {
+    match value {
+        Value::Array(items) => {
+            let all_scalar = items
+                .iter()
+                .all(|i| !matches!(i, Value::Array(_) | Value::Object(_)));
+            for item in items.iter_mut() {
+                sort_scalar_arrays(item);
+            }
+            if all_scalar {
+                items.sort_by(|a, b| a.to_string().cmp(&b.to_string()));
+            }
+        }
+        Value::Object(map) => {
+            for (_, v) in map.iter_mut() {
+                sort_scalar_arrays(v);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn compare_image(sb: &[u8], rb: &[u8], ct: &str) -> BodyMatch {
+    // The `image` crate ships jpeg/png/tiff only; jp2 falls to a length
+    // band. ICC creation timestamps make image bodies non-byte-deterministic
+    // off the approval path (prod-shape binaries don't set SOURCE_DATE_EPOCH,
+    // ADR-0002), so compare decoded dimensions rather than bytes.
+    if ct.contains("jp2") || ct.contains("jpx") {
+        return length_band(sb, rb);
+    }
+    match (image::load_from_memory(sb), image::load_from_memory(rb)) {
+        (Ok(si), Ok(ri)) => {
+            if si.dimensions() == ri.dimensions() {
+                BodyMatch::Match
+            } else {
+                BodyMatch::Mismatch(format!(
+                    "image dims subject={:?} reference={:?}",
+                    si.dimensions(),
+                    ri.dimensions()
+                ))
+            }
+        }
+        _ => length_band(sb, rb),
+    }
+}
+
+fn length_band(a: &[u8], b: &[u8]) -> BodyMatch {
+    let (la, lb) = (a.len(), b.len());
+    let max = la.max(lb).max(1) as f64;
+    if (la as f64 - lb as f64).abs() / max <= LENGTH_BAND {
+        BodyMatch::Match
+    } else {
+        BodyMatch::Mismatch(format!(
+            "byte-length band exceeded: subject={la} reference={lb} (tol {:.0}%)",
+            LENGTH_BAND * 100.0
+        ))
+    }
+}

--- a/test/e2e/src/lib.rs
+++ b/test/e2e/src/lib.rs
@@ -8,6 +8,9 @@ use std::sync::atomic::{AtomicU16, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
+pub mod diff;
+pub use diff::{diff_get, diff_request, BodyMatch, DiffAllowlist, DiffResult, HeaderDiff};
+
 /// Atomic port counter to avoid conflicts when tests run in parallel.
 /// Start well above privileged ports (macOS restricts ports below 1024).
 /// The base offset is derived from the PID so back-to-back test
@@ -31,6 +34,43 @@ pub fn allocate_ports() -> (u16, u16) {
     (http, ssl)
 }
 
+/// Which binary a `SipiServer` instance wraps. Internal to the harness —
+/// callers select a binary through `start_with_args` (subject) or
+/// `start_pair` (subject + reference), never by naming a `ServerKind`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ServerKind {
+    /// The Rust shell under test — `//src/cli-rs:sipi`, resolved from `$SIPI_BIN`.
+    Subject,
+    /// The retained C++ server used as a differential oracle —
+    /// `//src/cli:sipi`, resolved from `$SIPI_BIN_REF`.
+    Reference,
+}
+
+impl ServerKind {
+    /// The log line each binary emits once its HTTP listener is bound, used
+    /// as a fast readiness hint. The startup poll falls back to a TCP /
+    /// `/health` probe if it never appears (suppressed by log level, or
+    /// written to a stream we don't match), so this is an optimization, not
+    /// a hard requirement.
+    fn ready_signal(self) -> &'static str {
+        match self {
+            // server-rs logs this once `sipi::run` binds the axum listener.
+            ServerKind::Subject => "SIPI Rust shell listening",
+            // shttps `Server::run` logs "Server listening on HTTP port %d".
+            ServerKind::Reference => "Server listening on HTTP port",
+        }
+    }
+
+    /// Short label for `[test-harness]` diagnostics so two interleaved
+    /// spawns are distinguishable.
+    fn label(self) -> &'static str {
+        match self {
+            ServerKind::Subject => "subject(rust)",
+            ServerKind::Reference => "reference(c++)",
+        }
+    }
+}
+
 /// Manages a sipi server process for testing.
 pub struct SipiServer {
     child: Child,
@@ -41,15 +81,59 @@ pub struct SipiServer {
 }
 
 impl SipiServer {
-    /// Start a sipi server with the given config file and extra CLI arguments.
+    /// Start the Rust shell (the subject under test) with the given config
+    /// file and extra CLI arguments.
     ///
-    /// `config` — path to the Lua config file, relative to `working_dir`.
+    /// `config` — path to the config file, relative to `working_dir`.
     /// `working_dir` — the directory sipi should run in (where config/, scripts/, images/ are).
     /// `extra_args` — additional CLI arguments appended after standard ones.
-    ///                 CLI args override Lua config values (CLI11 precedence).
+    ///                 CLI args override config values (CLI precedence).
     pub fn start_with_args(config: &str, working_dir: &Path, extra_args: &[&str]) -> Self {
-        let sipi_bin = sipi_bin_path();
+        Self::spawn(
+            sipi_bin_path(),
+            ServerKind::Subject,
+            config,
+            working_dir,
+            extra_args,
+        )
+    }
 
+    /// Start the Rust shell (subject) and the C++ oracle (reference) on
+    /// separate port pairs from the same config, for differential testing.
+    /// The subject resolves from `$SIPI_BIN`, the reference from
+    /// `$SIPI_BIN_REF` (set only by the `//test/e2e:differential` target).
+    /// Spawned sequentially so the two binaries' startup logs don't interleave.
+    pub fn start_pair(
+        config: &str,
+        working_dir: &Path,
+        extra_args: &[&str],
+    ) -> (SipiServer, SipiServer) {
+        let subject = Self::spawn(
+            sipi_bin_path(),
+            ServerKind::Subject,
+            config,
+            working_dir,
+            extra_args,
+        );
+        let reference = Self::spawn(
+            sipi_oracle_bin_path(),
+            ServerKind::Reference,
+            config,
+            working_dir,
+            extra_args,
+        );
+        (subject, reference)
+    }
+
+    /// Spawn one sipi process of `kind` from the resolved `bin`, wait until
+    /// it serves `/health`, and return the handle.
+    fn spawn(
+        bin: String,
+        kind: ServerKind,
+        config: &str,
+        working_dir: &Path,
+        extra_args: &[&str],
+    ) -> Self {
         let (http_port, ssl_port) = allocate_ports();
 
         // If a stale sipi from a previous test run is still holding these
@@ -60,8 +144,9 @@ impl SipiServer {
         kill_process_on_port(ssl_port);
 
         eprintln!(
-            "[test-harness] Starting sipi: bin={} config={} ports={}/{} cwd={} extra_args={:?}",
-            sipi_bin,
+            "[test-harness] Starting {} sipi: bin={} config={} ports={}/{} cwd={} extra_args={:?}",
+            kind.label(),
+            bin,
             config,
             http_port,
             ssl_port,
@@ -73,16 +158,22 @@ impl SipiServer {
         // (default is 30s). With `stop()`'s 5s deadline, this leaves a 2.5×
         // margin even under ASan's runtime overhead, so SIGKILL never fires
         // on a still-draining server. Placed before `extra_args` so an
-        // individual test can still override it (CLI11 last-wins).
-        let mut cmd = Command::new(&sipi_bin);
+        // individual test can still override it (last-wins).
+        let mut cmd = Command::new(&bin);
         cmd.arg("server")
             .arg("--config")
             .arg(config)
             .arg("--serverport")
-            .arg(http_port.to_string())
-            .arg("--sslport")
-            .arg(ssl_port.to_string())
-            .arg("--drain-timeout")
+            .arg(http_port.to_string());
+        // The Rust shell parses `--sslport` but serves plain HTTP behind
+        // Traefik. The C++ oracle would bind a real SSL listener, so the
+        // reference is spawned HTTP-only: with `--config` its `ssl_port`
+        // defaults to -1 and the SSL block is skipped when `--sslport` is
+        // absent. The resulting TLS difference is an allowlisted divergence.
+        if matches!(kind, ServerKind::Subject) {
+            cmd.arg("--sslport").arg(ssl_port.to_string());
+        }
+        cmd.arg("--drain-timeout")
             .arg("2")
             .args(extra_args)
             .current_dir(working_dir)
@@ -100,11 +191,10 @@ impl SipiServer {
         // changes cwd to test/_test_data/, gcda files would land there instead of
         // in build/. GCOV_PREFIX redirects them to the build dir.
         //
-        // Derive `build_dir` from the *actually-resolved* sipi binary, not from
-        // `find_sipi_bin()` (the cmake-inner-loop default). When `$SIPI_BIN`
-        // points outside `repo_root/build` (static-musl CI, sanitizer CI, or
-        // any custom binary), `find_sipi_bin()` would compute the wrong dir.
-        let build_dir = PathBuf::from(&sipi_bin)
+        // Derive `build_dir` from the *actually-resolved* sipi binary so a
+        // `$SIPI_BIN`/`$SIPI_BIN_REF` outside `repo_root/build` (static-musl CI,
+        // sanitizer CI, or any custom binary) still computes the right dir.
+        let build_dir = PathBuf::from(&bin)
             .parent()
             .expect("sipi binary should be in a build directory")
             .to_path_buf();
@@ -114,104 +204,78 @@ impl SipiServer {
         }
 
         let mut child = cmd.spawn().unwrap_or_else(|e| {
-            panic!("Failed to start sipi at {}: {}", sipi_bin, e);
+            panic!("Failed to start {} sipi at {}: {}", kind.label(), bin, e);
         });
-        let child_pid = child.id();
-        eprintln!("[test-harness] Spawned sipi PID={}", child_pid);
+        eprintln!(
+            "[test-harness] Spawned {} sipi PID={}",
+            kind.label(),
+            child.id()
+        );
 
-        // Drain stderr in a background thread to prevent pipe buffer from filling.
-        let stderr = child.stderr.take().expect("stderr captured");
-        let stderr_buf = Arc::new(Mutex::new(String::new()));
-        let stderr_buf_clone = Arc::clone(&stderr_buf);
-        std::thread::spawn(move || {
-            let mut reader = BufReader::new(stderr);
-            let mut buf = String::new();
-            loop {
-                buf.clear();
-                match reader.read_line(&mut buf) {
-                    Ok(0) | Err(_) => break,
-                    Ok(_) => {
-                        if let Ok(mut captured) = stderr_buf_clone.lock() {
-                            captured.push_str(&buf);
-                            if captured.len() > 65536 {
-                                let drain = captured.len() - 32768;
-                                captured.drain(..drain);
-                            }
-                        }
-                    }
-                }
-            }
-        });
-
-        // Drain stdout in a background thread. Capture content for diagnostics
-        // AND watch for the readiness signal.
-        let stdout = child.stdout.take().expect("stdout captured");
-        let stdout_buf = Arc::new(Mutex::new(String::new()));
-        let stdout_buf_clone = Arc::clone(&stdout_buf);
-        // The Rust shell (the cutover binary) logs this once it binds the listener;
-        // it serves plain HTTP behind Traefik, so there is no SSL-port line.
-        let ready_signal = "SIPI Rust shell listening";
+        // Drain both child streams on background threads (prevents pipe-buffer
+        // backpressure) and feed the readiness channel on the listen-log line.
+        // Watching both streams keeps readiness independent of which sink a
+        // given binary logs to.
+        let ready_signal = kind.ready_signal();
         let (tx, rx) = std::sync::mpsc::channel();
+        let stderr_buf = spawn_log_drain(
+            child.stderr.take().expect("stderr captured"),
+            ready_signal,
+            tx.clone(),
+        );
+        let stdout_buf = spawn_log_drain(
+            child.stdout.take().expect("stdout captured"),
+            ready_signal,
+            tx,
+        );
 
-        std::thread::spawn(move || {
-            let reader = BufReader::new(stdout);
-            for line in reader.lines() {
-                match line {
-                    Ok(l) => {
-                        if let Ok(mut captured) = stdout_buf_clone.lock() {
-                            captured.push_str(&l);
-                            captured.push('\n');
-                            if captured.len() > 65536 {
-                                let drain = captured.len() - 32768;
-                                captured.drain(..drain);
-                            }
-                        }
-                        // Detect readiness: the Rust shell's listen log line.
-                        if l.contains(ready_signal) {
-                            let _ = tx.send(());
-                        }
-                    }
-                    Err(_) => break,
-                }
-            }
-        });
-
-        // Wait for ready signal or TCP connectivity
+        // Wait for readiness: the listen-log signal (fast hint) or a successful
+        // TCP connect. Polling both avoids a 30s stall when the signal is
+        // suppressed or lands on a stream we don't match (the C++ oracle's log
+        // sink is configurable).
         let timeout = Duration::from_secs(30);
         let start = Instant::now();
-
-        match rx.recv_timeout(timeout) {
-            Ok(()) => {
+        let mut connected = false;
+        while start.elapsed() < timeout {
+            if rx.try_recv().is_ok() {
                 eprintln!(
-                    "[test-harness] Readiness signal received after {:?}",
+                    "[test-harness] {} readiness signal after {:?}",
+                    kind.label(),
                     start.elapsed()
                 );
+                connected = true;
+                break;
             }
-            Err(_) => {
-                // Fallback: poll TCP
-                eprintln!("[test-harness] No readiness signal, falling back to TCP probe");
-                while start.elapsed() < timeout {
-                    if TcpStream::connect(format!("127.0.0.1:{}", http_port)).is_ok() {
-                        break;
-                    }
-                    std::thread::sleep(Duration::from_millis(100));
-                }
-                if TcpStream::connect(format!("127.0.0.1:{}", http_port)).is_err() {
-                    let captured_stderr = stderr_buf.lock().map(|s| s.clone()).unwrap_or_default();
-                    let captured_stdout = stdout_buf.lock().map(|s| s.clone()).unwrap_or_default();
-                    child.kill().ok();
-                    panic!(
-                        "Sipi failed to start within {:?} on port {}\nstdout:\n{}\nstderr:\n{}",
-                        timeout, http_port, captured_stdout, captured_stderr
-                    );
-                }
+            if TcpStream::connect(format!("127.0.0.1:{}", http_port)).is_ok() {
+                connected = true;
+                break;
             }
+            if let Ok(Some(status)) = child.try_wait() {
+                panic!(
+                    "{} sipi exited with {} during startup\nstdout:\n{}\nstderr:\n{}",
+                    kind.label(),
+                    status,
+                    dump(&stdout_buf),
+                    dump(&stderr_buf)
+                );
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        if !connected {
+            child.kill().ok();
+            panic!(
+                "{} sipi failed to start within {:?} on port {}\nstdout:\n{}\nstderr:\n{}",
+                kind.label(),
+                timeout,
+                http_port,
+                dump(&stdout_buf),
+                dump(&stderr_buf)
+            );
         }
 
-        // The readiness log is emitted before the event loop starts accepting
-        // connections. Probe /health (Rust-native, engine-independent) to confirm
-        // the server is actually processing — the Rust shell is OTLP-only, so it
-        // exposes no /metrics scrape, and /health is served by both transports.
+        // The listen log / TCP-accept precedes the event loop actually
+        // processing requests. Probe /health (Rust-native, engine-independent,
+        // served by both transports) to confirm the server is serving.
         let base_url = format!("http://127.0.0.1:{}", http_port);
         let probe_client = reqwest::blocking::Client::builder()
             .danger_accept_invalid_certs(true)
@@ -228,7 +292,8 @@ impl SipiServer {
                 Ok(resp) if resp.status().is_success() => {
                     http_ready = true;
                     eprintln!(
-                        "[test-harness] HTTP ready after {} probes, {:?} total",
+                        "[test-harness] {} HTTP ready after {} probes, {:?} total",
+                        kind.label(),
                         probe_count,
                         start.elapsed()
                     );
@@ -241,27 +306,33 @@ impl SipiServer {
                     last_probe_err = format!("{}", e);
                 }
             }
-            // Check if child is still alive
             if let Ok(Some(status)) = child.try_wait() {
-                let captured_stdout = stdout_buf.lock().map(|s| s.clone()).unwrap_or_default();
-                let captured_stderr = stderr_buf.lock().map(|s| s.clone()).unwrap_or_default();
                 panic!(
-                    "Sipi process exited unexpectedly with {} after {} probes\n\
+                    "{} sipi exited with {} after {} /health probes\n\
                      last probe error: {}\nstdout:\n{}\nstderr:\n{}",
-                    status, probe_count, last_probe_err, captured_stdout, captured_stderr
+                    kind.label(),
+                    status,
+                    probe_count,
+                    last_probe_err,
+                    dump(&stdout_buf),
+                    dump(&stderr_buf)
                 );
             }
             std::thread::sleep(Duration::from_millis(50));
         }
 
         if !http_ready {
-            let captured_stdout = stdout_buf.lock().map(|s| s.clone()).unwrap_or_default();
-            let captured_stderr = stderr_buf.lock().map(|s| s.clone()).unwrap_or_default();
             child.kill().ok();
             panic!(
-                "Sipi started but never served HTTP on port {} within {:?}\n\
+                "{} sipi started but never served HTTP on port {} within {:?}\n\
                  probes attempted: {}, last error: {}\nstdout:\n{}\nstderr:\n{}",
-                http_port, timeout, probe_count, last_probe_err, captured_stdout, captured_stderr
+                kind.label(),
+                http_port,
+                timeout,
+                probe_count,
+                last_probe_err,
+                dump(&stdout_buf),
+                dump(&stderr_buf)
             );
         }
 
@@ -323,6 +394,41 @@ impl Drop for SipiServer {
     fn drop(&mut self) {
         self.stop();
     }
+}
+
+/// Drain a child stream on a background thread: capture lines for
+/// diagnostics (ring-capped at 64 KiB → 32 KiB) and signal `tx` on the
+/// first line containing `ready_signal`. Returns the shared capture buffer.
+fn spawn_log_drain(
+    stream: impl std::io::Read + Send + 'static,
+    ready_signal: &'static str,
+    tx: std::sync::mpsc::Sender<()>,
+) -> Arc<Mutex<String>> {
+    let buf = Arc::new(Mutex::new(String::new()));
+    let buf_clone = Arc::clone(&buf);
+    std::thread::spawn(move || {
+        let reader = BufReader::new(stream);
+        for line in reader.lines() {
+            let Ok(l) = line else { break };
+            if let Ok(mut captured) = buf_clone.lock() {
+                captured.push_str(&l);
+                captured.push('\n');
+                if captured.len() > 65536 {
+                    let drain = captured.len() - 32768;
+                    captured.drain(..drain);
+                }
+            }
+            if l.contains(ready_signal) {
+                let _ = tx.send(());
+            }
+        }
+    });
+    buf
+}
+
+/// Snapshot a capture buffer for inclusion in a panic message.
+fn dump(buf: &Arc<Mutex<String>>) -> String {
+    buf.lock().map(|s| s.clone()).unwrap_or_default()
 }
 
 /// Path to the sipi repository root.
@@ -450,13 +556,12 @@ pub fn find_sipi_bin() -> PathBuf {
     repo_root().join("build").join("sipi")
 }
 
-/// Resolve the sipi binary path for spawning. Reads `SIPI_BIN` (or falls
-/// back to `find_sipi_bin()`) and canonicalises the result to an
-/// absolute path.
+/// Resolve a sipi binary path from `env_var`, falling back to `fallback`,
+/// and canonicalise the result to an absolute path.
 ///
 /// Why canonicalise: callers spawn sipi via `Command::new(&path).
 /// current_dir(working_dir)`, and Rust resolves the binary path AFTER
-/// applying `current_dir`. A relative `SIPI_BIN` like `src/sipi`
+/// applying `current_dir`. A relative path like `src/sipi`
 /// (Bazel `$(rootpath …)` output) would be looked up under
 /// `working_dir/src/sipi` — wrong. The canonicalisation runs in the
 /// parent's cwd, which under Bazel `rust_test` is the runfiles
@@ -464,11 +569,9 @@ pub fn find_sipi_bin() -> PathBuf {
 ///
 /// Returns the binary path as a String (kept as String rather than
 /// PathBuf so callers can pass it straight to `Command::new` or to
-/// derived `PathBuf::from(&sipi_bin)` arithmetic in
-/// `SipiServer::start_with_args`).
-pub fn sipi_bin_path() -> String {
-    let raw =
-        std::env::var("SIPI_BIN").unwrap_or_else(|_| find_sipi_bin().to_string_lossy().to_string());
+/// derived `PathBuf::from(&bin)` arithmetic in `SipiServer::spawn`).
+pub fn sipi_bin_path_from(env_var: &str, fallback: PathBuf) -> String {
+    let raw = std::env::var(env_var).unwrap_or_else(|_| fallback.to_string_lossy().to_string());
     std::path::Path::new(&raw)
         .canonicalize()
         .map(|p| p.to_string_lossy().into_owned())
@@ -476,6 +579,24 @@ pub fn sipi_bin_path() -> String {
         // doesn't exist yet) so the downstream `Command::spawn` panic
         // surfaces the original user input rather than swallowing it.
         .unwrap_or(raw)
+}
+
+/// The Rust shell under test (`//src/cli-rs:sipi`), from `$SIPI_BIN` or the
+/// cmake inner-loop fallback (`<repo>/build/sipi`).
+pub fn sipi_bin_path() -> String {
+    sipi_bin_path_from("SIPI_BIN", find_sipi_bin())
+}
+
+/// The C++ oracle (`//src/cli:sipi`) for the differential harness, from
+/// `$SIPI_BIN_REF`. Set only by the `//test/e2e:differential` Bazel target;
+/// under `cargo test` it is unset and the fallback path won't exist, so
+/// `start_pair` panics at spawn with a clear message — the differential
+/// suite is Bazel-only.
+pub fn sipi_oracle_bin_path() -> String {
+    sipi_bin_path_from(
+        "SIPI_BIN_REF",
+        repo_root().join("build").join("sipi-oracle"),
+    )
 }
 
 /// Path to the test data directory.

--- a/test/e2e/tests/differential.rs
+++ b/test/e2e/tests/differential.rs
@@ -1,0 +1,268 @@
+//! Differential parity gate — THE strangler parity check: replay every
+//! replayable request the e2e suite exercises against BOTH binaries (the Rust
+//! shell, subject, `$SIPI_BIN`; and the retained C++ server, reference,
+//! `$SIPI_BIN_REF`) and assert they agree modulo the §5 allowlist. A green run
+//! over the whole corpus is the definition of "Rust is at parity" — the
+//! deploy gate for deleting the C++ transport (plan 02 §1 / §9).
+//!
+//! Coverage model (back-to-back testing; see plan 02 §7): `CASES` below is the
+//! deduped corpus of every idempotent GET/HEAD across `test/e2e/tests/*.rs`.
+//! Non-replayable behaviours (uploads/state mutation, raw-TCP byte tests,
+//! timing/concurrency, lifecycle/SIGTERM, config-writing, CLI subprocesses,
+//! proptest, insta snapshots) stay in their single-server e2e files — the
+//! drift guard (`tools/differential_coverage_check`) enforces that every e2e
+//! test is either represented here or annotated non-replayable.
+//!
+//! A `Case` with `gap: Some(reason)` is a known divergence or crash-risk
+//! skipped today; `gap: None` is asserted at parity. Shrinking the set of
+//! `Some` entries is the measurable definition of cutover progress.
+//!
+//! Bazel-only (needs `$SIPI_BIN_REF`); run via `just bazel-test-differential`.
+
+use std::sync::OnceLock;
+
+use reqwest::Method;
+use sipi_e2e::{diff_request, DiffAllowlist, SipiServer};
+
+/// Per-case allowlist profile.
+#[derive(Clone, Copy)]
+enum Allow {
+    /// Transport framing only (plan 02 §5 always-ignore).
+    Default,
+    /// `X-Forwarded-Proto` present: the Rust shell derives the canonical scheme
+    /// from XFP while the C++ transport hardcodes `http://` (§5 #9, intentional).
+    /// Mask the host-bearing `id` so that scheme divergence is tolerated.
+    Xfp,
+    /// `/health`: the version string (Rust `CARGO_PKG_VERSION` vs C++
+    /// `SipiVersion`) and the uptime counter differ by design (§5 #2,
+    /// observability). Mask both; the `status: ok` shape still asserts.
+    Health,
+}
+
+impl Allow {
+    fn build(self) -> DiffAllowlist {
+        match self {
+            Allow::Default => DiffAllowlist::default_transport(),
+            Allow::Xfp => DiffAllowlist::default_transport().masking_json("/id"),
+            Allow::Health => DiffAllowlist::default_transport()
+                .masking_json("/version")
+                .masking_json("/uptime_seconds"),
+        }
+    }
+}
+
+/// One replayable request in the differential corpus.
+struct Case {
+    name: &'static str,
+    method: Method,
+    path: &'static str,
+    headers: &'static [(&'static str, &'static str)],
+    allow: Allow,
+    /// `Some(reason)` = a known divergence or crash-risk skipped today; `None`
+    /// = asserted at parity. Removing a `Some` is the unit of cutover progress.
+    gap: Option<&'static str>,
+}
+
+/// The corpus: every replayable GET/HEAD the e2e suite exercises, deduped by
+/// (method, path, headers). Generated from the suite and kept complete by the
+/// drift guard.
+const CASES: &[Case] = &[
+    Case { name: "info_json_has_required_fields", method: Method::GET, path: "/unit/lena512.jp2/info.json", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "info_json_x_forwarded_proto_https", method: Method::GET, path: "/unit/lena512.jp2/info.json", headers: &[("X-Forwarded-Proto", "https")], allow: Allow::Xfp, gap: None },
+    Case { name: "cors_info_json_with_origin", method: Method::GET, path: "/unit/lena512.jp2/info.json", headers: &[("Origin", "https://example.org")], allow: Allow::Default, gap: None },
+    Case { name: "cors_image_with_origin", method: Method::GET, path: "/unit/lena512.jp2/full/max/0/default.jpg", headers: &[("Origin", "https://example.org")], allow: Allow::Default, gap: None },
+    Case { name: "cors_image_without_origin", method: Method::GET, path: "/unit/lena512.jp2/full/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "base_uri_redirect", method: Method::GET, path: "/unit/lena512.jp2", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "jsonld_media_type_with_accept", method: Method::GET, path: "/unit/lena512.jp2/info.json", headers: &[("Accept", "application/ld+json")], allow: Allow::Default, gap: None },
+    Case { name: "region_square", method: Method::GET, path: "/unit/lena512.jp2/square/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "region_percent", method: Method::GET, path: "/unit/lena512.jp2/pct:10,10,50,50/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "region_pixel", method: Method::GET, path: "/unit/lena512.jp2/0,0,100,100/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "region_pixel_offset", method: Method::GET, path: "/unit/lena512.jp2/50,50,200,200/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "region_beyond_bounds_is_cropped", method: Method::GET, path: "/unit/lena512.jp2/400,400,9999,9999/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "region_start_beyond_image", method: Method::GET, path: "/unit/lena512.jp2/600,600,100,100/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "region_zero_width", method: Method::GET, path: "/unit/lena512.jp2/0,0,0,100/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "region_invalid_syntax", method: Method::GET, path: "/unit/lena512.jp2/invalid/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "size_by_width", method: Method::GET, path: "/unit/lena512.jp2/full/256,/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "size_by_height", method: Method::GET, path: "/unit/lena512.jp2/full/,256/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "size_exact", method: Method::GET, path: "/unit/lena512.jp2/full/200,200/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "size_best_fit", method: Method::GET, path: "/unit/lena512.jp2/full/!200,200/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "size_percent", method: Method::GET, path: "/unit/lena512.jp2/full/pct:50/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "size_upscaling", method: Method::GET, path: "/unit/lena512.jp2/full/^1000,/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "size_no_upscale_beyond_original", method: Method::GET, path: "/unit/lena512.jp2/full/1000,/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "size_after_region", method: Method::GET, path: "/unit/lena512.jp2/0,0,200,200/100,/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "size_invalid_syntax", method: Method::GET, path: "/unit/lena512.jp2/full/invalid/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "mirror_rotation", method: Method::GET, path: "/unit/lena512.jp2/full/max/!0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "rotation_180", method: Method::GET, path: "/unit/lena512.jp2/full/max/180/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "rotation_270", method: Method::GET, path: "/unit/lena512.jp2/full/max/270/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "rotation_arbitrary", method: Method::GET, path: "/unit/lena512.jp2/full/max/45/default.png", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "mirror_plus_180", method: Method::GET, path: "/unit/lena512.jp2/full/max/!180/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "rotation_after_region", method: Method::GET, path: "/unit/lena512.jp2/square/max/90/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "rotation_invalid", method: Method::GET, path: "/unit/lena512.jp2/full/max/abc/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "quality_gray", method: Method::GET, path: "/unit/lena512.jp2/full/max/0/gray.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "quality_color", method: Method::GET, path: "/unit/lena512.jp2/full/max/0/color.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "quality_bitonal", method: Method::GET, path: "/unit/lena512.jp2/full/max/0/bitonal.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "quality_invalid", method: Method::GET, path: "/unit/lena512.jp2/full/max/0/invalid.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "format_png_content_type", method: Method::GET, path: "/unit/lena512.jp2/full/max/0/default.png", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "format_tiff_content_type", method: Method::GET, path: "/unit/lena512.jp2/full/max/0/default.tif", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "format_jp2_content_type", method: Method::GET, path: "/unit/lena512.jp2/full/max/0/default.jp2", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "unsupported_formats_rejected_gif", method: Method::GET, path: "/unit/lena512.jp2/full/max/0/default.gif", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "unsupported_formats_rejected_pdf", method: Method::GET, path: "/unit/lena512.jp2/full/max/0/default.pdf", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "unsupported_formats_rejected_webp", method: Method::GET, path: "/unit/lena512.jp2/full/max/0/default.webp", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "unsupported_formats_rejected_bmp", method: Method::GET, path: "/unit/lena512.jp2/full/max/0/default.bmp", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "id_escaped", method: Method::GET, path: "/unit/test%23image.jp2/full/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "id_escaped_slash_decoded", method: Method::GET, path: "/unit%2Flena512.jp2/full/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "id_random_gives_404", method: Method::GET, path: "/nonexistent-random-id/full/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "id_incomplete_iiif_url", method: Method::GET, path: "/unit/lena512.jp2/full/max/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "id_malformed_iiif_url", method: Method::GET, path: "/unit/lena512.jp2/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "invalid_iiif_url_empty_identifier", method: Method::GET, path: "/unit//lena512.jp2", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "size_upscale_max", method: Method::GET, path: "/unit/lena512.jp2/full/^max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "size_upscale_height", method: Method::GET, path: "/unit/lena512.jp2/full/^,1024/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "size_upscale_exact", method: Method::GET, path: "/unit/lena512.jp2/full/^1024,1024/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "size_upscale_confined", method: Method::GET, path: "/unit/lena512.jp2/full/^!1024,1024/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "size_upscale_percent", method: Method::GET, path: "/unit/lena512.jp2/full/^pct:150/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "region_dimension_verification", method: Method::GET, path: "/unit/lena512.jp2/100,100,100,100/max/0/default.png", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "size_dimension_verification", method: Method::GET, path: "/unit/lena512.jp2/full/256,/0/default.png", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "rotation_dimension_verification", method: Method::GET, path: "/unit/lena512.jp2/0,0,200,100/max/90/default.png", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "operation_ordering", method: Method::GET, path: "/unit/lena512.jp2/0,0,200,100/100,/90/default.png", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "fractional_percent_region", method: Method::GET, path: "/unit/lena512.jp2/pct:0.5,0.5,99.0,99.0/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "id_non_ascii", method: Method::GET, path: "/unit/caf%C3%A9.jp2/full/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "iiif_region_crop", method: Method::GET, path: "/unit/lena512.jp2/0,0,256,256/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "iiif_rotation_90", method: Method::GET, path: "/unit/lena512.jp2/full/max/90/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "deny_unauthorized_image", method: Method::GET, path: "/knora/DenyLeaves.jpg/full/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "head_iiif_image_empty_body", method: Method::HEAD, path: "/unit/lena512.jp2/full/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "path_traversal_rejected_variant_1", method: Method::GET, path: "/unit/%2E%2E%2F%2E%2E%2Fetc%2Fpasswd/full/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "path_traversal_rejected_variant_2", method: Method::GET, path: "/unit/..%2F..%2Fetc%2Fpasswd/full/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "metadata_iiif_pipeline", method: Method::GET, path: "/unit/lena512.jp2/0,0,256,256/128,128/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "double_encoded_url", method: Method::GET, path: "/unit%252Flena512.jp2/full/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: Some("intentional (FINDING, DEV-6700): C++ double-decodes %252F → serves the file (200); the Rust shell decodes once → 404. Rust's single-decode is the safer contract (no double-decoded path separators). Move to the §5 allowlist once confirmed (DEV-6700).") },
+    Case { name: "cmyk_through_iiif_pipeline", method: Method::GET, path: "/unit/cmyk.tif/full/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "cielab_through_iiif_pipeline", method: Method::GET, path: "/unit/cielab.tif/full/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "progressive_jpeg_input_full_max", method: Method::GET, path: "/unit/MaoriFigure.jpg/full/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "progressive_jpeg_input_region_size_transform", method: Method::GET, path: "/unit/MaoriFigure.jpg/0,0,200,200/100,100/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "file_access_allowed", method: Method::GET, path: "/unit/test.csv/file", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "file_access_denied", method: Method::GET, path: "/unit/test2.csv/file", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "iiif_file_download_range_first_bytes", method: Method::GET, path: "/unit/test.csv/file", headers: &[("Range", "bytes=0-99")], allow: Allow::Default, gap: None },
+    Case { name: "iiif_file_download_range_middle", method: Method::GET, path: "/unit/test.csv/file", headers: &[("Range", "bytes=1000-1999")], allow: Allow::Default, gap: None },
+    Case { name: "video_knora_json", method: Method::GET, path: "/unit/8pdET49BfoJ-EeRcIbgcLch.mp4/knora.json", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "missing_sidecar_handled_gracefully", method: Method::GET, path: "/unit/has-missing-sidecar-file.mp4/knora.json", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "sqlite_api", method: Method::GET, path: "/sqlite", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "lua_test_functions", method: Method::GET, path: "/test_functions", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "lua_mediatype", method: Method::GET, path: "/test_mediatype", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "lua_mimetype_func", method: Method::GET, path: "/test_mimetype_func", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "lua_knora_session_cookie", method: Method::GET, path: "/test_knora_session_cookie", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "lua_orientation", method: Method::GET, path: "/test_orientation", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "lua_exif_gps", method: Method::GET, path: "/test_exif_gps", headers: &[], allow: Allow::Default, gap: Some("BUG (Rust shell, DEV-6699): emits a duplicate content-type (application/json + text/html) on this Lua-route response where C++ sends only application/json. Un-gap when fixed.") },
+    Case { name: "lua_read_write", method: Method::GET, path: "/read_write_lua", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "video_knora_json_x_forwarded_proto", method: Method::GET, path: "/unit/8pdET49BfoJ-EeRcIbgcLch.mp4/knora.json", headers: &[("X-Forwarded-Proto", "https")], allow: Allow::Xfp, gap: None },
+    Case { name: "knora_json_image_required_fields", method: Method::GET, path: "/unit/lena512.jp2/knora.json", headers: &[], allow: Allow::Default, gap: Some("cluster D (DEV-6659 step 7): info.rs defers originalFilename/originalMimeType on the image knora.json path (the video path emits them) — plan 02 §3 cluster D") },
+    Case { name: "knora_json_nonexistent_file", method: Method::GET, path: "/unit/no-such-file.jp2/knora.json", headers: &[], allow: Allow::Default, gap: Some("intentional: missing knora.json source → Rust 404, C++ 500 (the e2e test accepts either; 404 is the more correct status).") },
+    Case { name: "knora_json_csv_file", method: Method::GET, path: "/unit/test.csv/knora.json", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "prometheus_metrics", method: Method::GET, path: "/metrics", headers: &[], allow: Allow::Default, gap: Some("§5 #1 intentional: /metrics is removed in the Rust shell (OTLP replaces the Prometheus scrape) — C++ serves 200, Rust has no route. Permanent divergence.") },
+    Case { name: "restricted_image_reduction", method: Method::GET, path: "/test_restrict/lena512.jp2/full/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "lua_route_error_handling", method: Method::GET, path: "/test_lua_error", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "lua_image_crop_verify", method: Method::GET, path: "/test_image_ops?op=crop&param=0,0,256,256&file=unit/lena512.jp2", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "lua_image_scale_verify", method: Method::GET, path: "/test_image_ops?op=scale&param=200,&file=unit/lena512.jp2", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "lua_image_rotate_verify", method: Method::GET, path: "/test_image_ops?op=rotate&param=90&file=unit/lena512.jp2", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "lua_jwt_round_trip", method: Method::GET, path: "/test_jwt_round_trip", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "lua_uuid_round_trip", method: Method::GET, path: "/test_uuid_round_trip", headers: &[], allow: Allow::Default, gap: Some("non-replayable: the response embeds a freshly-generated random UUID (non-deterministic across the two calls); round_trip_ok is covered by the single-server e2e test.") },
+    Case { name: "lua_http_client_error_handling", method: Method::GET, path: "/test_http_error", headers: &[], allow: Allow::Default, gap: Some("non-replayable: the error message embeds a non-deterministic connection-timeout duration (e.g. \"2004 ms\" vs \"2002 ms\"); http_success=false is covered by the single-server e2e test.") },
+    Case { name: "watermark_applied_via_http_watermarked", method: Method::GET, path: "/test_watermark/lena512.jp2/full/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "restrict_plus_watermark", method: Method::GET, path: "/test_restrict_wm/lena512.jp2/full/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "iiif_auth_api", method: Method::GET, path: "/auth/lena512.jp2/info.json", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "temp_directory_cleanup", method: Method::GET, path: "/test_clean_temp_dir", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "cache_returns_consistent_results", method: Method::GET, path: "/unit/lena512.jp2/pct:5,5,90,90/100,/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "jwt_expired_token", method: Method::GET, path: "/auth/lena512.jp2/full/max/0/default.jpg", headers: &[("Authorization", "Bearer <HS256-JWT allow:true exp:past>")], allow: Allow::Default, gap: Some("cluster F: read-only preflight crashes on a Bearer token (response-sink DoS, DEV-6670) — plan 02 §8.1") },
+    Case { name: "jwt_alg_none_bypass", method: Method::GET, path: "/auth/lena512.jp2/full/max/0/default.jpg", headers: &[("Authorization", "Bearer <alg:none JWT allow:true no-signature>")], allow: Allow::Default, gap: Some("cluster F: read-only preflight crashes on a Bearer token (response-sink DoS, DEV-6670) — plan 02 §8.1") },
+    Case { name: "jwt_tampered_payload", method: Method::GET, path: "/auth/lena512.jp2/full/max/0/default.jpg", headers: &[("Authorization", "Bearer <HS256-signed allow:false token with payload swapped to allow:true>")], allow: Allow::Default, gap: Some("cluster F: read-only preflight crashes on a Bearer token (response-sink DoS, DEV-6670) — plan 02 §8.1") },
+    Case { name: "crlf_header_injection", method: Method::GET, path: "/unit/lena512%0d%0aX-Injected:%20evil/full/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "error_no_path_disclosure", method: Method::GET, path: "/unit/nonexistent-file-for-path-test.jp2/full/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "decompression_bomb_rejection", method: Method::GET, path: "/unit/lena512.jp2/full/^100000,100000/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "bilevel_tiff_info_json", method: Method::GET, path: "/bilevel/bilevel_lzw_miniswhite.tif/info.json", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "bilevel_tiff_full_default_jpg", method: Method::GET, path: "/bilevel/bilevel_lzw_miniswhite.tif/full/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "bilevel_tiff_region_default_jpg", method: Method::GET, path: "/bilevel/bilevel_roi_test.tif/32,32,64,64/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "bilevel_tiff_minisblack_full_default_jpg", method: Method::GET, path: "/bilevel/bilevel_lzw_minisblack.tif/full/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "bilevel_tiff_uncompressed_full_default_jpg", method: Method::GET, path: "/bilevel/bilevel_none_miniswhite.tif/full/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "heritage_jpeg_o_full_default_jpg", method: Method::GET, path: "/jpeg/35-2421d-o.jpg/full/max/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "heritage_jpeg_r_info_json", method: Method::GET, path: "/jpeg/35-2421d-r.jpg/info.json", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "iiif_region_size_jpeg_has_non_trivial_body", method: Method::GET, path: "/unit/lena512.jp2/0,0,256,256/128,/0/default.jpg", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "returns_404_for_missing_file", method: Method::GET, path: "/file-should-be-missing-123", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "head_request_returns_headers", method: Method::HEAD, path: "/unit/lena512.jp2/info.json", headers: &[], allow: Allow::Default, gap: None },
+    Case { name: "health_returns_200_with_json", method: Method::GET, path: "/health", headers: &[], allow: Allow::Health, gap: None },
+];
+
+/// Shared subject+reference pair — the corpus is read-only GETs, so one pair
+/// is reused (each `start_pair` spawns two processes). `--test-threads=1`
+/// (Bazel macro) keeps the single corpus test serial.
+fn pair() -> &'static (SipiServer, SipiServer) {
+    static PAIR: OnceLock<(SipiServer, SipiServer)> = OnceLock::new();
+    PAIR.get_or_init(|| {
+        SipiServer::start_pair(
+            "config/sipi.e2e-test-config.lua",
+            &sipi_e2e::test_data_dir(),
+            &[],
+        )
+    })
+}
+
+/// Replay the whole corpus against both binaries, collecting every divergence
+/// into one report (rather than failing on the first), so a CI run shows the
+/// complete parity picture. `gap` cases are skipped and logged.
+#[test]
+fn differential_corpus_parity() {
+    let (subject, reference) = pair();
+    let mut failures: Vec<String> = Vec::new();
+    let mut skipped: Vec<(&str, &str)> = Vec::new();
+    let mut asserted = 0usize;
+
+    for case in CASES {
+        if let Some(reason) = case.gap {
+            skipped.push((case.name, reason));
+            continue;
+        }
+        asserted += 1;
+        // Isolate each case: a request that crashes a server (a real finding)
+        // is reported as a failure instead of aborting the whole corpus run.
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            diff_request(
+                subject,
+                reference,
+                case.method.clone(),
+                case.path,
+                case.headers,
+                None,
+                &case.allow.build(),
+            )
+        }));
+        match outcome {
+            Ok(diff) => {
+                if !diff.is_parity() {
+                    failures.push(format!(
+                        "[{}] {} {}\n      {}",
+                        case.name,
+                        case.method,
+                        case.path,
+                        diff.divergences().join("\n      ")
+                    ));
+                }
+            }
+            Err(_) => failures.push(format!(
+                "[{}] {} {} — request PANICKED (connection error / server crash)",
+                case.name, case.method, case.path
+            )),
+        }
+    }
+
+    eprintln!(
+        "[differential] {asserted} asserted at parity, {} skipped (known divergences / crash-risks)",
+        skipped.len()
+    );
+    for (name, reason) in &skipped {
+        eprintln!("[differential]   SKIP {name}: {reason}");
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} differential parity failure(s) of {asserted} asserted:\n\n{}",
+        failures.len(),
+        failures.join("\n\n")
+    );
+}

--- a/tools/differential_coverage_check.sh
+++ b/tools/differential_coverage_check.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Drift guard for the differential parity gate (plan 02 §7).
+#
+# The gate in `test/e2e/tests/differential.rs` must stay COMPLETE: every
+# replayable e2e behaviour is represented in its corpus, and every behaviour
+# that isn't is inherently non-replayable (uploads/state, raw-TCP, timing,
+# lifecycle, config-write, CLI, proptest, snapshots). Because the corpus is
+# deduped (many e2e tests hit one request), we can't map tests 1:1 — so we
+# pin the e2e #[test] count as a coarse ratchet. When it changes, the author
+# must consciously update the corpus (or confirm the new test is
+# non-replayable) and bump EXPECTED_E2E_TESTS below in the same change.
+#
+# This is intentionally cheap (grep + compare); run in CI and via
+# `just differential-coverage-check`.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Baseline: #[test] + #[tokio::test] across test/e2e/tests/*.rs EXCLUDING the
+# differential corpus file itself. Bump this (with a corpus update) whenever an
+# e2e test is added or removed.
+EXPECTED_E2E_TESTS=271
+
+# Count via awk on a concatenated stream with literal `[ \t]` + exact string
+# compare — deterministic across awk/grep implementations. (Earlier a
+# `grep -E '\s'` form disagreed between GNU grep on CI and a local `ugrep`
+# alias; awk + `[ \t]` + equality avoids that regex-class portability trap.)
+actual=$(find test/e2e/tests -maxdepth 1 -name '*.rs' ! -name 'differential.rs' -exec cat {} + |
+  awk '{ s = $0; gsub(/^[ \t]+|[ \t]+$/, "", s); if (s == "#[test]" || s == "#[tokio::test]") c++ } END { print c + 0 }')
+
+if [ "$actual" -ne "$EXPECTED_E2E_TESTS" ]; then
+  cat >&2 <<EOF
+differential coverage drift: e2e #[test] count is $actual, expected $EXPECTED_E2E_TESTS.
+
+An e2e test was added or removed. Before bumping EXPECTED_E2E_TESTS in
+tools/differential_coverage_check.sh, make sure the change is reflected in the
+differential gate:
+  - replayable (idempotent GET/HEAD against a static fixture)  -> add a Case to
+    the corpus in test/e2e/tests/differential.rs
+  - non-replayable (upload/state, raw-TCP, timing, lifecycle, config-write,
+    CLI, proptest, snapshot)                                    -> no Case needed
+Then set EXPECTED_E2E_TESTS=$actual in the same commit.
+EOF
+  exit 1
+fi
+
+echo "differential coverage OK: $actual e2e tests, corpus in differential.rs is the parity gate."


### PR DESCRIPTION
Part of DEV-6659

> Phase C step 4. DEV-6659 is the Phase C umbrella (many PRs), so this is "Part of", not "Fixes" — it must not auto-close the issue on merge.

## Motivation
Phase C deletes the C++ HTTP transport, but the e2e suite spawns only the Rust shell — it tests new-against-new and calls it parity. The retained C++ server is only worth keeping during the cutover if it acts as a *live differential oracle*. This makes the differential test **THE strangler parity gate** (plan 02 §1 / §9): replay every replayable request the e2e suite exercises against both binaries and fail on any non-allowlisted divergence. A green run over the whole corpus is the definition of "Rust is at parity → safe to delete the C++ transport."

## Summary
- New `//test/e2e:differential` gate: a **deduped corpus of all 120 replayable GET/HEAD requests** drawn from the 269-test e2e suite, replayed against the Rust shell (subject) and the C++ oracle (reference) and compared modulo the §5 allowlist.
- **110 asserted at parity; 10 documented per-`Case` gaps** (intentional divergences, known cluster gaps, crash-risks, non-deterministic responses).
- Runs in CI as a dedicated **linux-amd64** step (`manual`-tagged, so still out of the `:all_e2e` matrix and coverage); a pure-shell **drift guard** keeps the corpus from silently lagging the suite.
- Test-harness + test code only; no production change. The C++ transport is untouched.

## Key Changes
### Harness + comparator (`test/e2e/src/{lib,diff}.rs`)
- `ServerKind` + `start_pair` spawn both binaries on separate port pairs from one config; the reference is HTTP-only (`--sslport` stripped; `/health`+TCP readiness).
- `diff_request` + `DiffAllowlist`: content-type-aware body compare — JSON as `serde_json::Value` with scalar-array canonicalisation + RFC 6901 field masks; images by decoded dims / jp2 length-band (ADR-0002); empty bodies short-circuit (HEAD/204). Two-form host:port scrub (`{BASE}`/`{HOST}`). §5 always-ignore + the structural `traceparent` / `access-control-allow-credentials` asymmetries; the §5 #5 error-body divergence is skipped on shared 4xx/5xx.

### Corpus (`test/e2e/tests/differential.rs`)
- One `Case` per distinct request, replayed in a single collect-all-failures pass (CI shows the whole parity picture at once). Per-`Case` `Allow` profile (Default / Xfp / Health) and `gap` reason; shrinking the `gap` set is the measurable definition of cutover progress.

### Gate + drift guard (Bazel, justfile, ci.yml, tools/)
- `//test/e2e:differential` (`manual`-tagged) + `just bazel-test-differential`; two CI steps on linux-amd64 (drift guard, then the gate). `tools/differential_coverage_check.sh` + `just differential-coverage-check` pin the e2e `#[test]` count so the corpus can't silently lag.

## Challenges and Decisions

### Architecture: dual-run corpus, not a 1:1 test port
**Problem:** "make it cover all e2e tests" — but 269 tests, many hitting the same URL with different assertions; hand-porting 269 differential fns is unmaintainable.
**Solution:** a back-to-back parity suite (Sam Newman / GitHub Scientist model; researched). The 269 tests dedupe to **122 distinct requests** (differential only cares about the request, not each assertion); the corpus is that deduped set. Non-replayable behaviours (uploads/state, raw-TCP, timing, lifecycle, config-write, CLI, proptest, snapshots — ~123 tests) stay single-server; the drift guard enforces the boundary.

### e2e `#[ignore]` gaps are not differential gaps
**Problem:** I first carried the e2e `#[ignore]` annotations into the corpus as gaps.
**Solution:** most e2e gaps are Rust-vs-*spec/golden*, not Rust-vs-C++ — e.g. `profile_link_header` (both binaries omit it → they *match* differentially). So the corpus is run empirically and each *actual* divergence is triaged, rather than assuming the e2e ignores apply.

### Triaging the 8 first-run divergences
The gate immediately surfaced 8 divergences; triage drove the final 10 gaps:
- **Comparator fix:** HEAD responses (empty body) were JSON-parse-erroring → both-empty now short-circuits to Match.
- **Masks:** `/health` version+uptime (§5 #2) masked via an `Allow::Health` profile.
- **Intentional / known:** `/metrics` removed (§5 #1); knora image `originalMeta` (cluster D, step 7); two non-deterministic responses (random UUID, timeout-ms in an error string) → non-replayable.
- **Crash-risk pre-gapped:** the 3 JWT/Authorization cases crash the read-only preflight (the DoS, DEV-6670) — skipped to protect the shared pair.

### Keeping the heavy gate affordable in CI
**Problem:** two-process spawn, `exclusive`/`local`; running it on the full 3-platform matrix triples a heavy per-PR step.
**Solution:** dedicated linux-amd64 step (mirroring the rustfmt gate); divergences are code-level, not platform-specific. (Supersedes plan §8's original "local pre-deploy, not CI" placement — at the maintainer's request.)

## Findings (the gate already paid for itself)
- 🐞 **Rust bug:** `/test_exif_gps` emits a **duplicate `content-type`** (`application/json` + `text/html`) on a Lua-route response where C++ sends only `application/json`. Gapped + flagged; worth a Linear issue.
- 🔒 **Latent C++ smell:** C++ **double-decodes `%252F`** (`/unit%252Flena512.jp2/...` → serves the file, 200); the Rust shell decodes once → 404. Rust's single-decode is the safer contract.
- `knora.json` for a missing source: Rust 404 vs C++ 500 (Rust's status is more correct).

## Gotchas
- The gate asserts **Rust ↔ C++ parity**, not Rust ↔ a golden. An e2e `#[ignore]` gap can still be at parity (both behave the same), so don't assume it maps to a differential gap.
- Image bodies are compared by **decoded dimensions / length band, not bytes** (ICC timestamps; ADR-0002). Don't reintroduce byte-exact image expectations here.
- The gate is **Bazel-only** (needs `$SIPI_BIN_REF`, set only by the `//test/e2e:differential` target); `cargo test` or running it outside that target panics at spawn — by design.
- Per-`Case` `gap: Some(reason)` is the inventory of remaining divergences; removing one (when a cluster closes) is the unit of cutover progress. The drift guard's `EXPECTED_E2E_TESTS` must be bumped (with a corpus review) when an e2e test is added/removed.

## Test Plan
- [x] `just bazel-test-differential` → green: 110 asserted at parity, 10 documented skips (subject ↔ C++ oracle); wired as a linux-amd64 CI step.
- [x] `just differential-coverage-check` → green (269 e2e tests; drift guard wired as a CI step).
- [x] `just bazel-test-e2e` → 24/24 existing targets pass (no regression from the shared-lib changes).
- [x] `just bazel-rustfmt-check` clean.
- [x] Verified `differential` excluded from `:all_e2e` and the `//test/e2e/...` coverage wildcard (`manual` tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
