### PR TITLE
build: fix the bazel-remote download cache (RestrictSUIDSGID blocked setgid CAS writes)

### DIFF
--- a/docs/src/development/rbe.md
+++ b/docs/src/development/rbe.md
@@ -45,6 +45,30 @@ an upstream is reachable from the VM warms it for good; no manual step is requir
 limitation: when the VM cannot reach an upstream the runner CAN reach, a green
 local-fallback build does not write back to the download cache.
 
+### Why a separate bazel-remote, not just NativeLink
+
+NativeLink *does* implement the Remote Asset API (`FetchServer` / `PushServer`,
+`build.bazel.remote.asset.v1`), so the obvious question is why we don't point
+`--experimental_remote_downloader` at `:50051` and drop bazel-remote. The reason is
+*how* each implements `FetchBlob`:
+
+- **NativeLink's Fetch is push-then-serve.** `fetch_blob` (nativelink-service
+  `fetch_server.rs`) hashes the URI + qualifiers to a digest, does a single store
+  lookup, and on a miss returns `NotFound` — it never contacts the upstream. It only
+  serves assets that were *explicitly pushed* into its `fetch_store` first. (Its only
+  `reqwest` HTTP client backs the GCS store, not URL fetching.)
+- **bazel-remote's Fetch is a transparent proxy.** On a miss it fetches the URL
+  itself, verifies the `sha256` qualifier, stores the blob, and serves it thereafter.
+
+`--experimental_remote_downloader` relies on the proxy behavior — it expects the
+endpoint to transparently mirror `http_archive` tarballs on first use. Replacing
+bazel-remote with NativeLink's FetchServer would mean building a separate warming
+pipeline that fetches every external dependency and pushes it (blob + asset mapping)
+into NativeLink ahead of the build, i.e. reimplementing bazel-remote's proxy logic.
+So the two services are not redundant: NativeLink caches and runs *build actions*
+(AC/CAS + executor); bazel-remote transparently mirrors *source downloads*. (Verified
+against NativeLink v1.5.2 — revisit if a later release adds proxy-fetch-on-miss.)
+
 ### GitHub Actions wiring
 
 The `.github/actions/bazel-rbe` composite action encapsulates all RBE wiring:

--- a/infra/nativelink/startup.sh
+++ b/infra/nativelink/startup.sh
@@ -199,9 +199,13 @@ NLUNIT
 
 systemctl daemon-reload
 systemctl enable nativelink.service
-# --no-block: the blocking cert-fetch ExecStartPre runs in the background while
-# this script finishes. Only start if not already active (idempotent re-runs).
-systemctl is-active --quiet nativelink.service || systemctl start --no-block nativelink.service
+# restart, NOT `is-active || start`: on every boot the enabled service
+# auto-starts early from the unit file as it existed at boot time, which is
+# BEFORE this script rewrites it — so a plain `start` is a no-op and unit changes
+# from this run never reach the running process. `restart` forces the
+# freshly-written unit to take effect. --no-block so the blocking cert-fetch
+# ExecStartPre runs in the background instead of hanging this script.
+systemctl restart --no-block nativelink.service
 
 # --- 4c. bazel-remote systemd unit (download cache) --------------------------
 # Reuses NativeLink's mTLS material: the server cert's IP SAN is the VM's static
@@ -255,7 +259,11 @@ BRUNIT
 
 systemctl daemon-reload
 systemctl enable bazel-remote.service
-systemctl is-active --quiet bazel-remote.service || systemctl start --no-block bazel-remote.service
+# restart (see the nativelink unit above): forces the freshly-written unit to
+# take effect even when the enabled service already auto-started early in boot
+# from the previous on-disk unit. --no-block so the cert-wait ExecStartPre
+# doesn't hang this script.
+systemctl restart --no-block bazel-remote.service
 
 # --- 5. Cloud Ops Agent (guest metrics + systemd journal → Cloud Mon/Logging) -
 # Makes the VM observable without SSH: host metrics (memory, per-filesystem disk %)

--- a/infra/nativelink/startup.sh
+++ b/infra/nativelink/startup.sh
@@ -208,6 +208,11 @@ systemctl enable nativelink.service
 systemctl restart --no-block nativelink.service
 
 # --- 4c. bazel-remote systemd unit (download cache) --------------------------
