### PR TITLE
feat(server-rs): Phase C step 2 — §7.7 flag matrix + sipi_port fallback (§6 R3)

### DIFF
--- a/src/cli-rs/src/commands/server/args/paths.rs
+++ b/src/cli-rs/src/commands/server/args/paths.rs
@@ -1,8 +1,11 @@
 //! Filesystem path + path-resolution flags (the "Paths" `--help` heading).
 //!
-//! `pathprefix` and `subdirlevels` are deprecated and have no effect on the
-//! Rust serve path (plan 02 §3 P3); they parse for oracle parity. `pathprefix`
-//! is flag-shaped on the C++ side (a bare `--pathprefix` means "true"), so it
+//! `subdirlevels` is deprecated and has no effect on the Rust serve path (plan
+//! 02 §3 P3); it parses for oracle parity. `pathprefix` DOES have an effect —
+//! `routes.rs` reads `prefix_as_path` off the engine context to decide whether
+//! the IIIF prefix is a path component under imgroot (plan 02 §7.7, the
+//! previously-untested `prefix_as_path = false` branch). `pathprefix` is
+//! flag-shaped on the C++ side (a bare `--pathprefix` means "true"), so it
 //! takes an optional value here (`--pathprefix` → true, `--pathprefix=false` →
 //! false, absent → fall through to the config).
 
@@ -32,8 +35,9 @@ pub struct PathArgs {
     /// Path to the Lua init script.
     #[arg(long, env = "SIPI_INITSCRIPT", value_name = "FILE")]
     pub initscript: Option<String>,
-    /// IIIF prefix is part of the image path (deprecated; no effect on the Rust
-    /// path — §3 P3).
+    /// IIIF prefix is part of the image path (deprecated on the C++ oracle;
+    /// still honoured on the Rust serve path via `routes.rs`'s
+    /// `prefix_as_path`).
     #[arg(
         long,
         env = "SIPI_PATHPREFIX",

--- a/src/cli/cli_app.cpp
+++ b/src/cli/cli_app.cpp
@@ -666,6 +666,7 @@ extern "C" int sipi_init(const char *lua_config_path, const SipiServerConfig *ov
       .max_pixel_limit = conf.getMaxPixelLimit(),
       .nthreads = static_cast<int>(conf.getNThreads()),
       .max_post_size = conf.getMaxPostSize(),
+      .port = conf.getPort(),
     });
 
     // Install the engine-held Lua config (the per-call VM factory behind

--- a/src/cli/cli_app.cpp
+++ b/src/cli/cli_app.cpp
@@ -665,8 +665,8 @@ extern "C" int sipi_init(const char *lua_config_path, const SipiServerConfig *ov
       .scaling_quality = to_scaling_quality(conf.getScalingQuality()),
       .max_pixel_limit = conf.getMaxPixelLimit(),
       .nthreads = static_cast<int>(conf.getNThreads()),
-      .max_post_size = conf.getMaxPostSize(),
       .port = conf.getPort(),
+      .max_post_size = conf.getMaxPostSize(),
     });
 
     // Install the engine-held Lua config (the per-call VM factory behind

--- a/src/ffi/engine_context.h
+++ b/src/ffi/engine_context.h
@@ -51,6 +51,7 @@ struct EngineContext
   ScalingQuality scaling_quality{};//!< per-format scaling method
   std::size_t max_pixel_limit = 0;//!< max output pixels per request (0 = unlimited)
   int nthreads = 0;//!< configured worker-thread count; 0 = auto (the shell sizes its pool from host parallelism)
+  int port = 3333;//!< configured HTTP listen port (the Lua config `sipi.port`); a fallback for the Rust edge's listener bind when no `--serverport`/`SIPI_SERVERPORT`/`SIPI_RS_PORT` selected one (plan 02 §6 R3)
   std::size_t max_post_size = 0;//!< max POST body size in bytes (the Rust shell caps Lua-route uploads); 0 = unlimited
 };
 

--- a/src/ffi/sipi_ffi.cpp
+++ b/src/ffi/sipi_ffi.cpp
@@ -279,6 +279,17 @@ int sipi_max_post_size(size_t *out)
   });
 }
 
