### PR TITLE
refactor(server-rs): Phase C step 7 — knora.json Essentials identity fields

### DIFF
--- a/docs/src/development/testing-strategy.md
+++ b/docs/src/development/testing-strategy.md
@@ -583,14 +583,14 @@ The following matrix maps every testable IIIF spec requirement to its test statu
 | XMP preservation through IIIF pipeline | :x: GAP | — | No test verifies XMP survives transforms |
 | ICC profile preservation/conversion | :x: GAP | — | C++ unit tests exist but no HTTP-level test |
 | IPTC metadata preservation | :x: GAP | — | No e2e test |
-| Essentials round-trip | :x: GAP | — | Custom metadata not tested via HTTP |
+| Essentials round-trip | :white_check_mark: | `upload.rs` | `metadata_essentials_roundtrip` |
 | CLI conversion metadata fidelity | :x: GAP | — | Untested |
 | MIME consistency check (`/api/mimetest`) | :x: GAP | — | Python-only |
 | Thumbnail generation (`/make_thumbnail`) | :x: GAP | — | Python-only |
 | Convert from binaries (`/convert_from_binaries`) | :x: GAP | — | Python-only |
 | Temp directory cleanup | :x: GAP | — | Python-only |
 | Restricted image size reduction | :x: GAP | — | Python tests only |
-| 4-bit palette PNG upload | :x: GAP | — | Python-only |
+| 4-bit palette PNG upload | :white_check_mark: | `upload.rs` | `upload_4bit_palette_png` |
 | Cache API routes (`/api/cache`) | :x: GAP | — | No tests |
 | Favicon endpoint | :x: GAP | — | Handler exists, no tests |
 | Memory safety (ASan/LSan) | :x: GAP | — | Only fuzz harness uses sanitizers |
@@ -668,12 +668,12 @@ The following matrix maps every testable IIIF spec requirement to its test statu
 | CORS | 5 | 0 | 100% |
 | HTTP behavior | 10 | 3 (304, operation order, fractional pct) | 77% |
 | Identifiers | 2 | 3 (non-ASCII, ARK/URN, bug) | 40% |
-| Sipi extensions | 19 | 76 | 20% |
-| **Total** | **96** | **92** | **51%** |
+| Sipi extensions | 28 | 72 | 28% |
+| **Total** | **105** | **88** | **54%** |
 
 **Key gap categories:**
 
-- **Metadata** (6 gaps): EXIF, XMP, ICC, IPTC, Essentials, CLI metadata — silent drift risk
+- **Metadata** (5 gaps): EXIF, XMP, ICC, IPTC, CLI metadata — silent drift risk
 - **Error handling** (6 gaps): corrupt images, Lua errors, empty uploads, config, double-encoding, long URLs — crash/hang risk
 - **Security** (7 gaps): JWT, decompression bombs, upload limits, CRLF injection, cache poisoning, info disclosure, slowloris
 - **Configuration** (6 gaps): parseSizeString, deprecated keys, CLI overrides, jwt_secret, invalid Lua, nonexistent paths

--- a/src/ffi/seam_probe_test.cpp
+++ b/src/ffi/seam_probe_test.cpp
@@ -6,8 +6,9 @@
 // Co-located unit tests (ADR-0003) for the edge-probe seam entries the Rust
 // shell calls at the request boundary: sipi_imgroot / sipi_prefix_as_path (read
 // the installed engine context) and sipi_image_dims / sipi_mimetype (read a
-// validated file). All are sipi_guard-only — no response sink — so they run
-// without a transport.
+// validated file — sipi_image_dims also optionally emits the Essentials
+// identity from the same read). All are sipi_guard-only — no response sink —
+// so they run without a transport.
 
 #include "gtest/gtest.h"
 
@@ -45,6 +46,24 @@ void install_engine(bool prefix_as_path)
 
 // SipiStrFn that copies the emitted value into a std::string (the ctx).
 void collect_str(void *ctx, const char *value) { *static_cast<std::string *>(ctx) = value; }
+
+// The two-string result sipi_image_dims' optional essentials callback may
+// fire into.
+struct Essentials
+{
+  bool fired = false;
+  std::string mimetype;
+  std::string filename;
+};
+
+// SipiEssentialsFn that records whether it fired, plus both strings (the ctx).
+void collect_essentials(void *ctx, const char *orig_mimetype, const char *orig_filename)
+{
+  auto *out = static_cast<Essentials *>(ctx);
+  out->fired = true;
+  out->mimetype = orig_mimetype;
+  out->filename = orig_filename;
+}
 
 }// namespace
 
