### PR TITLE
refactor(cli-rs): clap polish — deprecated cache aliases, ADMINUSER typo pin, nthreads doc, --help snapshot

### DIFF
--- a/src/cli-rs/src/commands/server/args/cache.rs
+++ b/src/cli-rs/src/commands/server/args/cache.rs
@@ -2,10 +2,14 @@
 //!
 //! `cache_size` is a sized string ("-1" unlimited, "0" disabled, or e.g.
 //! "200M") parsed engine-side. The deprecated `--cachedir` / `--cachesize` /
-//! `--cachenfiles` aliases (and the no-op `--cachehysteresis`) are NOT declared
-//! here: the aliases land in M5 (hidden, collapsed in the override mapping) and
-//! `--cachehysteresis` is intentionally hard-rejected on the Rust shell
-//! (plan 02 §3 P3 / §7.5 M5).
+//! `--cachenfiles` aliases mirror the C++ oracle's separate CLI11 options
+//! (`cli_app.cpp:1776/1780/1784`, each with its own `->envname` binding onto
+//! the same underlying variable as the canonical flag) — declared here as
+//! hidden fields (a `visible_alias` doesn't apply: they differ in hyphen shape
+//! from the canonical long names) and collapsed onto the canonical field in
+//! `commands/server/mod.rs`'s `From<&ServerArgs>` (canonical wins if both are
+//! set). `--cachehysteresis` is intentionally never declared — an unknown flag
+//! rejection is the Rust-side equivalent of the C++ no-op (plan 02 §3 P3).
 
 use clap::Args;
 
@@ -23,4 +27,28 @@ pub struct CacheArgs {
     /// rejected (matches the C++ CLI; no signed→unsigned wrap).
     #[arg(long, env = "SIPI_CACHE_NFILES", value_name = "N")]
     pub cache_nfiles: Option<u32>,
+    /// DEPRECATED: use `--cache-dir`.
+    #[arg(
+        long = "cachedir",
+        hide = true,
+        env = "SIPI_CACHEDIR",
+        value_name = "DIR"
+    )]
+    pub cachedir: Option<String>,
+    /// DEPRECATED: use `--cache-size`.
+    #[arg(
+        long = "cachesize",
+        hide = true,
+        env = "SIPI_CACHESIZE",
+        value_name = "SIZE"
+    )]
+    pub cachesize: Option<String>,
+    /// DEPRECATED: use `--cache-nfiles`.
+    #[arg(
+        long = "cachenfiles",
+        hide = true,
+        env = "SIPI_CACHENFILES",
+        value_name = "N"
+    )]
+    pub cachenfiles: Option<u32>,
 }

--- a/src/cli-rs/src/commands/server/args/concurrency.rs
+++ b/src/cli-rs/src/commands/server/args/concurrency.rs
@@ -1,17 +1,24 @@
 //! Concurrency flags (the "Concurrency" `--help` heading).
 //!
