### PR TITLE
docs: align commit and PR conventions to full parity with dsp-repository

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+Fixes LINEAR-ID, LINEAR-ID, ...
+
+## Motivation
+Why this work was needed. What problem it solves for users.
+
+## Summary
+1-3 bullet points of user-visible changes.
+
+## Key Changes
+### [Topic]
+- change details
+
+## Challenges and Decisions
+What was tried, what failed, and key architecture decisions.
+Structure as sub-sections when multiple challenges exist:
+
+### [Challenge title]
+**Problem:** description of the issue encountered
+**Tried:** approaches that didn't work and why
+**Solution:** what worked and why it's the right approach
+
+## Gotchas
+Things future developers should know. Each gotcha should be
+actionable — not just "this is hard" but "do X instead of Y".
+
+## Test Plan
+- [ ] verification steps

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,11 +170,13 @@ Run a single unit-test target with `bazel test //test/unit/<component>:<componen
 
 For CI pipeline details (Docker publishing, release automation), see [`docs/src/development/ci.md`](docs/src/development/ci.md).
 
-**Releases are automated via release-please.** Correct [Conventional Commit](https://www.conventionalcommits.org/) prefixes are required — they drive SemVer bumps and changelog generation. See [`docs/src/development/ci.md`](docs/src/development/ci.md) for the full prefix-to-release mapping and [`docs/src/development/developing.md`](docs/src/development/developing.md) for the commit message schema.
+**Releases are automated via release-please.** Correct [Conventional Commit](https://www.conventionalcommits.org/) prefixes are required — they drive SemVer bumps and changelog generation. See [`docs/src/development/ci.md`](docs/src/development/ci.md) for the full prefix-to-release mapping.
 
-Valid prefixes: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `build`, `chore`, `ci`, `perf`. Breaking changes use `!` suffix: `feat!: ...`
+Valid prefixes: `feat`, `fix`, `perf`, `revert`, `refactor`, `docs`, `style`, `test`, `build`, `chore`, `ci`. Breaking changes use `!` suffix: `feat!: ...`. The scope is a module name from [`CONVENTIONS.md` § Module Layout](CONVENTIONS.md); if none fits, ask the maintainer before coining a new one.
 
-For commit organization rules (how to group commits in PRs) and PR description format (optimized for learnings extraction), see [`docs/src/development/commit-conventions.md`](docs/src/development/commit-conventions.md).
+**A PR lands as one commit by default.** Rebase-merge puts every branch commit on `main` verbatim — there is no squash safety net. Clean up the branch before merge; split into multiple commits only when the work is genuinely several independent, self-contained changes. A `fix:` corrects behavior already on `main`; a bug introduced earlier in the same branch is folded into its introducing commit, never a standalone `fix:`.
+
+For the git workflow, commit message schema, scope vocabulary, and PR description format (all single-sourced), see [`docs/src/development/commit-conventions.md`](docs/src/development/commit-conventions.md). PRs are scaffolded by [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md).
 
 **Code review:** Use [`docs/src/development/reviewer-guidelines.md`](docs/src/development/reviewer-guidelines.md) as the review checklist for all PRs.
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -80,6 +80,44 @@ The codebase has mixed naming styles. For new code, prefer the C++23 style guide
 
 ## Module Layout
 
+### Canonical modules (commit-scope vocabulary)
+
+These are SIPI's modules. Each name is also the canonical [commit
+scope](docs/src/development/commit-conventions.md#scopes). A module is a
+unit of responsibility, not necessarily a directory yet — the migration
+to per-module co-located directories is tracked by
+[ADR-0003](docs/adr/0003-module-co-located-source-and-tests.md).
+
+| Module (scope) | Path | Responsibility |
+|---|---|---|
+| `image` | `src/SipiImage.*`, `include/SipiImage.hpp` | Image read/write pipeline; orchestrates decode → process → encode |
+| `formats` | `src/formats/`, `include/formats/` | Per-format codecs: TIFF, JP2 (Kakadu), PNG, JPEG |
+| `metadata` | `src/metadata/` | EXIF, IPTC, XMP, ICC profile handling |
+| `iiifparser` | `src/iiifparser/`, `include/iiifparser/` | IIIF URL parsing (identifier, region, size, rotation, quality, format) |
+| `handlers` | `src/handlers/` | HTTP request handlers |
+| `shttps` | `src/shttps/` | Internal HTTP framework (threading, TLS, connection pooling, JWT) |
+| `cache` | `include/SipiCache.h` | File-based LRU cache with dual-limit eviction |
+| `memory-budget` | `include/SipiMemoryBudget.h` | Lock-free decode memory budget |
+| `observability` | `src/observability/` | Prometheus metrics, tracing |
+| `logging` | `src/logging/` | Structured logging |
+| `cli` | `src/cli/` | C++ CLI app, arg parsing, subcommand dispatch |
+| `ffi` | `src/ffi/` | Rust↔C++ FFI seam and Lua bindings |
+| `lua` | `scripts/`, `config/*.lua` | Lua route/preflight scripts and config |
+| `server-rs` | `src/server-rs/` | Rust server shell (strangler-fig subject) |
+| `cli-rs` | `src/cli-rs/` | Rust CLI shell |
+
+The C++ `SipiHttpServer` orchestration (`src/SipiHttpServer.*`) is being
+strangled by `server-rs`; new server work lands under `server-rs`, and
+route/handler changes use `handlers` or `shttps`.
+
+Beyond modules, commits use **test-layer scopes** (`e2e`, `approval`) and
+**cross-cutting scopes** (`deps`, `bazel`, `ci`, `nix`, `docker`). If none
+of the enumerated scopes genuinely fits a change, ask the maintainer
+before inventing a new one. The full scope rules live in
+[commit-conventions.md § Scopes](docs/src/development/commit-conventions.md#scopes).
+
+### Directory layouts
+
 The codebase has two coexisting layouts:
 
 - **Historical (current default):** `src/<mod>/Foo.cpp` paired with

--- a/docs/src/development/ci.md
+++ b/docs/src/development/ci.md
@@ -24,13 +24,14 @@ to determine the SemVer bump and generate the changelog.
 | `fix:` | patch bump | Bug Fixes |
 | `feat!:` / `fix!:` | major bump | Breaking Changes |
 | `perf:` | patch bump | Performance Improvements |
+| `revert:` | patch bump | Reverts |
 | `docs:`, `style:`, `refactor:`, `test:`, `build:`, `ci:`, `chore:` | no bump | hidden |
 
 !!! warning "Correct commit prefixes are critical"
     A commit without a valid Conventional Commit prefix will be invisible to
     release-please — it won't trigger a release or appear in the changelog.
-    See [Commit Message Schema](developing.md#commit-message-schema) for the
-    full format specification.
+    See [Commit and PR Conventions](commit-conventions.md) for the full
+    commit message schema, scope vocabulary, and what `fix:` means.
 
 ## Pull request CI
 

--- a/docs/src/development/commit-conventions.md
+++ b/docs/src/development/commit-conventions.md
@@ -1,19 +1,128 @@
 # Commit and PR Conventions
 
+## Git Workflow
+
+We use a **rebase workflow**. All changes are made on a branch, then
+rebased onto `main` before being merged. This keeps a clean, linear
+history.
+
+The goal is a **meaningful history on `main`**: every commit on main
+should be a deliberate, self-contained unit of change. Working commits
+("WIP", "fix typo", "address review feedback") do not belong on main.
+
+- **Rebase-merge**: PRs are integrated using rebase-merge (not squash or
+  merge commits). Every commit on the branch lands on main verbatim — so
+  the branch history _is_ the main history. There is no squash-on-merge
+  safety net; whatever you leave on the branch is what ships.
+- **Clean up before merging (mandatory)**: before a PR is merged, rewrite
+  the branch (interactive rebase) so its commits read well on main.
+  Squash working commits, reword messages, reorder as needed.
+- **Default to a single commit**: almost always, a PR should end up as
+  **one** clean commit. Split into multiple commits only when the work
+  genuinely represents several independent, self-contained changes that
+  each deserve their own line in the history — and each must stand on its
+  own. When in doubt, squash to one. See [Commit
+  Organization](#commit-organization).
+
+## Commit message schema
+
+We use [Conventional Commits](https://www.conventionalcommits.org/).
+These prefixes drive [release-please](ci.md#release-automation-release-please)
+to determine SemVer bumps and generate the changelog —
+**using the correct prefix is required, not optional**.
+
+    type(scope): subject
+    body
+
+| Prefix | Meaning | Changelog section | Version bump |
+|--------|---------|-------------------|--------------|
+| `feat` | New user-visible functionality | Features | minor |
+| `fix` | Bug fix (see [What `fix:` means](#what-fix-means)) | Bug Fixes | patch |
+| `perf` | Performance improvement | Performance Improvements | patch |
+| `revert` | Revert of a previous commit | Reverts | patch |
+| `refactor` | Code restructuring, no behavior change | hidden | none |
+| `docs` | Documentation | hidden | none |
+| `test` | Adding or refactoring tests | hidden | none |
+| `build` | Build system or dependencies | hidden | none |
+| `ci` | Continuous integration | hidden | none |
+| `style` | Formatting, no code change | hidden | none |
+| `chore` | Miscellaneous maintenance | hidden | none |
+
+Breaking changes take a `!` suffix (or a `BREAKING CHANGE:` footer) and
+bump the **major** version:
+
+    feat!: remove the deprecated cache-purge endpoint
+
+Example:
+
+    feat(shttps): support more authentication methods
+
+The release-please config sentence-cases subjects in the changelog, so
+write the subject in normal prose case (`feat(cache): add dual-limit
+eviction`, not `feat(cache): Add ...`).
+
+### What `fix:` means
+
+A `fix:` corrects behavior that exists on `main` — a bug a deployer could
+hit today, or that a released version shipped. It earns a "Bug Fixes"
+changelog line and a patch bump precisely because deployers need to know.
+
+A bug you introduced earlier in the **same branch** is not a `fix:`. Fold
+it into the commit that introduced it (`git commit --fixup=<sha>`, then
+`git rebase --autosquash`) so it never lands on `main` and never generates
+a changelog entry for a bug nobody ever saw.
+
+Corollary: if you discover a genuine pre-existing `main` bug while doing
+unrelated work, give it its **own** `fix:` commit — don't bury it inside
+the `feat:`/`refactor:` you happened to be writing.
+
+## Scopes
+
+The scope names the **module** the change belongs to. The canonical
+module list — which is also the scope vocabulary — lives in
+[`CONVENTIONS.md` § Module Layout](../../../CONVENTIONS.md). Use one of
+these names, lowercase:
+
+- **Module scopes:** `image`, `formats`, `metadata`, `iiifparser`,
+  `handlers`, `shttps`, `cache`, `memory-budget`, `observability`,
+  `logging`, `cli`, `ffi`, `lua`, `server-rs`, `cli-rs`
+- **Test-layer scopes** (test-only changes spanning a whole layer):
+  `e2e`, `approval`. A unit-test change takes the scope of the module
+  under test.
+- **Cross-cutting scopes** (changes not tied to one module): `deps`,
+  `bazel`, `ci`, `nix`, `docker`.
+
+Rules:
+
+- Lowercase, kebab-case. `ci` not `CI`; `bazel` not `bazel-build`.
+- Scope is optional. Omit it for genuinely repo-wide changes
+  (`chore: ...`, `ci: ...`).
+- A commit that spans several modules may list them comma-separated:
+  `refactor(cli-rs,server-rs): ...`.
+- **If none of the enumerated scopes genuinely fits, ask the maintainer
+  before inventing a new one.** New scopes are added to the canonical
+  list in `CONVENTIONS.md` deliberately, not ad hoc.
+
 ## Commit Organization
 
 ### Principle
-Group commits by user-visible impact, not by implementation journey.
+
+Start from the assumption that the whole PR is **one commit**. Group
+commits by user-visible impact, not by implementation journey. Only split
+the PR when the work genuinely divides into several independent,
+self-contained changes that each stand on their own.
 
 ### Rules
+
 1. Each `feat:` or `fix:` commit = one changelog entry visible to
-   developers deploying Sipi
+   developers deploying Sipi.
 2. Internal work (`build:`, `ci:`, `refactor:`, `docs:`, `chore:`,
-   `test:`) is hidden from changelog — squash aggressively
+   `test:`) is hidden from the changelog — squash aggressively.
 3. Ask: "would a developer deploying Sipi care about this change?"
    If yes → `feat:` or `fix:`. If no → hidden type.
-4. Debugging journeys (trial-and-error, reverts, iterative fixes)
-   belong in the PR description, not the commit history
+4. Debugging journeys (trial-and-error, reverts of in-branch mistakes,
+   iterative fixes) belong in the PR description, not the commit history.
+   See [What `fix:` means](#what-fix-means).
 
 ### Where context lives
 
@@ -25,6 +134,9 @@ Group commits by user-visible impact, not by implementation journey.
 | Code comments | Code readers | "Why not the obvious approach" |
 
 ## PR Description Format
+
+The repository ships a [`.github/PULL_REQUEST_TEMPLATE.md`](../../../.github/PULL_REQUEST_TEMPLATE.md)
+that pre-populates this structure when you open a PR.
 
 ### Template
 
@@ -58,7 +170,11 @@ actionable — not just "this is hard" but "do X instead of Y".
 - [ ] verification steps
 ```
 
+Use `Part of LINEAR-ID` instead of `Fixes LINEAR-ID` when the PR advances
+an umbrella issue it does not close.
+
 ### Why this format matters
+
 The "Challenges and Decisions" section captures the debugging journey
 that would otherwise be lost when commits are squashed. The
 `/eng:workflows:compound` skill reads PR descriptions to generate

--- a/docs/src/development/developing.md
+++ b/docs/src/development/developing.md
@@ -267,33 +267,9 @@ Kakadu is special: it is fetched via a custom `gh_release_archive`
 repository_rule (`bazel/gh_release.bzl`) that shells out to
 `gh release download`. See [Kakadu setup](kakadu.md).
 
-## Commit message schema
+## Commit and PR conventions
 
-We use [Conventional Commits](https://www.conventionalcommits.org/).
-These prefixes drive [release-please](ci.md#release-automation-release-please)
-to automatically determine SemVer bumps and generate changelogs —
-**using the correct prefix is required, not optional**.
-
-    type(scope): subject
-    body
-
-Types:
-
-- `feat` — new feature (SemVer minor)
-- `fix` — bug fix (SemVer patch)
-- `docs` — documentation changes
-- `style` — formatting, no code change
-- `refactor` — refactoring production code
-- `test` — adding or refactoring tests
-- `build` — changes to build system or dependencies
-- `chore` — miscellaneous maintenance
-- `ci` — continuous integration changes
-- `perf` — performance improvements
-
-Breaking changes are indicated with `!`:
-
-    feat!: remove deprecated API endpoint
-
-Example:
-
-    feat(HTTP server): support more authentication methods
+The commit message schema (Conventional Commit types, the scope
+vocabulary, and what `fix:` means), the rebase/one-commit-per-PR git
+workflow, and the PR description format all live in a single source:
+[`commit-conventions.md`](commit-conventions.md).


### PR DESCRIPTION
No associated Linear issue — process/docs alignment requested directly.

## Motivation
SIPI's and dsp-repository's commit/PR conventions descend from a shared template but had drifted. SIPI had two concrete gaps — no `.github/PULL_REQUEST_TEMPLATE.md`, and commit guidance duplicated across three files — plus one silent philosophical divergence (multi-commit-by-kind vs one-commit-default). We chose full parity with dsp-repository's `docs/src/workflows.md`.

## Summary
- One commit per PR is now the default; the rebase / meaningful-history workflow is documented explicitly.
- Adds the missing PR template so GitHub-UI PRs scaffold correctly.
- Defines a canonical module scope vocabulary and an explicit definition of what a `fix:` commit means.

## Key Changes
### Single source of truth
- `commit-conventions.md` now owns the git workflow, the commit schema (full type table with Changelog-section + Version-bump columns, grounded in `.github/release-please/config.json`), scopes, and the PR format.
- `developing.md` and `ci.md` point to it instead of restating the schema; fixed `ci.md`'s stale anchor and added `revert:` to its release table.

### PR template
- New `.github/PULL_REQUEST_TEMPLATE.md`, identical body to dsp-repository.

### Canonical scopes
- Module scopes enumerated in `CONVENTIONS.md § Module Layout`: `image`, `formats`, `metadata`, `iiifparser`, `handlers`, `shttps`, `cache`, `memory-budget`, `observability`, `logging`, `cli`, `ffi`, `lua`, `server-rs`, `cli-rs` — plus test-layer (`e2e`, `approval`) and cross-cutting (`deps`, `bazel`, `ci`, `nix`, `docker`) scopes. Escape hatch: ask the maintainer if none genuinely fits.

### What `fix:` means
- A `fix:` corrects behavior already on `main`. A bug introduced earlier in the same branch is folded into its introducing commit (`--fixup` + `--autosquash`), never a standalone `fix:`. A pre-existing `main` bug found mid-work gets its own `fix:`.

## Challenges and Decisions
### One-commit default vs SIPI's prior multi-commit model
**Problem:** SIPI's docs (and the working memory) said "squash to the minimum type-consistent set" — several commits by kind was normal — which conflicts with dsp-repository's "one commit by default."
**Solution:** Full parity. One commit is the default; multiple commits remain allowed for genuinely independent, self-contained changes, so nothing is lost. Multi-commit must be thoughtful, not implementation history or in-branch fix commits.

### C++ `SipiHttpServer` has no dedicated scope
**Problem:** A C++ `server` scope would collide with the Rust `server-rs` scope.
**Solution:** Under the strangler-fig, new server work lands under `server-rs`; route/handler changes use `handlers`/`shttps`. Documented as a note rather than a confusing extra scope.

## Gotchas
- The full commit type table lives ONLY in `commit-conventions.md`. `ci.md` keeps a short release-mechanics summary; adding a type means updating both.
- Scope must be lowercase kebab-case (`ci` not `CI`, `bazel` not `bazel-build`). Coining a new scope requires updating the canonical list in `CONVENTIONS.md` — ask first.
- Docs links to repo-root files use `../../../` from `docs/src/development/` (existing precedent; MkDocs builds from `docs/`).

## Test Plan
- [ ] `just docs-serve` renders `commit-conventions.md`, `CONVENTIONS.md`, `ci.md`, `developing.md` without broken links
- [ ] Opening a new PR shows the template body
- [x] Docs-only change; no build/test impact