+int sipi_port(int *out)
+{
+  // Guard-only edge probe — a pure read of the installed engine context, like
+  // sipi_nthreads. The Rust edge uses this only as a fallback below
+  // --serverport/SIPI_SERVERPORT/SIPI_RS_PORT (plan 02 §6 R3).
+  return Sipi::ffi::sipi_guard([&] {
+    *out = Sipi::ffi::engine_context().port;
+    return static_cast<int>(Sipi::ffi::SipiStatus::Ok);
+  });
+}
+
 int sipi_image_dims(const char *resolved_path, SipiImageDims *out)
 {
   // Header-only shape read. The Rust edge owns existence + containment (R1/R2)

--- a/src/ffi/sipi_ffi.h
+++ b/src/ffi/sipi_ffi.h
@@ -532,6 +532,12 @@ SIPI_FFI_NODISCARD int sipi_nthreads(int *out);
  *  `*out` = 0 means unlimited. Returns 0, or 500 if `sipi_init` has not run. */
 SIPI_FFI_NODISCARD int sipi_max_post_size(size_t *out);
 
+/*! The configured HTTP listen port (the Lua config `sipi.port`). The Rust edge
+ *  falls back to this only when neither `--serverport`/`SIPI_SERVERPORT` nor
+ *  the dev/test `SIPI_RS_PORT` selected a port (plan 02 §6 R3). Returns 0, or
+ *  500 if `sipi_init` has not run. */
+SIPI_FFI_NODISCARD int sipi_port(int *out);
+
 /*! Header-only image-shape probe (`SipiImage::read_shape` — no full decode).
  *  `resolved_path` is an already-validated absolute path (the Rust edge owns
  *  existence + containment). Fills `*out` on success. Returns 0, or 500 if the

--- a/src/server-rs/src/config.rs
+++ b/src/server-rs/src/config.rs
@@ -31,7 +31,11 @@ use std::os::raw::{c_char, c_int};
 #[derive(Debug, Default, Clone)]
 pub struct ServerOverrides {
     /// HTTP listen port (`--serverport` / `SIPI_SERVERPORT`). `None` → fall back
-    /// to `SIPI_RS_PORT` (dev/test) then the default port.
+    /// to the Lua config's `sipi.port` (Lua config only), then the hardcoded
+    /// default. `serve()`'s actual resolution order (`lib.rs`) is
+    /// `SIPI_RS_PORT` (dev/test) > this field > Lua config port > default —
+    /// `SIPI_RS_PORT` is checked first, ahead of this field, not after it
+    /// (plan 02 §6 R3).
     pub serverport: Option<u16>,
 
     // Paths

--- a/src/server-rs/src/ffi.rs
+++ b/src/server-rs/src/ffi.rs
@@ -257,6 +257,11 @@ extern "C" {
     /// Returns 0, or 500 if `sipi_init` has not run.
     pub fn sipi_max_post_size(out: *mut usize) -> c_int;
 
+    /// The configured HTTP listen port (the Lua config `sipi.port`); a
+    /// fallback below `--serverport`/`SIPI_SERVERPORT`/`SIPI_RS_PORT` (plan 02
+    /// §6 R3). Returns 0, or 500 if `sipi_init` has not run.
+    pub fn sipi_port(out: *mut c_int) -> c_int;
+
     /// Enumerate the configured Lua routes (method/route/script) installed by
     /// `sipi_init`, one `emit` call per route. Returns 0, or 500 if `sipi_init`
     /// has not run.
@@ -539,6 +544,19 @@ pub fn max_post_size() -> Result<usize, i32> {
         return Err(code);
     }
     Ok(v)
+}
+
+/// The configured HTTP listen port (the Lua config `sipi.port`). Used only as
+/// a fallback below `--serverport`/`SIPI_SERVERPORT`/`SIPI_RS_PORT` (plan 02
+/// §6 R3). `Err` carries the FFI status (500 if `sipi_init` has not run).
+pub fn port() -> Result<u16, i32> {
+    let mut v: c_int = 0;
+    // SAFETY: `out` is a valid pointer; the seam guards exceptions.
+    let code = unsafe { sipi_port(&mut v) };
+    if code != 0 {
+        return Err(code);
+    }
+    Ok(v.clamp(0, i32::from(u16::MAX)) as u16)
 }
 
 /// One configured Lua route: HTTP method, the route prefix, and the resolved

--- a/src/server-rs/src/lib.rs
+++ b/src/server-rs/src/lib.rs
@@ -100,60 +100,73 @@ async fn server_main(
     // into the override channel (Lua-less init; routes are sourced here); a `.lua`
     // path (or none) uses the engine's Lua VM as before. `effective` is the
     // overrides after the TOML base + CLI/env merge, used for the listen port.
-    let (effective, configured_routes): (ServerOverrides, Option<Vec<ffi::RouteEntry>>) =
-        match config.as_deref() {
-            Some(cfg) if cfg.ends_with(".toml") => {
-                // Experimental (ADR-0017): the native config format may change
-                // until it is validated in production.
-                tracing::warn!(
-                    "TOML config support is experimental; the schema may change \
-                     until it is validated in production"
-                );
-                let parsed = match config_file::Config::load(cfg) {
-                    Ok(c) => c,
-                    Err(e) => {
-                        tracing::error!(config = %cfg, error = %e, "invalid TOML config");
-                        flush_telemetry(otel).await;
-                        return ExitCode::FAILURE;
-                    }
-                };
-                let (effective, routes) = match parsed.resolve(overrides) {
-                    Ok(r) => r,
-                    Err(e) => {
-                        tracing::error!(config = %cfg, error = %e, "invalid TOML config");
-                        flush_telemetry(otel).await;
-                        return ExitCode::FAILURE;
-                    }
-                };
-                // Lua-less init: an empty path makes the engine default-construct
-                // its config; these overrides then supply every value.
-                if let Err(code) = ffi::init("", &effective) {
-                    tracing::error!(config = %cfg, code, "sipi_init failed");
+    // `lua_config_port` is the Lua config's `sipi.port` (plan 02 §6 R3) — set
+    // only on the Lua-config branch, where it is not otherwise reachable: the
+    // TOML branch already folds `[network].port` into `effective.serverport`
+    // via `resolve()`, and the no-config branch has no config to read.
+    let (effective, configured_routes, lua_config_port): (
+        ServerOverrides,
+        Option<Vec<ffi::RouteEntry>>,
+        Option<u16>,
+    ) = match config.as_deref() {
+        Some(cfg) if cfg.ends_with(".toml") => {
+            // Experimental (ADR-0017): the native config format may change
+            // until it is validated in production.
+            tracing::warn!(
+                "TOML config support is experimental; the schema may change \
+                 until it is validated in production"
+            );
+            let parsed = match config_file::Config::load(cfg) {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::error!(config = %cfg, error = %e, "invalid TOML config");
                     flush_telemetry(otel).await;
                     return ExitCode::FAILURE;
                 }
-                tracing::info!(config = %cfg, "engine installed (TOML config, Lua-less)");
-                (effective, Some(routes))
-            }
-            Some(cfg) => {
-                if let Err(code) = ffi::init(cfg, &overrides) {
-                    tracing::error!(config = %cfg, code, "sipi_init failed");
+            };
+            let (effective, routes) = match parsed.resolve(overrides) {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::error!(config = %cfg, error = %e, "invalid TOML config");
                     flush_telemetry(otel).await;
                     return ExitCode::FAILURE;
                 }
-                tracing::info!(config = %cfg, "engine + Lua config installed");
-                (overrides, None)
+            };
+            // Lua-less init: an empty path makes the engine default-construct
+            // its config; these overrides then supply every value.
+            if let Err(code) = ffi::init("", &effective) {
+                tracing::error!(config = %cfg, code, "sipi_init failed");
+                flush_telemetry(otel).await;
+                return ExitCode::FAILURE;
             }
-            None => {
-                tracing::warn!(
-                    "no --config: engine uninitialised; only /health and /favicon.ico will serve"
-                );
-                (overrides, None)
+            tracing::info!(config = %cfg, "engine installed (TOML config, Lua-less)");
+            (effective, Some(routes), None)
+        }
+        Some(cfg) => {
+            if let Err(code) = ffi::init(cfg, &overrides) {
+                tracing::error!(config = %cfg, code, "sipi_init failed");
+                flush_telemetry(otel).await;
+                return ExitCode::FAILURE;
             }
-        };
+            tracing::info!(config = %cfg, "engine + Lua config installed");
+            (overrides, None, ffi::port().ok())
+        }
+        None => {
+            tracing::warn!(
+                "no --config: engine uninitialised; only /health and /favicon.ico will serve"
+            );
+            (overrides, None, None)
+        }
+    };
 
     let drain_deadline = Duration::from_secs(drain_timeout.unwrap_or(30));
-    let result = serve(effective.serverport, drain_deadline, configured_routes).await;
+    let result = serve(
+        effective.serverport,
+        lua_config_port,
+        drain_deadline,
+        configured_routes,
+    )
+    .await;
 
     // Flush pending spans before the guard drops; the OTLP export is blocking
     // I/O, so do it off the async runtime.
@@ -239,6 +252,7 @@ pub fn app(state: Arc<routes::AppState>) -> Router {
 
 async fn serve(
     port: Option<u16>,
+    lua_config_port: Option<u16>,
     drain_timeout: Duration,
     configured_routes: Option<Vec<ffi::RouteEntry>>,
 ) -> std::io::Result<()> {
@@ -247,12 +261,17 @@ async fn serve(
     // `configured_routes` is `Some` for a TOML config (routes sourced Rust-side),
     // `None` for a Lua config (routes read back from the engine via the seam).
     let state = Arc::new(routes::AppState::load(configured_routes));
-    let port = port
-        .or_else(|| {
-            std::env::var("SIPI_RS_PORT")
-                .ok()
-                .and_then(|p| p.parse().ok())
-        })
+    // Precedence (plan 02 §6 R3): `SIPI_RS_PORT` (dev/test-only — lets the e2e
+    // harness spawn parallel shells without a `--serverport`) beats
+    // `--serverport`/`SIPI_SERVERPORT` (`port`, clap's own `CLI > env`), which
+    // beats the Lua config's `sipi.port` (`lua_config_port`, absent for a TOML
+    // config — already folded into `port` via `resolve()` — and for no config),
+    // which beats the hardcoded default.
+    let port = std::env::var("SIPI_RS_PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .or(port)
+        .or(lua_config_port)
         .unwrap_or(DEFAULT_PORT);
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
     let listener = tokio::net::TcpListener::bind(addr).await?;

--- a/src/server-rs/src/lib.rs
+++ b/src/server-rs/src/lib.rs
@@ -32,9 +32,12 @@ use std::process::ExitCode;
 use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
-/// Default listen port for the additive Rust shell. The real port will come
-/// from the SIPI config; until then it is overridable via `--serverport` or
-/// `SIPI_RS_PORT` so the parallel shell never collides with the C++ server.
+/// Last-resort listen port: used only when NONE of `SIPI_RS_PORT`,
+/// `--serverport`/`SIPI_SERVERPORT`, and (for a Lua config) the config's own
+/// `sipi.port` selected one. A Lua config that omits `port` entirely falls to
+/// `SipiConf`'s own in-class default (3333, `SipiConf.h`) one tier before this
+/// — that tier is never 1024, so an operator relying on this constant should
+/// set `port` explicitly (as every known config does; plan 02 §6 R3).
 const DEFAULT_PORT: u16 = 1024;
 
 /// Process start time, for the `/health` uptime field. Set once at server

--- a/test/_test_data/config/sipi.e2e-test-config.lua
+++ b/test/_test_data/config/sipi.e2e-test-config.lua
@@ -267,6 +267,11 @@ routes = {
     },
     {
         method = 'GET',
+        route = '/config_echo',
+        script = 'config_echo.lua'
+    },
+    {
+        method = 'GET',
         route = '/test_knora_session_cookie',
         script = 'test_knora_session_cookie.lua'
     },

--- a/test/_test_data/scripts/config_echo.lua
+++ b/test/_test_data/scripts/config_echo.lua
@@ -1,0 +1,11 @@
+-- Echoes a handful of `sipiConfGlobals`-installed config values as JSON.
+-- Used by the plan 02 §7.7 flag matrix to observe --thumbsize/--knorapath/
+-- --knoraport CLI/env overrides, which have no other HTTP-visible effect.
+
+require "send_response"
+
+send_success({
+    thumb_size = config.thumb_size,
+    knora_path = config.knora_path,
+    knora_port = config.knora_port
+})

--- a/test/e2e/src/lib.rs
+++ b/test/e2e/src/lib.rs
@@ -95,6 +95,7 @@ impl SipiServer {
             config,
             working_dir,
             extra_args,
+            &[],
         )
     }
 
@@ -108,12 +109,25 @@ impl SipiServer {
         working_dir: &Path,
         extra_args: &[&str],
     ) -> (SipiServer, SipiServer) {
+        Self::start_pair_env(config, working_dir, extra_args, &[])
+    }
+
+    /// Like [`Self::start_pair`], additionally setting `extra_env` in both
+    /// spawned processes' environment (e.g. to probe a `SIPI_*` env binding
+    /// per plan 02 §7.7).
+    pub fn start_pair_env(
+        config: &str,
+        working_dir: &Path,
+        extra_args: &[&str],
+        extra_env: &[(&str, &str)],
+    ) -> (SipiServer, SipiServer) {
         let subject = Self::spawn(
             sipi_bin_path(),
             ServerKind::Subject,
             config,
             working_dir,
             extra_args,
+            extra_env,
         );
         let reference = Self::spawn(
             sipi_oracle_bin_path(),
@@ -121,6 +135,36 @@ impl SipiServer {
             config,
             working_dir,
             extra_args,
+            extra_env,
+        );
+        (subject, reference)
+    }
+
+    /// Like [`Self::start_pair`], but the subject and reference get
+    /// DIFFERENT `extra_args` (e.g. each its own isolated `--cache-dir` so
+    /// two independent `SipiCache` instances never race on a shared
+    /// `.sipicache` index file — plan 02 §7.7's `cache-nfiles` probe).
+    pub fn start_pair_split(
+        config: &str,
+        working_dir: &Path,
+        subject_extra_args: &[&str],
+        reference_extra_args: &[&str],
+    ) -> (SipiServer, SipiServer) {
+        let subject = Self::spawn(
+            sipi_bin_path(),
+            ServerKind::Subject,
+            config,
+            working_dir,
+            subject_extra_args,
+            &[],
+        );
+        let reference = Self::spawn(
+            sipi_oracle_bin_path(),
+            ServerKind::Reference,
+            config,
+            working_dir,
+            reference_extra_args,
+            &[],
         );
         (subject, reference)
     }
@@ -133,6 +177,7 @@ impl SipiServer {
         config: &str,
         working_dir: &Path,
         extra_args: &[&str],
+        extra_env: &[(&str, &str)],
     ) -> Self {
         let (http_port, ssl_port) = allocate_ports();
 
@@ -144,14 +189,15 @@ impl SipiServer {
         kill_process_on_port(ssl_port);
 
         eprintln!(
-            "[test-harness] Starting {} sipi: bin={} config={} ports={}/{} cwd={} extra_args={:?}",
+            "[test-harness] Starting {} sipi: bin={} config={} ports={}/{} cwd={} extra_args={:?} extra_env={:?}",
             kind.label(),
             bin,
             config,
             http_port,
             ssl_port,
             working_dir.display(),
-            extra_args
+            extra_args,
+            extra_env
         );
 
         // `--drain-timeout 2` keeps every test's sipi shutdown bounded to ~2s
@@ -176,6 +222,7 @@ impl SipiServer {
         cmd.arg("--drain-timeout")
             .arg("2")
             .args(extra_args)
+            .envs(extra_env.iter().copied())
             .current_dir(working_dir)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());

--- a/test/e2e/src/lib.rs
+++ b/test/e2e/src/lib.rs
@@ -89,13 +89,56 @@ impl SipiServer {
     /// `extra_args` — additional CLI arguments appended after standard ones.
     ///                 CLI args override config values (CLI precedence).
     pub fn start_with_args(config: &str, working_dir: &Path, extra_args: &[&str]) -> Self {
+        Self::start_env(config, working_dir, extra_args, &[])
+    }
+
+    /// Like [`Self::start_with_args`], additionally setting `extra_env` in
+    /// the spawned process's environment.
+    pub fn start_env(
+        config: &str,
+        working_dir: &Path,
+        extra_args: &[&str],
+        extra_env: &[(&str, &str)],
+    ) -> Self {
         Self::spawn(
             sipi_bin_path(),
             ServerKind::Subject,
             config,
             working_dir,
             extra_args,
-            &[],
+            extra_env,
+        )
+    }
+
+    /// Start ONLY the C++ oracle (reference) — the reference-side counterpart
+    /// to [`Self::start_with_args`]. Use when a probe needs subject and
+    /// reference to access shared state (e.g. a `--cache-dir`) SEQUENTIALLY
+    /// rather than concurrently, to avoid two live `SipiCache` instances
+    /// racing on the same `.sipicache` index file (confirmed on CI to be a
+    /// real crash, not just a benign duplicate write — plan 02 §7.7).
+    pub fn start_reference_with_args(
+        config: &str,
+        working_dir: &Path,
+        extra_args: &[&str],
+    ) -> Self {
+        Self::start_reference_env(config, working_dir, extra_args, &[])
+    }
+
+    /// Like [`Self::start_reference_with_args`], additionally setting
+    /// `extra_env` in the spawned process's environment.
+    pub fn start_reference_env(
+        config: &str,
+        working_dir: &Path,
+        extra_args: &[&str],
+        extra_env: &[(&str, &str)],
+    ) -> Self {
+        Self::spawn(
+            sipi_oracle_bin_path(),
+            ServerKind::Reference,
+            config,
+            working_dir,
+            extra_args,
+            extra_env,
         )
     }
 

--- a/test/e2e/tests/differential.rs
+++ b/test/e2e/tests/differential.rs
@@ -364,6 +364,12 @@ fn adminuser_env_name_documented_divergence() {
 /// `--cache-size 0` (disables `SipiCache` construction entirely, sidestepping
 /// the hazard with no tempdir needed); this helper is only for the few that
 /// specifically want a *working* cache under a non-default `--cache-size`.
+///
+/// Its callers (the A-batches) still point subject and reference at the SAME
+/// isolated directory — only isolated from the long-lived shared `pair()`,
+/// not from each other. That is deliberately bounded: those tests assert
+/// response parity, never cache-directory contents, so two processes racing
+/// on `.sipicache` there can't produce a false pass.
 fn isolated_cache_dir() -> (tempfile::TempDir, String) {
     let dir = tempfile::tempdir().expect("isolated cache dir");
     let path = dir.path().to_str().expect("utf-8 path").to_owned();
@@ -375,6 +381,13 @@ fn isolated_cache_dir() -> (tempfile::TempDir, String) {
 /// Assert both binaries refuse to start under `extra_args`. Only the exit
 /// status is checked (nonzero) — NOT the error text or exact code, which
 /// differ by design (clap vs CLI11; plan 02 §7.7's bad-value-set note).
+///
+/// Exempt from the cache-isolation convention used elsewhere in this file
+/// (no `--cache-size 0` / isolated `--cache-dir`): every bad value here is
+/// rejected during CLI/env argument validation, before `sipi_init` — and
+/// therefore before any `SipiCache` — ever runs (confirmed empirically: both
+/// binaries exit within milliseconds, never touching the shared config's
+/// `cache_dir`).
 fn assert_both_reject_at_startup(extra_args: &[&str]) {
     for (label, bin) in [
         ("subject(rust)", sipi_e2e::sipi_bin_path()),
@@ -446,6 +459,15 @@ fn serverport_cli_beats_env_on_both() {
 /// config sets a baseline `cache_dir`; three pair-spawns request the same
 /// derivative and assert it lands under the expected tier's directory on
 /// BOTH binaries: config-only, +env (beats config), +env+CLI (beats env).
+///
+/// Unlike every other probe in this file, subject and reference here
+/// deliberately point at the SAME directory per tier — the whole point is
+/// proving both binaries resolve the identical override to the identical
+/// path, which two different directories couldn't show. This is the one
+/// place two live `SipiCache` instances share a directory; the risk is
+/// bounded (a couple of small requests per tier, then the pair is dropped)
+/// and the assertion only checks "is anything there", not an exact count,
+/// so interleaved writes from both processes can't produce a false pass.
 #[test]
 fn cache_dir_precedence_config_env_cli() {
     let base = tempfile::tempdir().expect("tempdir");
@@ -525,19 +547,30 @@ routes = {{}}
 /// cache write may lag a hair behind the HTTP response, §7.7's
 /// `cache-nfiles` row note).
 fn assert_cache_populated(dir: &std::path::Path, label: &str) {
+    let count = poll_cache_file_count(dir, |c| c > 0);
+    assert!(
+        count > 0,
+        "[{label}] expected cache file(s) under {} within 2s",
+        dir.display()
+    );
+}
+
+/// Poll `dir`'s file count until `stop` is satisfied or 2s elapses (a cache
+/// write may lag a hair behind the HTTP response, §7.7's `cache-nfiles` row
+/// note), returning the last sampled count either way.
+fn poll_cache_file_count(dir: &std::path::Path, stop: impl Fn(usize) -> bool) -> usize {
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
     loop {
-        let populated = std::fs::read_dir(dir)
-            .map(|entries| entries.filter_map(Result::ok).any(|e| e.path().is_file()))
-            .unwrap_or(false);
-        if populated {
-            return;
-        }
-        if std::time::Instant::now() >= deadline {
-            panic!(
-                "[{label}] expected cache file(s) under {} within 2s",
-                dir.display()
-            );
+        let count = std::fs::read_dir(dir)
+            .map(|entries| {
+                entries
+                    .filter_map(Result::ok)
+                    .filter(|e| e.path().is_file())
+                    .count()
+            })
+            .unwrap_or(0);
+        if stop(count) || std::time::Instant::now() >= deadline {
+            return count;
         }
         std::thread::sleep(std::time::Duration::from_millis(50));
     }
@@ -956,29 +989,11 @@ fn cache_nfiles_flag_honoured_on_both() {
         ("subject", subject_cache.path()),
         ("reference", reference_cache.path()),
     ] {
-        let count = count_files_with_retry(dir);
+        let count = poll_cache_file_count(dir, |c| c <= 1);
         assert!(
             count <= 1,
             "[{label}] --cache-nfiles 1 should bound the cache directory to \u{2264}1 file, found {count}"
         );
-    }
-}
-
-fn count_files_with_retry(dir: &std::path::Path) -> usize {
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
-    loop {
-        let count = std::fs::read_dir(dir)
-            .map(|entries| {
-                entries
-                    .filter_map(Result::ok)
-                    .filter(|e| e.path().is_file())
-                    .count()
-            })
-            .unwrap_or(0);
-        if count <= 1 || std::time::Instant::now() >= deadline {
-            return count;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(100));
     }
 }
 
@@ -1234,12 +1249,15 @@ fn a_batch_subject_only_flags_accepted() {
 /// mirroring `adminuser_env_name_documented_divergence`'s pattern.
 #[test]
 fn r3_lua_config_port_is_listener_fallback() {
-    const PORT: u16 = 19876;
+    // Draws from the same PID-offset counter every other spawn in this file
+    // uses, so this literal-port raw spawn can't collide with a concurrently
+    // running test binary the way a hardcoded port could.
+    let (port, _) = sipi_e2e::allocate_ports();
     let tmp = tempfile::tempdir().expect("tempdir");
     let cache_dir = tmp.path().join("cache");
     let config_content = format!(
         r#"sipi = {{
-    port = {PORT},
+    port = {port},
     nthreads = 2,
     jpeg_quality = 60,
     scaling_quality = {{ jpeg = "medium", tiff = "high", png = "high", j2k = "high" }},
@@ -1283,7 +1301,7 @@ routes = {{}}
     let mut ready = false;
     while std::time::Instant::now() < deadline {
         if sipi_e2e::http_client()
-            .get(format!("http://127.0.0.1:{PORT}/health"))
+            .get(format!("http://127.0.0.1:{port}/health"))
             .send()
             .map(|r| r.status().is_success())
             .unwrap_or(false)
@@ -1299,7 +1317,62 @@ routes = {{}}
 
     assert!(
         ready,
-        "the Rust shell must listen on the Lua config's `port` ({PORT}) when no \
+        "the Rust shell must listen on the Lua config's `port` ({port}) when no \
          --serverport/SIPI_SERVERPORT/SIPI_RS_PORT overrides it"
+    );
+}
+
+/// §6 R3, the actual precedence INVERSION: `SIPI_RS_PORT` now wins even over
+/// an explicit `--serverport`, not just the implicit Lua-config fallback
+/// above. Raw spawn, not `SipiServer` (which always injects `--serverport`
+/// itself and polls readiness against that same port — it cannot express
+/// "give an explicit --serverport, then watch something ELSE win").
+#[test]
+fn sipi_rs_port_beats_explicit_serverport() {
+    let (explicit_port, _) = sipi_e2e::allocate_ports();
+    let (winning_port, _) = sipi_e2e::allocate_ports();
+
+    let mut child = std::process::Command::new(sipi_e2e::sipi_bin_path())
+        .arg("server")
+        .arg("--config")
+        .arg("config/sipi.e2e-test-config.lua")
+        .arg("--serverport")
+        .arg(explicit_port.to_string())
+        .arg("--cache-size")
+        .arg("0")
+        .env("SIPI_RS_PORT", winning_port.to_string())
+        .current_dir(sipi_e2e::test_data_dir())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn subject");
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    let mut ready = false;
+    while std::time::Instant::now() < deadline {
+        if sipi_e2e::http_client()
+            .get(format!("http://127.0.0.1:{winning_port}/health"))
+            .send()
+            .map(|r| r.status().is_success())
+            .unwrap_or(false)
+        {
+            ready = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    let explicit_port_free = TcpStream::connect(("127.0.0.1", explicit_port)).is_err();
+
+    child.kill().ok();
+    child.wait().ok();
+
+    assert!(
+        ready,
+        "SIPI_RS_PORT ({winning_port}) must win even over an explicit --serverport ({explicit_port})"
+    );
+    assert!(
+        explicit_port_free,
+        "the explicit --serverport ({explicit_port}) must NOT be where the shell \
+         listens once SIPI_RS_PORT wins"
     );
 }

--- a/test/e2e/tests/differential.rs
+++ b/test/e2e/tests/differential.rs
@@ -456,18 +456,20 @@ fn serverport_cli_beats_env_on_both() {
 
 /// §7.7: the `--cache-dir` / `SIPI_CACHE_DIR` precedence pin — the ONE flag
 /// this plan pins the full `config < env < CLI` order on. A throwaway Lua
-/// config sets a baseline `cache_dir`; three pair-spawns request the same
-/// derivative and assert it lands under the expected tier's directory on
-/// BOTH binaries: config-only, +env (beats config), +env+CLI (beats env).
+/// config sets a baseline `cache_dir`; three tiers (via `assert_tier`)
+/// request the same derivative and assert it lands under the expected
+/// tier's directory on BOTH binaries: config-only, +env (beats config),
+/// +env+CLI (beats env).
 ///
 /// Unlike every other probe in this file, subject and reference here
 /// deliberately point at the SAME directory per tier — the whole point is
 /// proving both binaries resolve the identical override to the identical
-/// path, which two different directories couldn't show. This is the one
-/// place two live `SipiCache` instances share a directory; the risk is
-/// bounded (a couple of small requests per tier, then the pair is dropped)
-/// and the assertion only checks "is anything there", not an exact count,
-/// so interleaved writes from both processes can't produce a false pass.
+/// path, which two different directories couldn't show. Originally run as a
+/// concurrent `start_pair` (like everywhere else); that crashed the C++
+/// oracle with `std::bad_alloc` on linux-amd64 CI (two live `SipiCache`
+/// instances racing on the same `.sipicache` index — a real crash, not a
+/// benign duplicate write). `assert_tier` now runs subject and reference
+/// SEQUENTIALLY against the shared directory instead.
 #[test]
 fn cache_dir_precedence_config_env_cli() {
     let base = tempfile::tempdir().expect("tempdir");
@@ -475,6 +477,15 @@ fn cache_dir_precedence_config_env_cli() {
     let env_tier_dir = base.path().join("env-tier");
     let cli_tier_dir = base.path().join("cli-tier");
 
+    // Matches the full field set every OTHER differential-tested Lua config
+    // in this suite carries (`sipi.e2e-test-config.lua`,
+    // `resource_limits.rs`'s pixel-limit template, `cache.rs`'s template).
+    // A trimmed config omitting `initscript`/`ssl_*`/`jwt_secret`/
+    // `fileserver` crashed the C++ oracle with `std::bad_alloc` on
+    // linux-amd64 CI only, the one time subject and reference also raced on
+    // this same `cache_dir` concurrently (see `assert_tier` below, which
+    // removes that race) — the two are not confirmed independent causes, but
+    // matching the proven config shape costs nothing, so both are fixed.
     let config_content = format!(
         r#"sipi = {{
     port = 1024,
@@ -487,6 +498,7 @@ fn cache_dir_precedence_config_env_cli() {
     prefix_as_path = true,
     subdir_levels = 0,
     subdir_excludes = {{ "tmp", "thumb" }},
+    initscript = './config/sipi.init-knora.lua',
     cache_dir = '{config_dir}',
     cache_size = '20M',
     cache_nfiles = 8,
@@ -496,10 +508,15 @@ fn cache_dir_precedence_config_env_cli() {
     max_temp_file_age = 86400,
     knora_path = 'localhost',
     knora_port = '3434',
+    ssl_port = 1025,
+    ssl_certificate = './certificate/certificate.pem',
+    ssl_key = './certificate/key.pem',
+    jwt_secret = 'UP 4888, nice 4-8-4 steam engine',
     logfile = "sipi.log",
     loglevel = "DEBUG"
 }}
 admin = {{ user = 'admin', password = 'Sipi-Admin' }}
+fileserver = {{ docroot = './server', wwwroute = '/server' }}
 routes = {{}}
 "#,
         config_dir = config_tier_dir.display(),
@@ -508,39 +525,66 @@ routes = {{}}
     std::fs::write(&config_path, &config_content).expect("write precedence config");
     let config_arg = config_path.to_str().expect("utf-8 path");
 
+    // Each tier runs subject then reference SEQUENTIALLY (never concurrently)
+    // against the same directory: two live `SipiCache` instances racing on
+    // the same `.sipicache` index crashed the C++ oracle with `std::bad_alloc`
+    // on linux-amd64 CI when this test ran them as a `start_pair` (both
+    // processes alive at once). `assert_tier` fully stops one binary
+    // (`Drop` blocks until the process exits) before starting the other.
+    assert_tier(config_arg, &[], &[], &config_tier_dir, "config-only");
+    assert_tier(
+        config_arg,
+        &[],
+        &[("SIPI_CACHE_DIR", env_tier_dir.to_str().unwrap())],
+        &env_tier_dir,
+        "env-over-config",
+    );
+    assert_tier(
+        config_arg,
+        &["--cache-dir", cli_tier_dir.to_str().unwrap()],
+        &[("SIPI_CACHE_DIR", env_tier_dir.to_str().unwrap())],
+        &cli_tier_dir,
+        "cli-over-env",
+    );
+}
+
+/// Run `derivative` against subject, then (after subject fully stops)
+/// against reference, and assert both got 200 and `expected_dir` ended up
+/// populated.
+fn assert_tier(
+    config_arg: &str,
+    extra_args: &[&str],
+    extra_env: &[(&str, &str)],
+    expected_dir: &std::path::Path,
+    label: &str,
+) {
     let derivative = "/unit/lena512.jp2/0,0,64,64/max/0/default.jpg";
+    let working_dir = sipi_e2e::test_data_dir();
+    let c = sipi_e2e::http_client();
 
-    // Tier 1: config only — neither CLI nor env overrides cache_dir.
     {
-        let (subject, reference) =
-            SipiServer::start_pair(config_arg, &sipi_e2e::test_data_dir(), &[]);
-        diff_get(&subject, &reference, derivative).assert_parity();
-        assert_cache_populated(&config_tier_dir, "config-only");
+        let subject = SipiServer::start_env(config_arg, &working_dir, extra_args, extra_env);
+        let status = c
+            .get(format!("{}{derivative}", subject.base_url))
+            .send()
+            .unwrap_or_else(|e| panic!("[{label}] subject request failed: {e}"))
+            .status()
+            .as_u16();
+        assert_eq!(status, 200, "[{label}] subject request");
+    }
+    {
+        let reference =
+            SipiServer::start_reference_env(config_arg, &working_dir, extra_args, extra_env);
+        let status = c
+            .get(format!("{}{derivative}", reference.base_url))
+            .send()
+            .unwrap_or_else(|e| panic!("[{label}] reference request failed: {e}"))
+            .status()
+            .as_u16();
+        assert_eq!(status, 200, "[{label}] reference request");
     }
 
-    // Tier 2: env beats config.
-    {
-        let (subject, reference) = SipiServer::start_pair_env(
-            config_arg,
-            &sipi_e2e::test_data_dir(),
-            &[],
-            &[("SIPI_CACHE_DIR", env_tier_dir.to_str().unwrap())],
-        );
-        diff_get(&subject, &reference, derivative).assert_parity();
-        assert_cache_populated(&env_tier_dir, "env-over-config");
-    }
-
-    // Tier 3: CLI beats env.
-    {
-        let (subject, reference) = SipiServer::start_pair_env(
-            config_arg,
-            &sipi_e2e::test_data_dir(),
-            &["--cache-dir", cli_tier_dir.to_str().unwrap()],
-            &[("SIPI_CACHE_DIR", env_tier_dir.to_str().unwrap())],
-        );
-        diff_get(&subject, &reference, derivative).assert_parity();
-        assert_cache_populated(&cli_tier_dir, "cli-over-env");
-    }
+    assert_cache_populated(expected_dir, label);
 }
 
 /// At least one file exists under `dir` within a short settle window (the

--- a/test/e2e/tests/differential.rs
+++ b/test/e2e/tests/differential.rs
@@ -19,10 +19,11 @@
 //!
 //! Bazel-only (needs `$SIPI_BIN_REF`); run via `just bazel-test-differential`.
 
+use std::net::TcpStream;
 use std::sync::OnceLock;
 
 use reqwest::Method;
-use sipi_e2e::{diff_request, DiffAllowlist, SipiServer};
+use sipi_e2e::{diff_get, diff_request, DiffAllowlist, SipiServer};
 
 /// Per-case allowlist profile.
 #[derive(Clone, Copy)]
@@ -341,5 +342,964 @@ fn adminuser_env_name_documented_divergence() {
         "C++ oracle should still carry its documented env-name typo \
          (cli_app.cpp:1822) — if this fails, the typo was fixed upstream and \
          this divergence pin (plan 02 §7.5 M6) should be revisited:\n{reference_help}"
+    );
+}
+
+// =============================================================================
+// §7.7 flag→probe matrix (plan 02 step 2, A1). Each fn below spins up its own
+// `start_pair`/`start_pair_env`/`start_with_args` — unlike the shared corpus
+// above (one config for every `Case`), a flag probe needs the flag under
+// test to vary per spawn. See plan 02 §7.7 for the P/R/A probe-class
+// definitions, the mechanics, and the out-of-scope list.
+// =============================================================================
+
+/// Every probe below that enables real caching runs CONCURRENTLY with the
+/// corpus's shared `pair()` (a `OnceLock`, alive for the whole test-binary
+/// run under the mandated `--test-threads=1`) — both would otherwise default
+/// to `config/sipi.e2e-test-config.lua`'s `cache_dir = './cache'`. Two
+/// `SipiCache` instances validating/writing the same `.sipicache` index
+/// concurrently is a real race (the same hazard `resource_limits.rs`'s
+/// `pixel_limit_rejects_oversized_request` isolates against with its own
+/// `--cache-dir`). Probes below that don't care about caching instead pass
+/// `--cache-size 0` (disables `SipiCache` construction entirely, sidestepping
+/// the hazard with no tempdir needed); this helper is only for the few that
+/// specifically want a *working* cache under a non-default `--cache-size`.
+fn isolated_cache_dir() -> (tempfile::TempDir, String) {
+    let dir = tempfile::tempdir().expect("isolated cache dir");
+    let path = dir.path().to_str().expect("utf-8 path").to_owned();
+    (dir, path)
+}
+
+// ---- Bad-value set ---------------------------------------------------------
+
+/// Assert both binaries refuse to start under `extra_args`. Only the exit
+/// status is checked (nonzero) — NOT the error text or exact code, which
+/// differ by design (clap vs CLI11; plan 02 §7.7's bad-value-set note).
+fn assert_both_reject_at_startup(extra_args: &[&str]) {
+    for (label, bin) in [
+        ("subject(rust)", sipi_e2e::sipi_bin_path()),
+        ("reference(c++)", sipi_e2e::sipi_oracle_bin_path()),
+    ] {
+        let status = std::process::Command::new(&bin)
+            .arg("server")
+            .arg("--config")
+            .arg("config/sipi.e2e-test-config.lua")
+            .args(extra_args)
+            .current_dir(sipi_e2e::test_data_dir())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .unwrap_or_else(|e| panic!("failed to spawn {label} with {extra_args:?}: {e}"));
+        assert!(
+            !status.success(),
+            "{label} should reject {extra_args:?} at startup (exited 0)"
+        );
+    }
+}
+
+#[test]
+fn bad_serverport_zero_rejected_by_both() {
+    assert_both_reject_at_startup(&["--serverport", "0"]);
+}
+
+#[test]
+fn bad_serverport_out_of_range_rejected_by_both() {
+    assert_both_reject_at_startup(&["--serverport", "70000"]);
+}
+
+#[test]
+fn bad_cache_nfiles_negative_rejected_by_both() {
+    assert_both_reject_at_startup(&["--cache-nfiles", "-1"]);
+}
+
+// ---- Ordering pins ----------------------------------------------------------
+
+/// §7.7: `--serverport` (CLI) beats `SIPI_SERVERPORT` (env) — "free" per the
+/// plan: every `start_pair` spawn already passes `--serverport` explicitly,
+/// so setting `SIPI_SERVERPORT` to a different free port and confirming both
+/// binaries still listen on the CLI-allocated port (not the env one) is a
+/// zero-extra-spawn proof that CLI beats env, on both binaries.
+#[test]
+fn serverport_cli_beats_env_on_both() {
+    let (decoy_http, _decoy_ssl) = sipi_e2e::allocate_ports();
+    let (subject, reference) = SipiServer::start_pair_env(
+        "config/sipi.e2e-test-config.lua",
+        &sipi_e2e::test_data_dir(),
+        &["--cache-size", "0"],
+        &[("SIPI_SERVERPORT", &decoy_http.to_string())],
+    );
+    // `start_pair_env` already had to bind subject.http_port /
+    // reference.http_port for its readiness probe to succeed — had env won,
+    // both would be listening on `decoy_http` instead and that probe would
+    // have timed out. Confirm the decoy is free as a stronger, explicit check.
+    assert!(
+        TcpStream::connect(("127.0.0.1", decoy_http)).is_err(),
+        "SIPI_SERVERPORT={decoy_http} must NOT be where either binary listens \
+         (CLI --serverport must win)"
+    );
+    drop(subject);
+    drop(reference);
+}
+
+/// §7.7: the `--cache-dir` / `SIPI_CACHE_DIR` precedence pin — the ONE flag
+/// this plan pins the full `config < env < CLI` order on. A throwaway Lua
+/// config sets a baseline `cache_dir`; three pair-spawns request the same
+/// derivative and assert it lands under the expected tier's directory on
+/// BOTH binaries: config-only, +env (beats config), +env+CLI (beats env).
+#[test]
+fn cache_dir_precedence_config_env_cli() {
+    let base = tempfile::tempdir().expect("tempdir");
+    let config_tier_dir = base.path().join("config-tier");
+    let env_tier_dir = base.path().join("env-tier");
+    let cli_tier_dir = base.path().join("cli-tier");
+
+    let config_content = format!(
+        r#"sipi = {{
+    port = 1024,
+    nthreads = 2,
+    jpeg_quality = 60,
+    scaling_quality = {{ jpeg = "medium", tiff = "high", png = "high", j2k = "high" }},
+    keep_alive = 5,
+    max_post_size = '300M',
+    imgroot = './images',
+    prefix_as_path = true,
+    subdir_levels = 0,
+    subdir_excludes = {{ "tmp", "thumb" }},
+    cache_dir = '{config_dir}',
+    cache_size = '20M',
+    cache_nfiles = 8,
+    scriptdir = './scripts',
+    thumb_size = '!128,128',
+    tmpdir = '/tmp',
+    max_temp_file_age = 86400,
+    knora_path = 'localhost',
+    knora_port = '3434',
+    logfile = "sipi.log",
+    loglevel = "DEBUG"
+}}
+admin = {{ user = 'admin', password = 'Sipi-Admin' }}
+routes = {{}}
+"#,
+        config_dir = config_tier_dir.display(),
+    );
+    let config_path = base.path().join("sipi.cache-precedence-test.lua");
+    std::fs::write(&config_path, &config_content).expect("write precedence config");
+    let config_arg = config_path.to_str().expect("utf-8 path");
+
+    let derivative = "/unit/lena512.jp2/0,0,64,64/max/0/default.jpg";
+
+    // Tier 1: config only — neither CLI nor env overrides cache_dir.
+    {
+        let (subject, reference) =
+            SipiServer::start_pair(config_arg, &sipi_e2e::test_data_dir(), &[]);
+        diff_get(&subject, &reference, derivative).assert_parity();
+        assert_cache_populated(&config_tier_dir, "config-only");
+    }
+
+    // Tier 2: env beats config.
+    {
+        let (subject, reference) = SipiServer::start_pair_env(
+            config_arg,
+            &sipi_e2e::test_data_dir(),
+            &[],
+            &[("SIPI_CACHE_DIR", env_tier_dir.to_str().unwrap())],
+        );
+        diff_get(&subject, &reference, derivative).assert_parity();
+        assert_cache_populated(&env_tier_dir, "env-over-config");
+    }
+
+    // Tier 3: CLI beats env.
+    {
+        let (subject, reference) = SipiServer::start_pair_env(
+            config_arg,
+            &sipi_e2e::test_data_dir(),
+            &["--cache-dir", cli_tier_dir.to_str().unwrap()],
+            &[("SIPI_CACHE_DIR", env_tier_dir.to_str().unwrap())],
+        );
+        diff_get(&subject, &reference, derivative).assert_parity();
+        assert_cache_populated(&cli_tier_dir, "cli-over-env");
+    }
+}
+
+/// At least one file exists under `dir` within a short settle window (the
+/// cache write may lag a hair behind the HTTP response, §7.7's
+/// `cache-nfiles` row note).
+fn assert_cache_populated(dir: &std::path::Path, label: &str) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    loop {
+        let populated = std::fs::read_dir(dir)
+            .map(|entries| entries.filter_map(Result::ok).any(|e| e.path().is_file()))
+            .unwrap_or(false);
+        if populated {
+            return;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!(
+                "[{label}] expected cache file(s) under {} within 2s",
+                dir.display()
+            );
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
+// ---- P-class per-flag honour probes -----------------------------------------
+
+/// §7.7: `--maxpost` — tightens the existing loose `upload_size_enforcement`
+/// assertion (`status == 413 || status >= 400`) to `413` OR a connection
+/// reset (the same two outcomes `upload_size_enforcement` already treats as
+/// equally valid enforcement — sending a body larger than `max_post_size`
+/// can trip the transport before the response is even readable) on both
+/// binaries, then confirms `--maxpost 0` means unlimited (the same body, now
+/// cleanly accepted) on both. Uses a real fixture (`unit/lena512.tif`, the
+/// exact file `upload_tiff_converts_to_jp2` proves converts cleanly) rather
+/// than a synthetic byte blob, so the "accepted" case can't fail on invalid
+/// image data instead of the size cap.
+#[test]
+fn maxpost_flag_honoured_on_both() {
+    let payload = std::fs::read(sipi_e2e::test_data_dir().join("images/unit/lena512.tif"))
+        .expect("read lena512.tif fixture");
+    assert!(
+        payload.len() > 1024,
+        "fixture must exceed the 1K cap under test"
+    );
+
+    let post_body = |srv: &SipiServer| -> Result<reqwest::blocking::Response, reqwest::Error> {
+        let form = reqwest::blocking::multipart::Form::new().part(
+            "file",
+            reqwest::blocking::multipart::Part::bytes(payload.clone())
+                .file_name("lena512.tif")
+                .mime_str("image/tiff")
+                .expect("valid mime"),
+        );
+        sipi_e2e::http_client()
+            .post(format!("{}/api/upload", srv.base_url))
+            .multipart(form)
+            .send()
+    };
+
+    // Tier: --maxpost 1K -> 413, or the connection resets mid-body (both
+    // equally valid enforcement — see doc comment above), on both binaries.
+    {
+        let (subject, reference) = SipiServer::start_pair(
+            "config/sipi.e2e-test-config.lua",
+            &sipi_e2e::test_data_dir(),
+            &["--cache-size", "0", "--maxpost", "1K"],
+        );
+        for (label, srv) in [("subject", &subject), ("reference", &reference)] {
+            match post_body(srv) {
+                Ok(resp) => assert_eq!(
+                    resp.status().as_u16(),
+                    413,
+                    "[{label}] --maxpost 1K should reject the oversized fixture with 413"
+                ),
+                Err(e) => assert!(
+                    e.is_body() || e.is_request() || e.is_connect(),
+                    "[{label}] expected a clean 413 or a connection-level failure, got: {e}"
+                ),
+            }
+        }
+    }
+
+    // Tier: --maxpost 0 -> unlimited, same fixture cleanly accepted (200).
+    {
+        let (subject, reference) = SipiServer::start_pair(
+            "config/sipi.e2e-test-config.lua",
+            &sipi_e2e::test_data_dir(),
+            &["--cache-size", "0", "--maxpost", "0"],
+        );
+        for (label, srv) in [("subject", &subject), ("reference", &reference)] {
+            assert_eq!(
+                post_body(srv)
+                    .unwrap_or_else(|e| panic!("[{label}] upload request failed: {e}"))
+                    .status()
+                    .as_u16(),
+                200,
+                "[{label}] --maxpost 0 (unlimited) should accept the same fixture"
+            );
+        }
+    }
+}
+
+/// §7.7: `--max-pixel-limit` — a full-resolution request (512×512 =
+/// 262,144px) exceeds a 10,000px limit (4xx on both); an explicit `100,100`
+/// (10,000px) output size stays within it (200 on both). NOTE: the pixel-
+/// limit pre-check (`serve_image.cpp`'s output pixel-count guard) sizes
+/// against the SOURCE image for a `max`/`full` SIZE spec — region cropping
+/// happens in a later step it doesn't see — so a pixel-coordinate region
+/// like `0,0,64,64/max` is checked against the full 512×512, not the 64×64
+/// crop, and would still be rejected. An explicit `<W>,<H>` SIZE spec (the
+/// same pattern `resource_limits.rs::pixel_limit_rejects_oversized_request`
+/// already relies on) is what's actually pixel-limited to the requested
+/// output.
+#[test]
+fn max_pixel_limit_flag_honoured_on_both() {
+    let (subject, reference) = SipiServer::start_pair(
+        "config/sipi.e2e-test-config.lua",
+        &sipi_e2e::test_data_dir(),
+        &["--cache-size", "0", "--max-pixel-limit", "10000"],
+    );
+
+    let over = diff_get(
+        &subject,
+        &reference,
+        "/unit/lena512.jp2/full/max/0/default.jpg",
+    );
+    over.assert_parity();
+    assert!(
+        over.subject_status.is_client_error(),
+        "512x512 (262144px) should exceed a 10000px limit with a 4xx, got {}",
+        over.subject_status
+    );
+
+    let within = diff_get(
+        &subject,
+        &reference,
+        "/unit/lena512.jp2/full/100,100/0/default.jpg",
+    );
+    within.assert_parity();
+    assert_eq!(within.subject_status.as_u16(), 200);
+}
+
+/// §7.7 joint probe: `--max-decode-memory` + `--decode-memory-mode`. NOTE:
+/// the plan's suggested "1M" budget is too generous for the lena512 fixture
+/// (~768KB decode buffer per `memory_budget.rs`) — empirically it returns
+/// 200 on both in enforce mode, which would prove nothing. Using "100" bytes
+/// instead (the value `memory_budget.rs`'s own enforce tests rely on for
+/// reliable rejection) actually exercises the flag.
+#[test]
+fn decode_memory_budget_flags_honoured_on_both() {
+    let path = "/unit/lena512.jp2/full/max/0/default.jpg";
+
+    let (subject, reference) = SipiServer::start_pair(
+        "config/sipi.e2e-test-config.lua",
+        &sipi_e2e::test_data_dir(),
+        &[
+            "--cache-size",
+            "0",
+            "--max-decode-memory",
+            "100",
+            "--decode-memory-mode",
+            "enforce",
+        ],
+    );
+    let enforced = diff_get(&subject, &reference, path);
+    enforced.assert_parity();
+    assert_eq!(enforced.subject_status.as_u16(), 503);
+    drop((subject, reference));
+
+    let (subject, reference) = SipiServer::start_pair(
+        "config/sipi.e2e-test-config.lua",
+        &sipi_e2e::test_data_dir(),
+        &[
+            "--cache-size",
+            "0",
+            "--max-decode-memory",
+            "100",
+            "--decode-memory-mode",
+            "monitor",
+        ],
+    );
+    let monitored = diff_get(&subject, &reference, path);
+    monitored.assert_parity();
+    assert_eq!(monitored.subject_status.as_u16(), 200);
+}
+
+/// §7.7: `--imgroot` — an alt root containing a fixture at a fresh identifier
+/// (not served by the default imgroot) proves the override is actually used,
+/// not silently ignored (a 404-vs-404 "parity" would otherwise pass without
+/// proving anything).
+#[test]
+fn imgroot_flag_honoured_on_both() {
+    let alt_root = tempfile::tempdir().expect("alt imgroot tempdir");
+    std::fs::create_dir_all(alt_root.path().join("unit")).expect("create alt unit dir");
+    std::fs::copy(
+        sipi_e2e::test_data_dir().join("images/bilevel/bilevel_lzw_miniswhite.tif"),
+        alt_root.path().join("unit").join("imgroot-probe.tif"),
+    )
+    .expect("stage alt-imgroot fixture");
+
+    let (subject, reference) = SipiServer::start_pair(
+        "config/sipi.e2e-test-config.lua",
+        &sipi_e2e::test_data_dir(),
+        &[
+            "--cache-size",
+            "0",
+            "--imgroot",
+            alt_root.path().to_str().expect("utf-8 path"),
+        ],
+    );
+    let diff = diff_get(&subject, &reference, "/unit/imgroot-probe.tif/info.json");
+    diff.assert_parity();
+    assert_eq!(
+        diff.subject_status.as_u16(),
+        200,
+        "the alt-imgroot fixture must actually be served (not silently falling back to the default imgroot)"
+    );
+}
+
+/// §7.7: `--scriptdir` — an alt scriptdir shadows an already-configured
+/// route's script with one returning a distinguishable marker. No `require`
+/// in the marker script: overriding `--scriptdir` replaces the Lua `require`
+/// path too (`LuaServer::setLuaPath`), so a helper like `send_response.lua`
+/// (which lives in the DEFAULT scriptdir) would not resolve — the bare
+/// `server.*` API is used instead. For the same reason, `--initscript` is
+/// ALSO overridden to a no-op: the shared config's default initscript
+/// (`sipi.init-knora.lua`) does `require "get_knora_session"`, which every
+/// new Lua VM re-executes (incl. the ones behind the `/health` readiness
+/// probe on the C++ oracle), and that require would no longer resolve once
+/// `--scriptdir` points elsewhere — confirmed empirically (the oracle failed
+/// to ever become ready, spamming "module 'get_knora_session' not found"
+/// until the spawn timeout).
+#[test]
+fn scriptdir_flag_honoured_on_both() {
+    let alt_scriptdir = tempfile::tempdir().expect("alt scriptdir tempdir");
+    std::fs::write(
+        alt_scriptdir.path().join("test_mediatype.lua"),
+        "server.sendHeader(\"Content-Type\", \"application/json\")\n\
+         server.sendStatus(200)\n\
+         server.print('{\"marker\":\"scriptdir-override\"}')\n",
+    )
+    .expect("write alt script");
+    let noop_initscript = alt_scriptdir.path().join("noop_init.lua");
+    std::fs::write(&noop_initscript, "-- no-op init script (scriptdir probe)\n")
+        .expect("write noop initscript");
+
+    let (subject, reference) = SipiServer::start_pair(
+        "config/sipi.e2e-test-config.lua",
+        &sipi_e2e::test_data_dir(),
+        &[
+            "--cache-size",
+            "0",
+            "--scriptdir",
+            alt_scriptdir.path().to_str().expect("utf-8 path"),
+            "--initscript",
+            noop_initscript.to_str().expect("utf-8 path"),
+        ],
+    );
+    diff_get(&subject, &reference, "/test_mediatype").assert_parity();
+
+    let body: serde_json::Value = sipi_e2e::http_client()
+        .get(format!("{}/test_mediatype", subject.base_url))
+        .send()
+        .expect("test_mediatype request")
+        .json()
+        .expect("test_mediatype JSON");
+    assert_eq!(
+        body["marker"], "scriptdir-override",
+        "the alt scriptdir's script must run instead of the configured default"
+    );
+}
+
+/// §7.7: `--docroot` — an alt docroot's `marker.html` must be served at the
+/// configured `wwwroute` (`/server`, unchanged) on both binaries.
+#[test]
+fn docroot_flag_honoured_on_both() {
+    let alt_docroot = tempfile::tempdir().expect("alt docroot tempdir");
+    std::fs::write(
+        alt_docroot.path().join("marker.html"),
+        b"<html>docroot-override-marker</html>",
+    )
+    .expect("write alt docroot fixture");
+
+    let (subject, reference) = SipiServer::start_pair(
+        "config/sipi.e2e-test-config.lua",
+        &sipi_e2e::test_data_dir(),
+        &[
+            "--cache-size",
+            "0",
+            "--docroot",
+            alt_docroot.path().to_str().expect("utf-8 path"),
+        ],
+    );
+    let diff = diff_get(&subject, &reference, "/server/marker.html");
+    diff.assert_parity();
+    assert_eq!(diff.subject_status.as_u16(), 200);
+}
+
+/// §7.7: `--wwwroute` — moves the docroot fileserver's URL mount point. The
+/// new mount point serves the (unmodified default) docroot's fixture; the
+/// old mount point's miss status may legitimately differ between binaries
+/// (falls through to the IIIF catch-all differently) — assert per-binary,
+/// don't diff it, per the table's note.
+#[test]
+fn wwwroute_flag_honoured_on_both() {
+    write_docroot_fixtures();
+    let (subject, reference) = SipiServer::start_pair(
+        "config/sipi.e2e-test-config.lua",
+        &sipi_e2e::test_data_dir(),
+        &["--cache-size", "0", "--wwwroute", "/altroute"],
+    );
+    let diff = diff_get(&subject, &reference, "/altroute/parity_probe.html");
+    diff.assert_parity();
+    assert_eq!(diff.subject_status.as_u16(), 200);
+
+    let c = sipi_e2e::http_client();
+    for (label, srv) in [("subject", &subject), ("reference", &reference)] {
+        let missed = c
+            .get(format!("{}/server/parity_probe.html", srv.base_url))
+            .send()
+            .unwrap_or_else(|e| panic!("{label} old-mount request failed: {e}"));
+        assert_ne!(
+            missed.status().as_u16(),
+            200,
+            "[{label}] the old /server mount should no longer serve the docroot once --wwwroute moves it"
+        );
+    }
+}
+
+/// §7.7: `--pathprefix` — the never-tested `prefix_as_path = false` branch
+/// (plan 02 §3 P2). An alt imgroot holds the fixture at its ROOT (no `unit/`
+/// subdir). With the prefix stripped (`--pathprefix=false`), the resolved
+/// path drops "unit" -> `<alt>/<file>` exists -> 200 on both. With the
+/// prefix kept (bare `--pathprefix`, forcing true), the resolved path keeps
+/// "unit" -> `<alt>/unit/<file>` does not exist -> 404 on both.
+///
+/// Also confirmed empirically: the C++ CLI11 arm DOES accept
+/// `--pathprefix=false` (both binaries start cleanly with it), so no
+/// config-driven fallback is needed for the false case.
+#[test]
+fn pathprefix_flag_honoured_on_both() {
+    let alt_root = tempfile::tempdir().expect("alt imgroot tempdir");
+    std::fs::copy(
+        sipi_e2e::test_data_dir().join("images/unit/lena512.jp2"),
+        alt_root.path().join("pathprefix-probe.jp2"),
+    )
+    .expect("stage alt-imgroot fixture at the root (no unit/ subdir)");
+    let alt_root_str = alt_root.path().to_str().expect("utf-8 path");
+
+    {
+        let (subject, reference) = SipiServer::start_pair(
+            "config/sipi.e2e-test-config.lua",
+            &sipi_e2e::test_data_dir(),
+            &[
+                "--cache-size",
+                "0",
+                "--imgroot",
+                alt_root_str,
+                "--pathprefix=false",
+            ],
+        );
+        let diff = diff_get(&subject, &reference, "/unit/pathprefix-probe.jp2/info.json");
+        diff.assert_parity();
+        assert_eq!(diff.subject_status.as_u16(), 200);
+    }
+    {
+        let (subject, reference) = SipiServer::start_pair(
+            "config/sipi.e2e-test-config.lua",
+            &sipi_e2e::test_data_dir(),
+            &[
+                "--cache-size",
+                "0",
+                "--imgroot",
+                alt_root_str,
+                "--pathprefix",
+            ],
+        );
+        let diff = diff_get(&subject, &reference, "/unit/pathprefix-probe.jp2/info.json");
+        diff.assert_parity();
+        assert_eq!(diff.subject_status.as_u16(), 404);
+    }
+}
+
+/// §7.7: `--cache-nfiles 1` bounds the cache directory to ≤1 file after two
+/// distinct derivatives, on both binaries. Subject and reference get their
+/// OWN isolated `--cache-dir` (via `start_pair_split`) rather than sharing
+/// one — two independent `SipiCache` instances racing on the same
+/// `.sipicache` index would make the file count meaningless.
+#[test]
+fn cache_nfiles_flag_honoured_on_both() {
+    let subject_cache = tempfile::tempdir().expect("subject cache dir");
+    let reference_cache = tempfile::tempdir().expect("reference cache dir");
+    let subject_cache_str = subject_cache
+        .path()
+        .to_str()
+        .expect("utf-8 path")
+        .to_owned();
+    let reference_cache_str = reference_cache
+        .path()
+        .to_str()
+        .expect("utf-8 path")
+        .to_owned();
+
+    let (subject, reference) = SipiServer::start_pair_split(
+        "config/sipi.e2e-test-config.lua",
+        &sipi_e2e::test_data_dir(),
+        &["--cache-nfiles", "1", "--cache-dir", &subject_cache_str],
+        &["--cache-nfiles", "1", "--cache-dir", &reference_cache_str],
+    );
+
+    let c = sipi_e2e::http_client();
+    for path in [
+        "/unit/lena512.jp2/0,0,64,64/max/0/default.jpg",
+        "/unit/lena512.jp2/0,0,128,128/max/0/default.jpg",
+    ] {
+        assert_eq!(
+            c.get(format!("{}{path}", subject.base_url))
+                .send()
+                .unwrap()
+                .status()
+                .as_u16(),
+            200
+        );
+        assert_eq!(
+            c.get(format!("{}{path}", reference.base_url))
+                .send()
+                .unwrap()
+                .status()
+                .as_u16(),
+            200
+        );
+    }
+
+    for (label, dir) in [
+        ("subject", subject_cache.path()),
+        ("reference", reference_cache.path()),
+    ] {
+        let count = count_files_with_retry(dir);
+        assert!(
+            count <= 1,
+            "[{label}] --cache-nfiles 1 should bound the cache directory to \u{2264}1 file, found {count}"
+        );
+    }
+}
+
+fn count_files_with_retry(dir: &std::path::Path) -> usize {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    loop {
+        let count = std::fs::read_dir(dir)
+            .map(|entries| {
+                entries
+                    .filter_map(Result::ok)
+                    .filter(|e| e.path().is_file())
+                    .count()
+            })
+            .unwrap_or(0);
+        if count <= 1 || std::time::Instant::now() >= deadline {
+            return count;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+}
+
+/// §7.7 joint probe: the four `--rate-limit-*` flags together. `Retry-After`
+/// presence only is asserted — the exact seconds-remaining is
+/// timing-dependent and deliberately unpinned (§3 P3).
+#[test]
+fn rate_limit_flags_honoured_on_both() {
+    let (subject, reference) = SipiServer::start_pair(
+        "config/sipi.e2e-test-config.lua",
+        &sipi_e2e::test_data_dir(),
+        &[
+            "--cache-size",
+            "0",
+            "--rate-limit-mode",
+            "enforce",
+            "--rate-limit-max-pixels",
+            "300000", // just above one 512x512 request's 262144px
+            "--rate-limit-window",
+            "60",
+            "--rate-limit-pixel-threshold",
+            "0",
+        ],
+    );
+    let path = "/unit/lena512.jp2/full/max/0/default.jpg";
+    let c = sipi_e2e::http_client();
+
+    for (label, srv) in [("subject", &subject), ("reference", &reference)] {
+        let first = c
+            .get(format!("{}{path}", srv.base_url))
+            .send()
+            .expect("first request");
+        assert_eq!(
+            first.status().as_u16(),
+            200,
+            "[{label}] first request within budget"
+        );
+
+        let second = c
+            .get(format!("{}{path}", srv.base_url))
+            .send()
+            .expect("second request");
+        assert_eq!(
+            second.status().as_u16(),
+            429,
+            "[{label}] second request exceeds budget"
+        );
+        assert!(
+            second.headers().contains_key("retry-after"),
+            "[{label}] 429 should include a Retry-After header"
+        );
+    }
+}
+
+// ---- P-conditional probes ----------------------------------------------------
+
+/// §7.7 P-conditional: `--thumbsize`/`--knorapath`/`--knoraport` have no
+/// direct HTTP-visible effect, but `sipiConfGlobals` (`cli_app.cpp`) exposes
+/// them to every Lua VM as `config.thumb_size`/`config.knora_path`/
+/// `config.knora_port` — the shared `/config_echo` route
+/// (`test/_test_data/scripts/config_echo.lua`) echoes them as JSON.
+#[test]
+fn config_echo_flags_honoured_on_both() {
+    let (subject, reference) = SipiServer::start_pair(
+        "config/sipi.e2e-test-config.lua",
+        &sipi_e2e::test_data_dir(),
+        &[
+            "--cache-size",
+            "0",
+            "--thumbsize",
+            "!256,256",
+            "--knorapath",
+            "example.org",
+            "--knoraport",
+            "9999",
+        ],
+    );
+    diff_get(&subject, &reference, "/config_echo").assert_parity();
+
+    // `diff_get` alone would also pass if BOTH binaries silently ignored the
+    // overrides (agreeing on the unmodified default) — confirm the override
+    // actually took by checking the subject's own echoed values.
+    let body: serde_json::Value = sipi_e2e::http_client()
+        .get(format!("{}/config_echo", subject.base_url))
+        .send()
+        .expect("config_echo request")
+        .json()
+        .expect("config_echo JSON");
+    assert_eq!(body["thumb_size"], "!256,256");
+    assert_eq!(body["knora_path"], "example.org");
+    assert_eq!(body["knora_port"], "9999");
+}
+
+// ---- R-class: positive path only ----------------------------------------------
+
+/// §7.7: `--jwtkey` — positive path ONLY. A valid, non-expired token signed
+/// by the alt secret must be accepted on each binary. The negative path
+/// (invalid/expired/malformed tokens) crashes the subject today — the
+/// preflight response-sink DoS, DEV-6670 — and lands at step 11; do not add
+/// it here (the §7.7 trap).
+#[test]
+fn jwtkey_flag_honoured_positive_path_only() {
+    const ALT_SECRET: &str = "alt-jwt-secret-for-plan-02-step-2-probe";
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock")
+        .as_secs();
+    let claims = serde_json::json!({ "allow": true, "iat": now, "exp": now + 3600 });
+    let token = jsonwebtoken::encode(
+        &jsonwebtoken::Header::new(jsonwebtoken::Algorithm::HS256),
+        &claims,
+        &jsonwebtoken::EncodingKey::from_secret(ALT_SECRET.as_bytes()),
+    )
+    .expect("encode alt-secret JWT");
+
+    let (subject, reference) = SipiServer::start_pair(
+        "config/sipi.e2e-test-config.lua",
+        &sipi_e2e::test_data_dir(),
+        &["--cache-size", "0", "--jwtkey", ALT_SECRET],
+    );
+    let c = sipi_e2e::http_client();
+    for (label, srv) in [("subject", &subject), ("reference", &reference)] {
+        let resp = c
+            .get(format!(
+                "{}/auth/lena512.jp2/full/max/0/default.jpg",
+                srv.base_url
+            ))
+            .header("Authorization", format!("Bearer {token}"))
+            .send()
+            .unwrap_or_else(|e| panic!("[{label}] request failed: {e}"));
+        assert_eq!(
+            resp.status().as_u16(),
+            200,
+            "[{label}] a valid token signed by the --jwtkey alt secret should be accepted"
+        );
+    }
+}
+
+// ---- A-batch: acceptance-only flags --------------------------------------------
+
+/// §7.7 A-batch: every acceptance-only flag safe to share between both
+/// binaries, set to a harmless non-default all at once, plus a baseline
+/// probe. These flags either have no HTTP-visible effect worth a dedicated
+/// probe (no admin endpoint in the e2e config; `--logfile` NYI in the
+/// engine; syslog-vs-JSON `--loglevel` output is noise, §5 #2) or model
+/// concurrency differently between the two transports
+/// (hostname/keepalive/max-waiting/queue-timeout — XFH-derived / tokio-async
+/// / semaphore, §5 #6/#9; `--nthreads` — M7-resolved parse-only). `SIPI_*`
+/// env bindings are covered separately by `a_batch_env_flags_accepted_on_both`.
+#[test]
+fn a_batch_paired_flags_accepted_on_both() {
+    let (_cache, cache_dir) = isolated_cache_dir();
+    let (subject, reference) = SipiServer::start_pair(
+        "config/sipi.e2e-test-config.lua",
+        &sipi_e2e::test_data_dir(),
+        &[
+            "--cache-dir",
+            &cache_dir,
+            "--hostname",
+            "sipi-a-batch-probe.example.org",
+            "--keepalive",
+            "7",
+            "--max-waiting",
+            "3",
+            "--queue-timeout",
+            "9",
+            "--nthreads",
+            "3",
+            "--adminuser",
+            "a-batch-admin",
+            "--adminpasswd",
+            "a-batch-password",
+            "--cache-size",
+            "5M",
+            "--loglevel",
+            "INFO",
+            "--logfile",
+            "sipi-a-batch-probe.log",
+        ],
+    );
+    diff_get(&subject, &reference, "/unit/lena512.jp2/info.json").assert_parity();
+}
+
+/// §7.7 A-batch, env variant: the same flags via their `SIPI_*` env bindings
+/// instead of CLI flags — this is what would catch an `ADMIINUSER`-class
+/// env-name typo on a newly added A-class flag. (The C++ oracle's documented
+/// `SIPI_ADMIINUSER` typo, M6, means `SIPI_ADMINUSER` here is a no-op on the
+/// reference — harmless, since no admin endpoint is configured to observe it
+/// either way.)
+#[test]
+fn a_batch_env_flags_accepted_on_both() {
+    let (_cache, cache_dir) = isolated_cache_dir();
+    let (subject, reference) = SipiServer::start_pair_env(
+        "config/sipi.e2e-test-config.lua",
+        &sipi_e2e::test_data_dir(),
+        &["--cache-dir", &cache_dir],
+        &[
+            ("SIPI_HOSTNAME", "sipi-a-batch-env-probe.example.org"),
+            ("SIPI_KEEPALIVE", "7"),
+            ("SIPI_MAX_WAITING", "3"),
+            ("SIPI_QUEUE_TIMEOUT", "9"),
+            ("SIPI_NTHREADS", "3"),
+            ("SIPI_ADMINUSER", "a-batch-admin"),
+            ("SIPI_ADMINPASSWD", "a-batch-password"),
+            ("SIPI_CACHE_SIZE", "5M"),
+            ("SIPI_LOGLEVEL", "INFO"),
+            ("SIPI_LOGFILE", "sipi-a-batch-env-probe.log"),
+        ],
+    );
+    diff_get(&subject, &reference, "/unit/lena512.jp2/info.json").assert_parity();
+}
+
+/// §7.7 A-batch, subject-only: flags either dead-transport on the Rust shell
+/// (`--sslcert`/`--sslkey` — TLS terminates at Traefik; `--sslport` is
+/// already added automatically by `start_with_args`) or unsafe to probe
+/// against the C++ oracle (`--subdirlevels`/`--subdirexcludes` — the
+/// oracle's OWN `run_server()` command handler migrates the imgroot's
+/// on-disk layout at startup when these change, `cli_app.cpp:1419-1452`;
+/// `sipi_init`, which only the Rust shell calls, has no such migration, so
+/// this is safe on the subject).
+#[test]
+fn a_batch_subject_only_flags_accepted() {
+    let subject = SipiServer::start_with_args(
+        "config/sipi.e2e-test-config.lua",
+        &sipi_e2e::test_data_dir(),
+        &[
+            "--cache-size",
+            "0",
+            "--sslcert",
+            "./certificate/certificate.pem",
+            "--sslkey",
+            "./certificate/key.pem",
+            "--subdirlevels",
+            "1",
+            "--subdirexcludes",
+            "tmp,thumb",
+        ],
+    );
+    let resp = sipi_e2e::http_client()
+        .get(format!("{}/unit/lena512.jp2/info.json", subject.base_url))
+        .send()
+        .expect("baseline probe");
+    assert_eq!(resp.status().as_u16(), 200);
+}
+
+/// §6 R3: the Rust shell falls back to the Lua config's `sipi.port` when
+/// neither `--serverport`/`SIPI_SERVERPORT` nor the dev/test `SIPI_RS_PORT`
+/// selects one. Single-binary (subject-only) — this is an internal
+/// precedence chain in `server-rs::serve()`, not a flag to compare against
+/// the C++ oracle (the oracle has always read its own config's `port`
+/// natively via `run_server()`, unaffected by this fix). `SipiServer::spawn`
+/// always injects `--serverport`, so this uses a raw spawn instead,
+/// mirroring `adminuser_env_name_documented_divergence`'s pattern.
+#[test]
+fn r3_lua_config_port_is_listener_fallback() {
+    const PORT: u16 = 19876;
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let cache_dir = tmp.path().join("cache");
+    let config_content = format!(
+        r#"sipi = {{
+    port = {PORT},
+    nthreads = 2,
+    jpeg_quality = 60,
+    scaling_quality = {{ jpeg = "medium", tiff = "high", png = "high", j2k = "high" }},
+    keep_alive = 5,
+    max_post_size = '300M',
+    imgroot = './images',
+    prefix_as_path = true,
+    subdir_levels = 0,
+    subdir_excludes = {{ "tmp", "thumb" }},
+    cache_dir = '{cache_dir}',
+    cache_size = '5M',
+    cache_nfiles = 8,
+    scriptdir = './scripts',
+    thumb_size = '!128,128',
+    tmpdir = '/tmp',
+    max_temp_file_age = 86400,
+    knora_path = 'localhost',
+    knora_port = '3434',
+    logfile = "sipi.log",
+    loglevel = "DEBUG"
+}}
+admin = {{ user = 'admin', password = 'Sipi-Admin' }}
+routes = {{}}
+"#,
+        cache_dir = cache_dir.display(),
+    );
+    let config_path = tmp.path().join("sipi.r3-port-test.lua");
+    std::fs::write(&config_path, &config_content).expect("write config");
+
+    let mut child = std::process::Command::new(sipi_e2e::sipi_bin_path())
+        .arg("server")
+        .arg("--config")
+        .arg(&config_path)
+        .current_dir(sipi_e2e::test_data_dir())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn subject without --serverport");
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    let mut ready = false;
+    while std::time::Instant::now() < deadline {
+        if sipi_e2e::http_client()
+            .get(format!("http://127.0.0.1:{PORT}/health"))
+            .send()
+            .map(|r| r.status().is_success())
+            .unwrap_or(false)
+        {
+            ready = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    child.kill().ok();
+    child.wait().ok();
+
+    assert!(
+        ready,
+        "the Rust shell must listen on the Lua config's `port` ({PORT}) when no \
+         --serverport/SIPI_SERVERPORT/SIPI_RS_PORT overrides it"
     );
 }

--- a/test/e2e/tests/snapshots/cli__sipi-server-help.snap
+++ b/test/e2e/tests/snapshots/cli__sipi-server-help.snap
@@ -34,7 +34,7 @@ Paths:
       --tmpdir <DIR>          Temporary directory (uploads etc.) [env: SIPI_TMPDIR=]
       --maxtmpage <SECS>      Max age in seconds of temp files before deletion [env: SIPI_MAXTMPAGE=]
       --initscript <FILE>     Path to the Lua init script [env: SIPI_INITSCRIPT=]
-      --pathprefix [<BOOL>]   IIIF prefix is part of the image path (deprecated; no effect on the Rust path — §3 P3) [env: SIPI_PATHPREFIX=] [possible values: true, false]
+      --pathprefix [<BOOL>]   IIIF prefix is part of the image path (deprecated on the C++ oracle; still honoured on the Rust serve path via `routes.rs`'s `prefix_as_path`) [env: SIPI_PATHPREFIX=] [possible values: true, false]
       --subdirlevels <N>      Number of subdir levels (deprecated; no effect on the Rust path) [env: SIPI_SUBDIRLEVELS=]
       --subdirexcludes <DIR>  Directories excluded from subdir calculations [env: SIPI_SUBDIREXCLUDES=]
 


### PR DESCRIPTION
[DEV-6659](https://linear.app/dasch/issue/DEV-6659)

## Summary
- Closes plan 02 §6 R3: adds a `sipi_port` FFI getter so the Rust shell falls back to the Lua config's `sipi.port` when no `--serverport`/`SIPI_SERVERPORT`/`SIPI_RS_PORT` is given. Also fixes the listener precedence to `SIPI_RS_PORT > --serverport/SIPI_SERVERPORT > Lua config port > 1024 default` — a precedence *inversion* for `SIPI_RS_PORT` (now beats CLI/env), confirmed safe (no reference to `SIPI_RS_PORT` in ops-deploy or dsp-api).
- Executes plan 02 step 2 (§7.7): 24 new differential-harness tests covering the per-flag CLI/env honour probes, ordering pins, the bad-value set, a P-conditional probe via a new `/config_echo` Lua route, the `--jwtkey` positive-path probe, three A-batches, and a dedicated regression test for the SIPI_RS_PORT-beats-explicit---serverport inversion.
- Adds `SipiServer::start_pair_env`/`start_pair_split` to the e2e harness (env threading + per-binary distinct args).

## Changes
- **FFI seam**: `src/ffi/engine_context.h`, `src/cli/cli_app.cpp`, `src/ffi/sipi_ffi.{h,cpp}`, `src/server-rs/src/ffi.rs` — new `sipi_port` getter, mirroring `sipi_nthreads`.
- **Listener precedence**: `src/server-rs/src/lib.rs` — new `lua_config_port` tier in `serve()`'s port resolution.
- **e2e harness**: `test/e2e/src/lib.rs` — `start_pair_env`, `start_pair_split`.
- **Differential tests**: `test/e2e/tests/differential.rs` — the §7.7 flag matrix (24 new `#[test]` fns).
- **Fixtures**: `test/_test_data/scripts/config_echo.lua` (new), `test/_test_data/config/sipi.e2e-test-config.lua` (new route entry).
- **Doc fix**: `src/cli-rs/src/commands/server/args/paths.rs` — corrects a stale claim that `--pathprefix` has no effect on the Rust serve path (it does, via `routes.rs`'s `prefix_as_path`); matching snapshot update.

An adversarial multi-reviewer pass (Rust/C++/consistency/security/simplicity, each finding independently verified) surfaced and fixed: an out-of-declaration-order designated initializer (`-Wreorder-init-list`), two stale doc comments, a missing regression test for the actual precedence inversion, a hardcoded port in a new test (now uses the shared PID-offset allocator), and two duplicate polling helpers merged into one.

One pre-existing, out-of-scope finding not fixed here: `docs/src/guide/running.md` still lists `--pathprefix` under "Deprecated Options" as a no-op — this is general CLI-reference doc staleness predating this PR, owned by Phase Docs (plan 02 step 12), not this change.

## Test plan
- [x] `just bazel-coverage` (unit + approval + e2e) green
- [x] `just bazel-test-differential` green (24/24 flag-matrix tests + full corpus)
- [x] `just bazel-rustfmt-check` clean
- [x] `just differential-coverage-check` green (no drift-guard bump needed — the corpus file is excluded from the count)
- [x] Manual end-to-end verification of the full port-precedence chain (SIPI_RS_PORT > --serverport > Lua config port > 1024) against both binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)