@@ -103,7 +122,7 @@ TEST(SeamProbe, ImageDimsReadsNativeShape)
 {
   const std::string path = fixture("/unit/lena512.tif");
   SipiImageDims dims{};
-  ASSERT_EQ(sipi_image_dims(path.c_str(), &dims), 0);
+  ASSERT_EQ(sipi_image_dims(path.c_str(), &dims, nullptr, nullptr), 0);
   EXPECT_EQ(dims.width, 512u);
   EXPECT_EQ(dims.height, 512u);
 }
@@ -114,7 +133,7 @@ TEST(SeamProbe, ImageDimsOnNonImageIsError)
   // a non-zero (500) status, never a crash or a bogus 0×0 success.
   const std::string path = fixture("/unit/test.csv");
   SipiImageDims dims{};
-  EXPECT_NE(sipi_image_dims(path.c_str(), &dims), 0);
+  EXPECT_NE(sipi_image_dims(path.c_str(), &dims, nullptr, nullptr), 0);
 }
 
 TEST(SeamProbe, MimetypeMatchesEngineLibmagic)
@@ -128,4 +147,37 @@ TEST(SeamProbe, MimetypeMatchesEngineLibmagic)
   std::string csv_mime;
   ASSERT_EQ(sipi_mimetype(csv.c_str(), collect_str, &csv_mime), 0);
   EXPECT_FALSE(csv_mime.empty());
+}
+
+TEST(SeamProbe, ImageDimsEssentialsFiresOnFileWithPacket)
+{
+  // lena512.jp2 carries a legacy pipe-delimited Essentials packet:
+  // SIPI:lena512.tif|image/tiff|sha256|...
+  const std::string path = fixture("/unit/lena512.jp2");
+  SipiImageDims dims{};
+  Essentials out;
+  ASSERT_EQ(sipi_image_dims(path.c_str(), &dims, collect_essentials, &out), 0);
+  EXPECT_TRUE(out.fired);
+  EXPECT_EQ(out.mimetype, "image/tiff");
+  EXPECT_EQ(out.filename, "lena512.tif");
+}
+
+TEST(SeamProbe, ImageDimsEssentialsDoesNotFireWithoutPacket)
+{
+  // lena512.tif is a plain source fixture — no embedded Essentials packet, so
+  // the callback must not fire (not an error: 0 either way).
+  const std::string path = fixture("/unit/lena512.tif");
+  SipiImageDims dims{};
+  Essentials out;
+  ASSERT_EQ(sipi_image_dims(path.c_str(), &dims, collect_essentials, &out), 0);
+  EXPECT_FALSE(out.fired);
+}
+
+TEST(SeamProbe, ImageDimsEssentialsOnNonImageIsError)
+{
+  const std::string path = fixture("/unit/test.csv");
+  SipiImageDims dims{};
+  Essentials out;
+  EXPECT_NE(sipi_image_dims(path.c_str(), &dims, collect_essentials, &out), 0);
+  EXPECT_FALSE(out.fired);
 }

--- a/src/ffi/sipi_ffi.cpp
+++ b/src/ffi/sipi_ffi.cpp
@@ -290,12 +290,16 @@ int sipi_port(int *out)
   });
 }
 
-int sipi_image_dims(const char *resolved_path, SipiImageDims *out)
+int sipi_image_dims(const char *resolved_path, SipiImageDims *out, SipiEssentialsFn emit, void *ctx)
 {
   // Header-only shape read. The Rust edge owns existence + containment (R1/R2)
   // before calling, so read_shape throwing here is a genuine engine failure →
   // 500 via the guard (read_shape never returns FAILURE; it throws). Native
   // shape only: numpages/tile_*/clevels drive info.json sizes[]/tiles[].
+  // One read_shape() call also carries the Essentials identity (origmimetype/
+  // origname) when the file has one — emitted through the optional `emit`
+  // callback (NULL when the caller, e.g. info.json, doesn't need it), so a
+  // caller that wants both the shape and the identity pays for a single read.
   return Sipi::ffi::sipi_guard([&] {
     const Sipi::SipiImage probe;
     const Sipi::SipiImgInfo info = probe.read_shape(resolved_path);
@@ -305,6 +309,9 @@ int sipi_image_dims(const char *resolved_path, SipiImageDims *out)
     out->tile_width = static_cast<std::uint32_t>(info.tile_width);
     out->tile_height = static_cast<std::uint32_t>(info.tile_height);
     out->clevels = static_cast<std::uint32_t>(info.clevels);
+    if (emit != nullptr && info.success == Sipi::SipiImgInfo::ALL) {
+      emit(ctx, info.origmimetype.c_str(), info.origname.c_str());
+    }
     return static_cast<int>(Sipi::ffi::SipiStatus::Ok);
   });
 }