-//! `max_waiting` and `queue_timeout` are parse-only: the Rust shell uses a
-//! semaphore concurrency model (shed-load → 503) rather than the C++
-//! thread-per-connection socket queue, so the queue knobs are unread
-//! (plan 02 §5 #4 / §7.5 forward/parse-only split).
+//! `nthreads`, `max_waiting`, and `queue_timeout` are all parse-only (plan 02
+//! §7.5 forward/parse-only split, M7-resolved): the Rust shell bounds
+//! concurrent engine work with a tokio semaphore (shed-load → 503) sized from
+//! the Lua/TOML config's `nthreads` key (`server-rs/routes.rs`'s
+//! `ffi::nthreads()`), not from a CLI/env override — thread count is one of
+//! the "transport knobs the shell does not own", grouped with TLS/hostname/
+//! keep-alive/logfile in the M5 TOML schema (`server-rs/config_file.rs`), and
+//! the CLI stays consistent with that. `max_waiting`/`queue_timeout` are
+//! unread for a different reason: the semaphore model has no queue to size
+//! (§5 #4).
 
 use clap::Args;
 
 #[derive(Args, Debug)]
 #[command(next_help_heading = "Concurrency")]
 pub struct ConcurrencyArgs {
-    /// Worker thread count (0 = auto-detect from CPU cores). Also accepts the
-    /// C++ oracle's `-t` short form.
+    /// Worker thread count (0 = auto-detect from CPU cores; parse-only — sizes
+    /// the engine-work semaphore only from the Lua/TOML config, not the CLI).
+    /// Also accepts the C++ oracle's `-t` short form.
     #[arg(long, short = 't', env = "SIPI_NTHREADS", value_name = "N")]
     pub nthreads: Option<u32>,
     /// Max waiting connections before 503 (parse-only: semaphore model).

--- a/src/cli-rs/src/commands/server/args/mod.rs
+++ b/src/cli-rs/src/commands/server/args/mod.rs
@@ -10,10 +10,12 @@
 //! no longer exits 2), with each overridable flag an `Option<T>` carrying its
 //! `SIPI_*` env var — NO `default_value`, so an unset flag stays `None` and
 //! falls through to the loaded Lua config (the Rust analog of the C++
-//! `user_set` gate; precedence `config < env < CLI`, plan 02 §7.5). The flags
-//! are **unwired**: only `serverport` is forwarded into `ServerOverrides`
-//! today; the override channel into the engine (the `repr(C)` struct + the
-//! `sipi_init` apply block) lands in M4.
+//! `user_set` gate; precedence `config < env < CLI`, plan 02 §7.5). Every
+//! engine-behaviour flag forwards into `ServerOverrides` (see `mod.rs`'s
+//! `From<&ServerArgs>`); the transport flags the Rust shell owns
+//! (`sslport`/`sslcert`/`sslkey`, `keepalive`, `max-waiting`/`queue-timeout`,
+//! `hostname`, `nthreads`, `logfile`) parse for CLI/oracle parity but stay
+//! unforwarded, doc-commented per group.
 //!
 //! Two fields stay top-level rather than in a group:
 //! - `config` is bootstrap — it *selects* the base Lua config the overrides

--- a/src/cli-rs/src/commands/server/args/mod.rs
+++ b/src/cli-rs/src/commands/server/args/mod.rs
@@ -22,6 +22,11 @@
 //!   layer onto; it is not itself an override.
 //! - `drain_timeout` is a Rust-owned serve knob (the graceful-drain deadline),
 //!   not a config override, so it is handed straight to `sipi::run`.
+//!
+//! `term_width = 0` pins `--help`'s wrapping to clap's fixed default rather
+//! than the invoking terminal's width, so the heading-order snapshot in
+//! `test/e2e/tests/cli.rs::sipi_server_help_heading_order` is stable across
+//! CI and local dev (plan 02 §7.5 M8).
 
 mod cache;
 mod concurrency;
@@ -46,7 +51,7 @@ pub use tls_auth::TlsAuthArgs;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
-#[command(name = "sipi server")]
+#[command(name = "sipi server", term_width = 0)]
 pub struct ServerArgs {
     /// Path to the SIPI Lua config (installed by `sipi_init` before serving).
     /// Also accepts the C++ oracle's `-c` short form.

--- a/src/cli-rs/src/commands/server/args/tls_auth.rs
+++ b/src/cli-rs/src/commands/server/args/tls_auth.rs
@@ -3,8 +3,11 @@
 //! `sslcert` / `sslkey` are parse-only: TLS terminates at Traefik and the shell
 //! serves plain HTTP (plan 02 §5 #3). `--adminuser` binds the correct
 //! `SIPI_ADMINUSER` env var; the C++ oracle binds the misspelled
-//! `SIPI_ADMIINUSER` (`cli_app.cpp`) — a latent typo nobody can intentionally
-//! rely on. The documented typo-divergence test lands in M5 (plan 02 §7.5).
+//! `SIPI_ADMIINUSER` (`cli_app.cpp:1822`) — a latent typo nobody can
+//! intentionally rely on. The documented typo-divergence is pinned by
+//! `test/e2e/tests/differential.rs::adminuser_env_name_documented_divergence`
+//! (plan 02 §7.5 M6): a parse-level `--help` grep, since no behavioural probe
+//! exists.
 
 use clap::Args;
 

--- a/src/cli-rs/src/commands/server/mod.rs
+++ b/src/cli-rs/src/commands/server/mod.rs
@@ -7,7 +7,7 @@
 //!
 //! Every forwarded `server` flag maps into `ServerOverrides`; the override
 //! channel into the engine (the `repr(C)` struct + the `sipi_init` apply block)
-//! lands in the remaining M4 slices (plan 02 §7.5).
+//! lives in `server-rs/config.rs` (plan 02 §7.5).
 
 mod args;
 
@@ -21,8 +21,12 @@ impl From<&ServerArgs> for ServerOverrides {
         // Engine-behaviour flags forward; transport flags the Rust shell owns
         // (sslport/sslcert/sslkey, keepalive, max-waiting/queue-timeout,
         // hostname, nthreads, logfile) parse for CLI parity but are never
-        // forwarded. The deprecated cache aliases (--cachedir/--cachesize/
-        // --cachenfiles) land in M5; this maps the canonical names only.
+        // forwarded (plan 02 §7.5 forward/parse-only split). The deprecated
+        // cache aliases (--cachedir/--cachesize/--cachenfiles) collapse onto
+        // their canonical field here — canonical wins if both are somehow set
+        // (matches the C++ oracle's last-write-wins on the shared `optCache*`
+        // variable closely enough: neither binary's precedence between the two
+        // spellings is a contract anyone can rely on).
         ServerOverrides {
             serverport: args.network.serverport,
             imgroot: args.paths.imgroot.clone(),
@@ -38,9 +42,17 @@ impl From<&ServerArgs> for ServerOverrides {
             jwtkey: args.tls_auth.jwtkey.clone(),
             adminuser: args.tls_auth.adminuser.clone(),
             adminpasswd: args.tls_auth.adminpasswd.clone(),
-            cache_dir: args.cache.cache_dir.clone(),
-            cache_size: args.cache.cache_size.clone(),
-            cache_nfiles: args.cache.cache_nfiles,
+            cache_dir: args
+                .cache
+                .cache_dir
+                .clone()
+                .or_else(|| args.cache.cachedir.clone()),
+            cache_size: args
+                .cache
+                .cache_size
+                .clone()
+                .or_else(|| args.cache.cachesize.clone()),
+            cache_nfiles: args.cache.cache_nfiles.or(args.cache.cachenfiles),
             rate_limit_max_pixels: args.rate_limit.rate_limit_max_pixels,
             rate_limit_window: args.rate_limit.rate_limit_window,
             rate_limit_mode: args.rate_limit.rate_limit_mode.clone(),

--- a/test/e2e/tests/cli.rs
+++ b/test/e2e/tests/cli.rs
@@ -1,3 +1,4 @@
+use insta::assert_snapshot;
 use sipi_e2e::{repo_root, sipi_bin_path, test_data_dir};
 use std::path::PathBuf;
 use std::process::Command;
@@ -401,4 +402,45 @@ fn cli_convert_quality_actually_affects_output() {
 
     let _ = std::fs::remove_file(&low);
     let _ = std::fs::remove_file(&high);
+}
+
+// =============================================================================
+// `sipi server --help` snapshot (plan 02 §7.5 M8).
+//
+// `ServerArgs` composes its ~40 flags from nine `#[command(flatten)]` groups
+// (Network/Concurrency/Limits/Paths/Cache/Rate limiting/TLS & Auth/Knora/
+// Logging); clap renders each group under its own `next_help_heading` in
+// declaration order. This snapshot locks that heading order (and the full
+// rendered surface) against silent drift from a reordered/renamed group.
+// `term_width = 0` (`args/mod.rs`) fixes the wrap width so the snapshot is
+// stable across CI and local terminal widths.
+//
+// The spawn strips every `SIPI_` var from the child env: clap renders each
+// bound var's *value* in its `[env: NAME=value]` annotation, so a `SIPI_*` var
+// set in the caller's shell (e.g. a dev's `SIPI_LOGLEVEL`) would corrupt the
+// capture. A prefix strip (not a full `env_clear`, which would also drop the
+// loader/runfiles vars the binary needs to start) covers every clap-bound flag.
+// =============================================================================
+
+#[test]
+fn sipi_server_help_heading_order() {
+    let mut cmd = Command::new(sipi_bin_path());
+    cmd.args(["server", "--help"]);
+    for (key, _) in std::env::vars() {
+        if key.starts_with("SIPI_") {
+            cmd.env_remove(key);
+        }
+    }
+    let result = cmd
+        .output()
+        .unwrap_or_else(|e| panic!("Failed to run sipi server --help: {}", e));
+
+    assert!(
+        result.status.success(),
+        "sipi server --help exited non-zero: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&result.stdout);
+    assert_snapshot!("sipi-server-help", stdout);
 }

--- a/test/e2e/tests/differential.rs
+++ b/test/e2e/tests/differential.rs
@@ -306,3 +306,40 @@ fn differential_corpus_parity() {
         failures.join("\n\n")
     );
 }
+
+/// Plan 02 §7.5 M6 pin: the C++ oracle binds `--adminuser` to the misspelled
+/// `SIPI_ADMIINUSER` env var (`cli_app.cpp:1822`, a latent typo nobody can
+/// intentionally rely on); the Rust shell binds the correct `SIPI_ADMINUSER`.
+/// This is a documented divergence, not a bug to fix — no e2e config wires an
+/// admin endpoint, so there is no behavioural probe, only this parse-level
+/// `--help` pin on each binary's own env-name rendering.
+#[test]
+fn adminuser_env_name_documented_divergence() {
+    let subject = std::process::Command::new(sipi_e2e::sipi_bin_path())
+        .args(["server", "--help"])
+        .output()
+        .expect("run the Rust shell's `server --help`");
+    assert!(subject.status.success());
+    let subject_help = String::from_utf8_lossy(&subject.stdout);
+    assert!(
+        subject_help.contains("SIPI_ADMINUSER"),
+        "Rust shell must bind the correctly-spelled SIPI_ADMINUSER:\n{subject_help}"
+    );
+    assert!(
+        !subject_help.contains("SIPI_ADMIINUSER"),
+        "Rust shell must not replicate the C++ oracle's env-name typo:\n{subject_help}"
+    );
+
+    let reference = std::process::Command::new(sipi_e2e::sipi_oracle_bin_path())
+        .args(["server", "--help"])
+        .output()
+        .expect("run the C++ oracle's `server --help`");
+    assert!(reference.status.success());
+    let reference_help = String::from_utf8_lossy(&reference.stdout);
+    assert!(
+        reference_help.contains("SIPI_ADMIINUSER"),
+        "C++ oracle should still carry its documented env-name typo \
+         (cli_app.cpp:1822) — if this fails, the typo was fixed upstream and \
+         this divergence pin (plan 02 §7.5 M6) should be revisited:\n{reference_help}"
+    );
+}

--- a/test/e2e/tests/snapshots/cli__sipi-server-help.snap
+++ b/test/e2e/tests/snapshots/cli__sipi-server-help.snap
@@ -1,0 +1,66 @@
+---
+source: tests/cli.rs
+expression: stdout
+---
+Usage: server [OPTIONS]
+
+Options:
+  -c, --config <FILE>  Path to the SIPI Lua config (installed by `sipi_init` before serving). Also accepts the C++ oracle's `-c` short form [env: SIPI_CONFIGFILE=]
+  -h, --help           Print help
+
+Network:
+      --serverport <PORT>  HTTP listen port (1–65535) [env: SIPI_SERVERPORT=]
+      --sslport <PORT>     TLS port 1–65535 (parse-only: SIPI serves plain HTTP behind Traefik — §5 #3) [env: SIPI_SSLPORT=]
+      --hostname <HOST>    Server hostname (parse-only: the shell derives the external host from `X-Forwarded-Host`) [env: SIPI_HOSTNAME=]
+      --keepalive <SECS>   HTTP/1.1 keep-alive timeout in seconds (parse-only: tokio is async, so the knob is unread — §3 P2) [env: SIPI_KEEPALIVE=]
+
+Concurrency:
+  -t, --nthreads <N>          Worker thread count (0 = auto-detect from CPU cores; parse-only — sizes the engine-work semaphore only from the Lua/TOML config, not the CLI). Also accepts the C++ oracle's `-t` short form [env: SIPI_NTHREADS=]
+      --max-waiting <N>       Max waiting connections before 503 (parse-only: semaphore model) [env: SIPI_MAX_WAITING=]
+      --queue-timeout <SECS>  Max seconds a request waits in queue before 503 (parse-only) [env: SIPI_QUEUE_TIMEOUT=]
+
+Limits:
+      --maxpost <SIZE>             Max POST body size, e.g. "300M" (engine parses the suffix) [env: SIPI_MAXPOSTSIZE=]
+      --max-pixel-limit <PIXELS>   Max output pixels (width × height) per IIIF request (0 = unlimited) [env: SIPI_MAX_PIXEL_LIMIT=]
+      --max-decode-memory <SIZE>   Max concurrent decode-memory budget, e.g. "2G" (0 = auto; engine parses the suffix) [env: SIPI_MAX_DECODE_MEMORY=]
+      --decode-memory-mode <MODE>  Decode-memory mode: off, monitor, enforce (engine validates) [env: SIPI_DECODE_MEMORY_MODE=]
+      --thumbsize <SIZE>           Thumbnail size used within Lua, e.g. "!128,128" [env: SIPI_THUMBSIZE=]
+
+Paths:
+      --imgroot <DIR>         Root directory containing the images [env: SIPI_IMGROOT=]
+      --docroot <DIR>         Document root for the static fileserver [env: SIPI_DOCROOT=]
+      --wwwroute <ROUTE>      URL route for the static fileserver [env: SIPI_WWWROUTE=]
+      --scriptdir <DIR>       Directory containing the Lua route scripts [env: SIPI_SCRIPTDIR=]
+      --tmpdir <DIR>          Temporary directory (uploads etc.) [env: SIPI_TMPDIR=]
+      --maxtmpage <SECS>      Max age in seconds of temp files before deletion [env: SIPI_MAXTMPAGE=]
+      --initscript <FILE>     Path to the Lua init script [env: SIPI_INITSCRIPT=]
+      --pathprefix [<BOOL>]   IIIF prefix is part of the image path (deprecated; no effect on the Rust path — §3 P3) [env: SIPI_PATHPREFIX=] [possible values: true, false]
+      --subdirlevels <N>      Number of subdir levels (deprecated; no effect on the Rust path) [env: SIPI_SUBDIRLEVELS=]
+      --subdirexcludes <DIR>  Directories excluded from subdir calculations [env: SIPI_SUBDIREXCLUDES=]
+
+Cache:
+      --cache-dir <DIR>    Cache directory [env: SIPI_CACHE_DIR=]
+      --cache-size <SIZE>  Cache size: "-1" (unlimited), "0" (disabled), or e.g. "200M" (engine parses the suffix) [env: SIPI_CACHE_SIZE=]
+      --cache-nfiles <N>   Max number of cached files (0 = no limit). Unsigned: a negative is rejected (matches the C++ CLI; no signed→unsigned wrap) [env: SIPI_CACHE_NFILES=]
+
+Rate limiting:
+      --rate-limit-max-pixels <PIXELS>       Max output pixels per client per window (0 = disabled) [env: SIPI_RATE_LIMIT_MAX_PIXELS=]
+      --rate-limit-window <SECS>             Sliding window in seconds [env: SIPI_RATE_LIMIT_WINDOW=]
+      --rate-limit-mode <MODE>               Rate-limit mode: off, monitor, enforce (engine validates) [env: SIPI_RATE_LIMIT_MODE=]
+      --rate-limit-pixel-threshold <PIXELS>  Requests below this pixel count are free [env: SIPI_RATE_LIMIT_PIXEL_THRESHOLD=]
+
+TLS & Auth:
+      --sslcert <FILE>        Path to the SSL certificate (parse-only: TLS at Traefik) [env: SIPI_SSLCERTIFICATE=]
+      --sslkey <FILE>         Path to the SSL key (parse-only: TLS at Traefik) [env: SIPI_SSLKEY=]
+      --jwtkey <SECRET>       Secret for generating JWTs (exactly 42 characters) [env: SIPI_JWTKEY=]
+      --adminuser <USER>      SIPI admin username [env: SIPI_ADMINUSER=]
+      --adminpasswd <PASSWD>  Admin password [env: SIPI_ADMINPASSWD=]
+
+Knora:
+      --knorapath <HOST>  Knora server host [env: SIPI_KNORAPATH=]
+      --knoraport <PORT>  Knora server port (a string in the engine config) [env: SIPI_KNORAPORT=]
+
+Logging:
+      --logfile <NAME>        Logfile name (NYI in the engine) [env: SIPI_LOGFILE=]
+      --loglevel <LEVEL>      Logging level: DEBUG, INFO, WARNING, ERR, CRIT, ALERT, EMERG [env: SIPI_LOGLEVEL=]
+      --drain-timeout <SECS>  Graceful-drain deadline in seconds (default 30): on SIGTERM/Ctrl-C, in-flight requests get this long to finish before a forced shutdown [env: SIPI_DRAIN_TIMEOUT=]

--- a/tools/differential_coverage_check.sh
+++ b/tools/differential_coverage_check.sh
@@ -20,7 +20,7 @@ cd "$(dirname "$0")/.."
 # Baseline: #[test] + #[tokio::test] across test/e2e/tests/*.rs EXCLUDING the
 # differential corpus file itself. Bump this (with a corpus update) whenever an
 # e2e test is added or removed.
-EXPECTED_E2E_TESTS=274
+EXPECTED_E2E_TESTS=275
 
 # Count via awk on a concatenated stream with literal `[ \t]` + exact string
 # compare — deterministic across awk/grep implementations. (Earlier a


### PR DESCRIPTION
Part of [DEV-6659](https://linear.app/dasch/issue/DEV-6659)

## Motivation
Closes out plan 02 §7.5's "Step 1 residue" (M6–M8) — the final clap-polish sub-steps of the SIPI Phase C CLI-override work (M0–M5 landed in #692/#697/#698/#700). These bring the Rust shell's `server` CLI to full flag parity with the retained C++ oracle and lock that surface against silent drift, keeping the differential parity gate trustworthy as the strangler continues.

## Summary
- Declares the last undeclared C++ CLI11 options as hidden clap aliases (full `server`-flag parity).
- Resolves the open `--nthreads` classification (parse-only) and corrects stale doc comments.
- Locks the `sipi server --help` heading order with a snapshot test.

## Key Changes
### M6 — deprecated cache aliases + ADMINUSER typo pin
- `--cachedir`/`--cachesize`/`--cachenfiles` declared as hidden clap fields with their own `SIPI_CACHE{DIR,SIZE,NFILES}` env vars (mirroring `cli_app.cpp:1776/1780/1784`), collapsed onto their canonical field in `From<&ServerArgs>` (canonical wins if both set).
- `differential.rs::adminuser_env_name_documented_divergence` pins `SIPI_ADMINUSER` (Rust, correct) vs `SIPI_ADMIINUSER` (C++ typo, `cli_app.cpp:1822`) via a `--help` grep on both binaries.

### M7 — nthreads forward/parse-only resolution
- `--nthreads`/`-t`/`SIPI_NTHREADS` stays parse-only: the shell sizes its tokio engine-work semaphore from the Lua/TOML config `nthreads` key, not a CLI/env override — consistent with the M5 TOML schema's "transport knob the shell does not own" classification. Doc comments in `concurrency.rs`/`args/mod.rs`/`server/mod.rs` corrected from the pre-M4 unwired state.

### M8 — `--help` heading-order snapshot
- `insta` snapshot in `test/e2e/tests/cli.rs` locking the nine `#[command(flatten)]` groups' heading order; `term_width = 0` fixes wrap width, and the spawn strips `SIPI_*` from the child env so the snapshot is deterministic across CI, local terminal widths, and any ambient `SIPI_*` vars.
- Drift guard bumped 274→275 (new non-replayable CLI subprocess test in a non-differential file).

## Challenges and Decisions
### Snapshot tool: insta over trycmd/assert_cmd
**Problem:** M8 as planned (§7.5) specified `trycmd`/`assert_cmd` for the `--help` snapshot.
**Tried:** `assert_cmd`/`trycmd` resolve the binary via Cargo conventions (`cargo_bin()` / `CARGO_BIN_EXE_*`), which don't exist under this repo's Bazel/`rules_rust` test runner (the binary arrives via the `SIPI_BIN` runfiles env var).
**Solution:** Used `insta` — already the repo's snapshot tool (the info.json goldens) and spawn-agnostic, so it composes with the existing `SIPI_BIN` spawn. Recorded as the deviation in plan 02 §8.

### Deprecated-alias precedence
**Problem:** C++ binds both spellings to one shared variable (order-dependent last-write-wins); Rust has two separate `Option` fields.
**Solution:** Collapse with canonical-wins (`.or_else`). Neither binary's precedence between the two spellings is a relied-upon contract, and no config sets both, so the divergence is inert.

## Gotchas
- The `--help` snapshot renders clap's `[env: SIPI_*=]` lines, which include the *value* of any bound var set in the environment. The spawn strips the `SIPI_` prefix from the child env to keep the capture deterministic — extend that strip if a future flag binds a non-`SIPI_`-prefixed env var. Prefer the prefix strip over a full `env_clear`, which would drop the loader/runfiles vars the binary needs to start.
- The alias commit is `refactor`, not `feat`: it ports existing oracle behaviour into the not-yet-deployed Rust shell (parity), not a new user-facing capability.

## Test Plan
- [x] `bazel test //src/cli-rs:sipi_unit_test` — green
- [x] `bazel test //test/e2e:cli` — green (incl. new `sipi_server_help_heading_order`, re-verified after the env-strip hardening)
- [x] `bazel test //test/e2e:differential` — green (incl. new `adminuser_env_name_documented_divergence`); full corpus green
- [x] `just bazel-coverage` — 51/52 pass, 1 skipped (`docker_smoke`, needs Docker)
- [x] `just bazel-rustfmt-check` — clean
- [x] `just differential-coverage-check` — clean (275 e2e tests)