+# Why a separate service and not NativeLink's own Remote Asset API: NativeLink's
+# Fetch is push-then-serve (returns NotFound on a miss, never contacts the
+# upstream), whereas --experimental_remote_downloader needs proxy-fetch-on-miss,
+# which bazel-remote provides. See docs/src/development/rbe.md ("Why a separate
+# bazel-remote, not just NativeLink").
 # Reuses NativeLink's mTLS material: the server cert's IP SAN is the VM's static
 # IP, so it's valid on :50052 too; --tls_ca_file enforces mTLS with the same
 # client CA (one client cert authenticates to both :50051 and :50052). Its own

--- a/infra/nativelink/startup.sh
+++ b/infra/nativelink/startup.sh
@@ -242,14 +242,19 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectHome=true
 ProtectSystem=full
-# Whitelist the mount POINT, not the /bazel-remote subdir: under ProtectSystem=full,
-# a ReadWritePaths that targets a subdirectory of a separate mount (/mnt/slow is its
-# own disk) does not actually grant write — file creation there returns EPERM, so
-# every CAS Put silently fails and the download cache stores nothing. The nativelink
-# unit whitelists /mnt/slow itself and writes fine; match that.
+# Whitelist the mount point (consistent with the nativelink unit; the narrower
+# /mnt/slow/bazel-remote subdir would work too).
 ReadWritePaths=/mnt/slow
 ProtectControlGroups=true
-RestrictSUIDSGID=true
+# RestrictSUIDSGID is intentionally NOT set here (it IS set on the nativelink unit
+# below). bazel-remote v2.6.1 creates its CAS temp files with the setgid bit
+# (utils/tempfile/tempfile.go: `wipMode = FinalMode | os.ModeSetgid`, a leftover
+# incomplete-file marker). RestrictSUIDSGID installs a seccomp filter that returns
+# EPERM on any openat(O_CREAT) whose mode carries setgid — so it breaks EVERY cache
+# write ("failed to Put … operation not permitted") and the download cache stores
+# nothing. Upstream deleted the setgid code after v2.6.1 (commit a95bc52); restore
+# this line once we pin a bazel-remote release that includes that fix. nativelink
+# is unaffected — it writes files with plain 0664.
 CapabilityBoundingSet=
 AmbientCapabilities=
 


### PR DESCRIPTION
Makes the NativeLink VM's **bazel-remote download cache actually persist** —
it had never stored a single blob since the VM came up (every `Put` failed),
so every build re-fetched all `http_archive` tarballs and flaky upstreams
(jbigkit / cl.cam.ac.uk) intermittently broke CI.

## Root cause (confirmed against the deployed v2.6.1 source)

bazel-remote logged every fetch as `200 OK` then `failed to Put …: operation
not permitted`. The cause is a seccomp interaction:

- bazel-remote **v2.6.1** creates its CAS temp files with the **setgid bit**:
  `utils/tempfile/tempfile.go` → `wipMode = FinalMode | os.ModeSetgid` (0664|S_ISGID),
  a leftover "incomplete file" marker.
- The systemd unit set **`RestrictSUIDSGID=true`**, which installs a seccomp
  filter returning **EPERM** on any `openat(O_CREAT)` whose mode carries setgid.
- So every cache write failed before a byte was written — unconditionally
  (ownership / ReadWritePaths / capabilities are all irrelevant; the filter
  fires on syscall args). nativelink (Rust, plain `0664`) is immune, which is
  why it writes 125G to the same disk fine.

Upstream removed the setgid code after v2.6.1 (commit `a95bc52`), but there's no
release past v2.6.1 that includes it yet.

## Changes

1. **Drop `RestrictSUIDSGID=true` from the bazel-remote unit** (nativelink keeps
   it). This is the actual fix. Also corrects the inaccurate comment from the
   earlier ReadWritePaths change — that EPERM was the setgid/seccomp issue, not
   the subdir scope.
2. **`startup.sh` activates services with `systemctl restart --no-block`** (was
   `is-active || start`). On reboot the enabled service auto-starts early from
   the *previous* on-disk unit before `startup.sh` rewrites it; a plain `start`
   was a no-op, so unit changes never reached the running process. `restart`
   makes a reboot/re-image converge in one shot.

## Deploy + verify

From this branch (not merging until verified): `tofu -chdir=infra/nativelink apply`
→ `gcloud compute instances reset nativelink-rbe …`. Then verify read-only that
`cas.v2` accumulates blobs, `failed to Put` stays at zero, and a second build
serves jbigkit from cache with no cl.cam hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