--- a/src/ffi/sipi_ffi.h
+++ b/src/ffi/sipi_ffi.h
@@ -361,6 +361,12 @@ typedef void (*SipiStrFn)(void *ctx, const char *value);
  *  no owned array. The Rust shell registers an axum route per emitted entry. */
 typedef void (*SipiRouteFn)(void *ctx, const char *method, const char *route, const char *script);
 
+/*! Emits an image's Essentials-packet identity — its original mimetype and
+ *  original filename — through a caller callback, so the seam returns no
+ *  owned strings. Called at most once, from sipi_image_dims: both strings are
+ *  known together or not at all. */
+typedef void (*SipiEssentialsFn)(void *ctx, const char *orig_mimetype, const char *orig_filename);
+
 /* ── Entry points ───────────────────────────────────────────────────────────
  * All return 0 on success / an error code on failure; none let a C++ exception
  * cross the boundary. */
@@ -538,12 +544,23 @@ SIPI_FFI_NODISCARD int sipi_max_post_size(size_t *out);
  *  500 if `sipi_init` has not run. */
 SIPI_FFI_NODISCARD int sipi_port(int *out);
 
-/*! Header-only image-shape probe (`SipiImage::read_shape` — no full decode).
+/*! Header-only image-shape probe (`SipiImage::read_shape` — no full decode;
+ *  one read_shape() call serves both the native shape AND the Essentials
+ *  identity, since both come from the same underlying engine read).
  *  `resolved_path` is an already-validated absolute path (the Rust edge owns
- *  existence + containment). Fills `*out` on success. Returns 0, or 500 if the
- *  shape cannot be read (the edge has already confirmed the file exists, so an
- *  unreadable image here is an engine-level failure). */
-SIPI_FFI_NODISCARD int sipi_image_dims(const char *resolved_path, SipiImageDims *out);
+ *  existence + containment). Fills `*out` on success. `emit`/`ctx` are
+ *  OPTIONAL (NULL `emit` = caller doesn't want the identity, matching the
+ *  seam's "NULL = absent" idiom) — when non-NULL, `emit` fires exactly once,
+ *  with BOTH the original mimetype and filename, iff the file carries a
+ *  parseable Essentials packet; it fires zero times otherwise (a plain
+ *  JPEG/PNG, or a TIFF/JP2 without a packet, has no original-file identity to
+ *  report — this is not an error). Returns 0, or 500 if the shape cannot be
+ *  read (the edge has already confirmed the file exists, so an unreadable
+ *  image here is an engine-level failure). */
+SIPI_FFI_NODISCARD int sipi_image_dims(const char *resolved_path,
+  SipiImageDims *out,
+  SipiEssentialsFn emit,
+  void *ctx);
 
 /*! The engine's libmagic MIME type for a file (the same `getBestFileMimetype`
  *  the `/file` and info.json paths use — one source of truth for MIME mapping),

--- a/src/server-rs/src/ffi.rs
+++ b/src/server-rs/src/ffi.rs
@@ -165,6 +165,12 @@ pub type SipiRouteFn = extern "C" fn(
     script: *const c_char,
 );
 
+/// Emits an image's Essentials-packet identity — original mimetype + original
+/// filename — together (mirrors `SipiEssentialsFn`). Called at most once: both
+/// strings are known together or not at all.
+pub type SipiEssentialsFn =
+    extern "C" fn(ctx: *mut c_void, orig_mimetype: *const c_char, orig_filename: *const c_char);
+
 // ── Preflight (auth) ────────────────────────────────────────────────────────
 
 /// Permission type a Lua preflight hook returns (mirrors `SipiPermType`). The
@@ -310,9 +316,19 @@ extern "C" {
     /// it unset, matching the C++ `script_handler`).
     pub fn sipi_request_context_set_docroot(ctx: *mut SipiRequestContext, docroot: *const c_char);
 
-    /// Header-only image-shape probe (no full decode). `resolved_path` is an
-    /// already-validated absolute path. Returns 0 (and fills `*out`), or 500.
-    pub fn sipi_image_dims(resolved_path: *const c_char, out: *mut SipiImageDims) -> c_int;
+    /// Header-only image-shape probe (no full decode) — also optionally emits
+    /// the Essentials identity from the SAME read via `emit`/`ctx` (`None` =
+    /// caller doesn't want it, e.g. info.json). When `emit` is present, it
+    /// fires exactly once, with both strings, iff the file carries a
+    /// parseable Essentials packet; zero times otherwise (not an error).
+    /// `resolved_path` is an already-validated absolute path. Returns 0 (and
+    /// fills `*out`), or 500.
+    pub fn sipi_image_dims(
+        resolved_path: *const c_char,
+        out: *mut SipiImageDims,
+        emit: Option<SipiEssentialsFn>,
+        ctx: *mut c_void,
+    ) -> c_int;
 
     /// The engine's libmagic MIME type for a file, emitted once via `emit`.
     /// `resolved_path` is an already-validated absolute path. Returns 0, or 500.
@@ -622,14 +638,18 @@ pub fn routes() -> Result<Vec<RouteEntry>, i32> {
     Ok(out)
 }
 
-/// Header-only image shape for a validated path. `Err` carries the FFI status
-/// (500 if the shape cannot be read, or -1 on an interior NUL in the path).
+/// Header-only image shape for a validated path (no Essentials identity —
+/// the info.json path doesn't need it, so this passes no callback and costs
+/// exactly one `read_shape()`; see [`image_dims_and_essentials`] for the
+/// knora.json path, which wants both from a single call). `Err` carries the
+/// FFI status (500 if the shape cannot be read, or -1 on an interior NUL in
+/// the path).
 pub fn image_dims(resolved_path: &str) -> Result<SipiImageDims, i32> {
     let c_path = CString::new(resolved_path).map_err(|_| -1)?;
     let mut dims = SipiImageDims::default();
     // SAFETY: `c_path` outlives the synchronous call; `out` is a valid pointer;
     // the seam guards exceptions.
-    let code = unsafe { sipi_image_dims(c_path.as_ptr(), &mut dims) };
+    let code = unsafe { sipi_image_dims(c_path.as_ptr(), &mut dims, None, std::ptr::null_mut()) };
     if code != 0 {
         return Err(code);
     }
@@ -672,6 +692,76 @@ pub fn mimetype(resolved_path: &str) -> Result<String, i32> {
         return Err(code);
     }
     out.ok_or(-1)
+}
+
+/// An image's original-file identity, read from its embedded Essentials
+/// packet: the client-declared mimetype and filename at upload time. Both
+/// fields are known together or not at all — see
+/// [`image_dims_and_essentials`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ImageEssentials {
+    pub original_mimetype: String,
+    pub original_filename: String,
+}
+
+/// Collects the jointly-emitted essentials strings into the
+/// `Option<ImageEssentials>` at `ctx`. Fires at most once; a null pointer on
+/// either string (should not happen — the probe emits both or neither) skips
+/// the write rather than panicking.
+extern "C" fn collect_essentials(
+    ctx: *mut c_void,
+    orig_mimetype: *const c_char,
+    orig_filename: *const c_char,
+) {
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        // SAFETY: `ctx` is the `&mut Option<ImageEssentials>` passed to
+        // sipi_image_dims.
+        let out = unsafe { &mut *(ctx as *mut Option<ImageEssentials>) };
+        if orig_mimetype.is_null() || orig_filename.is_null() {
+            return;
+        }
+        // SAFETY: the engine passes NUL-terminated C strings valid for the call.
+        let (original_mimetype, original_filename) = unsafe {
+            (
+                CStr::from_ptr(orig_mimetype).to_string_lossy().into_owned(),
+                CStr::from_ptr(orig_filename).to_string_lossy().into_owned(),
+            )
+        };
+        *out = Some(ImageEssentials {
+            original_mimetype,
+            original_filename,
+        });
+    }));
+}
+
+/// Header-only image shape AND original-file identity, for a validated path,
+/// from a SINGLE `read_shape()` call (the knora.json path wants both; see
+/// [`image_dims`] for the info.json path, which wants only the shape and so
+/// pays for no essentials work). The identity is `None` when the file carries
+/// no Essentials packet (a plain JPEG/PNG, or a packet-less TIFF/JP2 — not an
+/// error). `Err` carries the FFI status (500 if the shape cannot be read), or
+/// -1 on an interior NUL in the path.
+pub fn image_dims_and_essentials(
+    resolved_path: &str,
+) -> Result<(SipiImageDims, Option<ImageEssentials>), i32> {
+    let c_path = CString::new(resolved_path).map_err(|_| -1)?;
+    let mut dims = SipiImageDims::default();
+    let mut essentials: Option<ImageEssentials> = None;
+    // SAFETY: `c_path` outlives the synchronous call; `out` is a valid
+    // pointer; `collect_essentials` writes into `essentials` via the ctx
+    // pointer; the seam guards exceptions.
+    let code = unsafe {
+        sipi_image_dims(
+            c_path.as_ptr(),
+            &mut dims,
+            Some(collect_essentials),
+            &mut essentials as *mut Option<ImageEssentials> as *mut c_void,
+        )
+    };
+    if code != 0 {
+        return Err(code);
+    }
+    Ok((dims, essentials))
 }
 
 // ── Preflight wrappers ──────────────────────────────────────────────────────

--- a/src/server-rs/src/info.rs
+++ b/src/server-rs/src/info.rs
@@ -12,7 +12,7 @@
 
 use serde_json::{json, Map, Value};
 
-use crate::ffi::{SipiImageDims, SipiPermType};
+use crate::ffi::{ImageEssentials, SipiImageDims, SipiPermType};
 
 const IMAGE_CONTEXT: &str = "http://iiif.io/api/image/3/context.json";
 const FILE_CONTEXT: &str = "http://sipi.io/api/file/3/context.json";
@@ -172,11 +172,20 @@ fn knora_base(id: &str, sidecar: &Sidecar) -> Map<String, Value> {
 }
 
 /// `knora.json` for an image (`SipiHttpServer.cpp:913-944`). `originalMimeType` /
-/// `originalFilename` (only present when `read_shape` reports an Essentials
-/// packet, `success == ALL`) are deferred — `sipi_image_dims` does not surface
-/// the packet metadata; the e2e requires only the fields below.
+/// `originalFilename` come from the image's embedded Essentials packet
+/// (`essentials`, via `sipi_image_essentials`) — present together iff
+/// `read_shape` reports one (`success == ALL`), absent together otherwise (a
+/// plain JPEG/PNG or a packet-less TIFF/JP2). Unlike the video/generic paths,
+/// these do NOT come from the `.info` sidecar — the C++ oracle sources image
+/// identity from the embedded packet only.
 #[must_use]
-pub fn image_knora_json(id: &str, mime: &str, dims: &SipiImageDims, sidecar: &Sidecar) -> Value {
+pub fn image_knora_json(
+    id: &str,
+    mime: &str,
+    dims: &SipiImageDims,
+    sidecar: &Sidecar,
+    essentials: Option<&ImageEssentials>,
+) -> Value {
     let mut root = knora_base(id, sidecar);
     root.insert("width".into(), json!(dims.width));
     root.insert("height".into(), json!(dims.height));
@@ -184,6 +193,10 @@ pub fn image_knora_json(id: &str, mime: &str, dims: &SipiImageDims, sidecar: &Si
         root.insert("numpages".into(), json!(dims.numpages));
     }
     root.insert("internalMimeType".into(), json!(mime));
+    if let Some(e) = essentials {
+        root.insert("originalMimeType".into(), json!(e.original_mimetype));
+        root.insert("originalFilename".into(), json!(e.original_filename));
+    }
     Value::Object(root)
 }
 
@@ -364,10 +377,31 @@ mod tests {
             "image/jp2",
             &dims(512, 512, 512, 8),
             &Sidecar::default(),
+            None,
         );
         assert_eq!(v["@context"], FILE_CONTEXT);
         assert_eq!(v["width"], 512);
         assert_eq!(v["internalMimeType"], "image/jp2");
+        // No Essentials packet → neither identity field is emitted.
+        assert!(v.get("originalMimeType").is_none());
+        assert!(v.get("originalFilename").is_none());
+    }
+
+    #[test]
+    fn image_knora_json_with_essentials() {
+        let essentials = ImageEssentials {
+            original_mimetype: "image/tiff".to_string(),
+            original_filename: "lena512.tif".to_string(),
+        };
+        let v = image_knora_json(
+            "http://h/i.jp2",
+            "image/jp2",
+            &dims(512, 512, 512, 8),
+            &Sidecar::default(),
+            Some(&essentials),
+        );
+        assert_eq!(v["originalMimeType"], "image/tiff");
+        assert_eq!(v["originalFilename"], "lena512.tif");
     }
 
     #[test]

--- a/src/server-rs/src/routes.rs
+++ b/src/server-rs/src/routes.rs
@@ -1359,10 +1359,11 @@ fn serve_knora_json(resolved: &str, parsed: &ParsedRequest, headers: &HeaderMap)
     let sidecar = read_sidecar(resolved);
 
     let value = if IMAGE_MIMES.contains(&mime.as_str()) {
-        match ffi::image_dims(resolved) {
-            Ok(dims) => info::image_knora_json(&id, &mime, &dims, &sidecar),
+        let (dims, essentials) = match ffi::image_dims_and_essentials(resolved) {
+            Ok(result) => result,
             Err(_) => return sink::error_response(StatusCode::INTERNAL_SERVER_ERROR),
-        }
+        };
+        info::image_knora_json(&id, &mime, &dims, &sidecar, essentials.as_ref())
     } else {
         let size = match std::fs::metadata(resolved) {
             Ok(m) => m.len(),

--- a/test/_test_data/config/sipi.e2e-test-config.lua
+++ b/test/_test_data/config/sipi.e2e-test-config.lua
@@ -272,6 +272,11 @@ routes = {
     },
     {
         method = 'GET',
+        route = '/env_echo',
+        script = 'env_echo.lua'
+    },
+    {
+        method = 'GET',
         route = '/test_knora_session_cookie',
         script = 'test_knora_session_cookie.lua'
     },

--- a/test/_test_data/scripts/env_echo.lua
+++ b/test/_test_data/scripts/env_echo.lua
@@ -1,0 +1,14 @@
+-- Echoes an env var read via `os.getenv`, proving the Rust binary's Lua VM
+-- still sees process environment variables (no accidental env-scrubbing or
+-- sandboxing). A route, not a preflight: routes get a real response sink, so
+-- both the set and unset cases are safe to exercise here.
+
+require "send_response"
+
+local host = os.getenv("KNORA_WEBAPI_KNORA_API_EXTERNAL_HOST")
+
+if host then
+    send_success({ host = host })
+else
+    send_error(500, "KNORA_WEBAPI_KNORA_API_EXTERNAL_HOST is not set")
+end

--- a/test/e2e/tests/differential.rs
+++ b/test/e2e/tests/differential.rs
@@ -180,7 +180,7 @@ const CASES: &[Case] = &[
     Case { name: "lua_exif_gps", method: Method::GET, path: "/test_exif_gps", headers: &[], allow: Allow::Default, gap: None },
     Case { name: "lua_read_write", method: Method::GET, path: "/read_write_lua", headers: &[], allow: Allow::Default, gap: None },
     Case { name: "video_knora_json_x_forwarded_proto", method: Method::GET, path: "/unit/8pdET49BfoJ-EeRcIbgcLch.mp4/knora.json", headers: &[("X-Forwarded-Proto", "https")], allow: Allow::Xfp, gap: None },
-    Case { name: "knora_json_image_required_fields", method: Method::GET, path: "/unit/lena512.jp2/knora.json", headers: &[], allow: Allow::Default, gap: Some("cluster D (DEV-6659 step 7): info.rs defers originalFilename/originalMimeType on the image knora.json path (the video path emits them) — plan 02 §3 cluster D") },
+    Case { name: "knora_json_image_required_fields", method: Method::GET, path: "/unit/lena512.jp2/knora.json", headers: &[], allow: Allow::Default, gap: None },
     Case { name: "knora_json_nonexistent_file", method: Method::GET, path: "/unit/no-such-file.jp2/knora.json", headers: &[], allow: Allow::Default, gap: Some("intentional: missing knora.json source → Rust 404, C++ 500 (the e2e test accepts either; 404 is the more correct status).") },
     Case { name: "knora_json_csv_file", method: Method::GET, path: "/unit/test.csv/knora.json", headers: &[], allow: Allow::Default, gap: None },
     Case { name: "prometheus_metrics", method: Method::GET, path: "/metrics", headers: &[], allow: Allow::Default, gap: Some("§5 #1 intentional: /metrics is removed in the Rust shell (OTLP replaces the Prometheus scrape) — C++ serves 200, Rust has no route. Permanent divergence.") },
@@ -1417,4 +1417,47 @@ fn sipi_rs_port_beats_explicit_serverport() {
         "the explicit --serverport ({explicit_port}) must NOT be where the shell \
          listens once SIPI_RS_PORT wins"
     );
+}
+
+// ---- Env-var propagation (Lua os.getenv under the Rust binary) -------------
+
+/// The Lua VM under the Rust shell still sees process environment variables —
+/// no accidental env-scrubbing/sandboxing. Exercised through a plain Lua
+/// ROUTE (`/env_echo`, real response sink) rather than a preflight hook: a
+/// preflight's response sink is null today, so a preflight-based version of
+/// this test would crash the subject on the unset case below. Subject-only.
+#[test]
+fn env_var_reaches_lua_vm_when_set() {
+    let srv = SipiServer::start_env(
+        "config/sipi.e2e-test-config.lua",
+        &sipi_e2e::test_data_dir(),
+        &["--cache-size", "0"],
+        &[("KNORA_WEBAPI_KNORA_API_EXTERNAL_HOST", "example.test")],
+    );
+    let resp = sipi_e2e::http_client()
+        .get(format!("{}/env_echo", srv.base_url))
+        .send()
+        .expect("GET /env_echo failed");
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: serde_json::Value = resp.json().expect("env_echo response not JSON");
+    assert_eq!(body["host"], "example.test");
+}
+
+/// The unset case: no accidental fallback/panic when the var is absent —
+/// os.getenv returns nil and the script's own contract (send_error(500))
+/// takes effect cleanly. Not `--jwtkey`-style — this is a route, so an
+/// explicit 500 response is safe to construct (unlike preflight).
+#[test]
+fn env_var_absent_yields_clean_500() {
+    let srv = SipiServer::start_env(
+        "config/sipi.e2e-test-config.lua",
+        &sipi_e2e::test_data_dir(),
+        &["--cache-size", "0"],
+        &[],
+    );
+    let resp = sipi_e2e::http_client()
+        .get(format!("{}/env_echo", srv.base_url))
+        .send()
+        .expect("GET /env_echo failed");
+    assert_eq!(resp.status().as_u16(), 500);
 }

--- a/test/e2e/tests/upload.rs
+++ b/test/e2e/tests/upload.rs
@@ -73,7 +73,6 @@ fn upload_tiff_converts_to_jp2() {
 }
 
 #[test]
-#[ignore = "Phase C gap (DEV-6659 step 7): knora.json sidecar originalMimeType/originalFilename deferred on the image path — plan 02 cluster D"]
 fn upload_tiff_knora_json() {
     let srv = server();
     let file = test_image_path("unit/lena512.tif");
@@ -97,7 +96,6 @@ fn upload_tiff_knora_json() {
 }
 
 #[test]
-#[ignore = "Phase C gap (DEV-6659 step 7): knora.json sidecar originalMimeType/originalFilename deferred on the image path — plan 02 cluster D"]
 fn upload_jpeg_with_comment_block() {
     let srv = server();
     let file = test_image_path("unit/HasCommentBlock.JPG");
@@ -155,7 +153,6 @@ fn upload_odd_file() {
 // =============================================================================
 
 #[test]
-#[ignore = "Phase C gap (DEV-6659 step 7): knora.json sidecar originalMimeType/originalFilename deferred on the image path — plan 02 cluster D"]
 fn metadata_preservation_upload() {
     // Upload image with EXIF metadata (img_exif_gps.jpg has GPS EXIF data),
     // retrieve via knora.json, verify metadata fields are preserved.
@@ -223,7 +220,6 @@ fn metadata_format_conversion() {
 }
 
 #[test]
-#[ignore = "Phase C gap (DEV-6659 step 7): knora.json sidecar originalMimeType/originalFilename deferred on the image path — plan 02 cluster D"]
 fn metadata_essentials_roundtrip() {
     // Verify SipiEssentials (original filename, mimetype, data checksum)
     // survive upload→store→retrieve cycle via knora.json fields.
@@ -269,7 +265,6 @@ fn metadata_essentials_roundtrip() {
 }
 
 #[test]
-#[ignore = "Phase C gap (DEV-6659 step 7): knora.json sidecar originalMimeType/originalFilename deferred on the image path — plan 02 cluster D"]
 fn upload_4bit_palette_png() {
     // Upload the palette PNG (mario.png is a palette-based PNG).
     let srv = server();


### PR DESCRIPTION
Part of DEV-6659.

## Motivation
The Rust shell's `knora.json` handler omitted `originalMimeType`/`originalFilename` on the image path — the only FFI probe it had (`sipi_image_dims`) discarded these fields even though the underlying C++ engine call already computed them. This blocked one differential-parity case and 5 e2e tests. Phase C step 7 (cluster D) closes this gap against the C++ oracle. JWT/cluster F is deliberately out of scope — it's blocked on the preflight response-sink fix, now step 9.

## Summary
- `knora.json` for images now emits `originalMimeType`/`originalFilename`, at parity with the C++ oracle, sourced from the file's embedded Essentials packet.
- One previously-gapped differential case and 5 previously-ignored `upload.rs` tests are re-enabled.
- A route-based pin (`/env_echo`) proves Lua `os.getenv` still reaches the Rust binary's Lua VM (§7.6 R2), without touching the crash-prone preflight response sink.

## Key Changes
### The FFI probe (cluster D)
- `sipi_image_dims` gains an optional (nullable) `SipiEssentialsFn emit` parameter. One `read_shape()` call now serves both the native shape (always) and the Essentials identity (fired together, iff `success == ALL`). `info.json`'s call site passes no callback and pays nothing extra; `knora.json`'s call site (`image_dims_and_essentials`) gets both from a single call.
- `image_knora_json` inserts `originalMimeType`/`originalFilename` when the probe fires; the doc comment no longer says "deferred".
- New C++ unit tests (`seam_probe_test.cpp`): fires-with-packet, doesn't-fire-without-packet, non-image error.

### Differential + e2e re-enables
- `differential.rs::knora_json_image_required_fields` un-gapped — full corpus green.
- `upload.rs`: `upload_tiff_knora_json`, `upload_jpeg_with_comment_block`, `metadata_preservation_upload`, `metadata_essentials_roundtrip`, `upload_4bit_palette_png` un-ignored. Verified via static analysis of `upload.lua` (it stamps `file_role = "service-file"` at upload time, unconditionally for every image type) that the write path already embeds the packet, so the read-side fix alone suffices — confirmed by all 5 passing on the first run.

### R2 pin — env-var survival, via a route not a preflight
- New `test/_test_data/scripts/env_echo.lua` + `/env_echo` route registration. Preflight's response sink is null today (the response-sink DoS, DEV-6670, tracked for step 9) — any explicit response construction there crashes the process. A route gets a real sink, proving the identical env→process→Lua-VM property safely. Step 9 will add the literal preflight-based version once the sink fix lands (tracked in the master plan).

### Docs
- `testing-strategy.md`: flipped the two coverage-matrix rows this PR closes (Essentials round-trip, 4-bit palette PNG upload). Also recomputed the Gap Summary rollup — the Sipi-extensions row (19/76/20%) was already stale before this PR (actual matrix content was 26/74); corrected to the accurate current count (28/72/28%), which cascades into the Total row and the Metadata bullet.

## Challenges and Decisions
### Two probes vs. one (design reconsidered mid-review)
**Problem:** `originalMimeType`/`originalFilename` come from the same `SipiImage::read_shape()` call `sipi_image_dims` already makes, but `sipi_image_dims`'s existing signature only carries the numeric shape fields.
**Tried:** Initially shipped a wholly separate sibling probe, `sipi_image_essentials`, reasoning it as "one probe, one concern" (the precedent being `sipi_mimetype` existing separately from `sipi_image_dims`). This kept `sipi_image_dims`'s signature and its info.json call site untouched, at the cost of a second `read_shape()` call per `knora.json` request.
**Solution:** The adversarial review's simplicity pass re-raised this as a Critical finding, and a direct question from the maintainer ("why is image_dims and image_essentials not called read_shape?") clarified the actual distinction: `sipi_mimetype` is a genuinely different engine mechanism (libmagic sniff) from `read_shape`, so splitting it out was correct — but `sipi_image_dims` and the new `sipi_image_essentials` were never separate concerns, just two views into one already-computed result. Consolidated into a single `sipi_image_dims` with an optional emit callback (`None` = don't bother, matching the seam's existing "NULL = absent" idiom) — `info.json` costs nothing extra, `knora.json` costs one call instead of two.

### De-risking the upload write path before writing any code
**Problem:** The 5 upload tests exercise upload→convert→read, so a read-side-only fix might not be sufficient if the write path never embedded the Essentials packet in the first place.
**Solution:** Static analysis of `test/_test_data/scripts/upload.lua` (before touching the FFI) showed it unconditionally writes with `file_role = "service-file"` + the client's `origname`/`mimetype` for every image type the upload route accepts — routing through the same engine-side Essentials-stamping code `sipi convert service-file` uses. This confirmed the write path was healthy and let the plan proceed with the full read-side fix + all 5 re-enables in one pass, which the test run then confirmed.

## Gotchas
- **`sipi_image_dims` now has a 4th and 5th parameter.** Any future C++ or Rust call site must pass `nullptr, nullptr` (C++) or `None, ptr::null_mut()` (Rust) if it doesn't want the Essentials identity — don't add a third split-out probe for the next field pulled from `SipiImgInfo`; extend this one the same way.
- **The `/env_echo` route is an interim proxy, not the final R2 test.** It exists specifically to avoid the preflight response-sink DoS; step 9 must add a real preflight-based test once the sink fix lands (tracked in the master plan's step-9 checklist), and can retire or keep the route version as a secondary check.
- **Essentials identity is genuinely optional per-file, never a `has_X` flag.** A plain JPEG/PNG or a packet-less TIFF/JP2 legitimately has no original-file identity — this is not an error path, and the gating (`success == ALL`) must fire both strings together or neither, never per-field.

## Test Plan
- [x] `bazel test //src/ffi:seam_probe_test` — 10/10 (3 new)
- [x] `bazel test //src/server-rs:sipi_unit_test` — incl. 2 new `image_knora_json` tests
- [x] `bazel test //test/e2e:differential` — full corpus green, incl. the un-gapped case + 2 new R2 tests
- [x] `bazel test //test/e2e:upload` — all 5 previously-ignored tests now pass
- [x] `just bazel-coverage` — 51 pass, 1 expected skip (docker_smoke, no local Docker)
- [x] `just bazel-rustfmt-check`, `just differential-coverage-check`
- [x] Adversarial review (cpp / rust / consistency / simplicity / security, 3-vote verification): 17 findings survived — 2 real doc-staleness issues fixed, 1 Critical design finding addressed via consolidation, rest were correctness confirmations (no bugs found)