### PR TITLE
step 8: null-byte re-pin + HTTPS retarget (clusters G + J)

### DIFF
--- a/src/server-rs/src/routes.rs
+++ b/src/server-rs/src/routes.rs
@@ -159,6 +159,18 @@ pub async fn iiif(
         Err(_) => return sink::error_response(StatusCode::BAD_REQUEST),
     };
 
+    // R7: an interior NUL in the decoded identifier/prefix is rejected outright
+    // (matches the docroot guard's R7, `decode_path_suffix`; the C++ oracle's
+    // own null-byte guard, `Connection.cpp:359-373`, is also NUL-only). NUL
+    // only — not the full control-char set: this path has no independent CRLF
+    // guard (unlike `redirect()`, whose `HeaderValue::from_str` already rejects
+    // CRLF regardless of this check), and the C++ oracle doesn't reject CRLF
+    // here either — broadening this check would reject an identifier the
+    // oracle still serves, a new, unpinned divergence.
+    if parsed.identifier.contains('\0') || parsed.prefix.contains('\0') {
+        return sink::error_response(StatusCode::BAD_REQUEST);
+    }
+
     // R1: string-level traversal check on the decoded identifier (and prefix when
     // it is a path component), before any path construction or preflight.
     if path::contains_traversal(&parsed.identifier)
@@ -927,8 +939,10 @@ pub fn docroot_method_router(state: Arc<AppState>) -> Option<MethodRouter<Arc<Ap
 /// `.lua`/`.elua` script with `server.docroot` injected. The path is
 /// containment-validated against the realpath'd docroot before any open — the C++
 /// handler had no traversal guard; the Rust shell adds R1/R2 (plan 02 §6 C). An
-/// interior NUL / control char in the decoded path → 400 (the null-byte guard the
-/// IIIF catch-all applies, R7).
+/// interior NUL or other control char in the decoded path → 400 (this handler's
+/// own guard, `decode_path_suffix`, R7 — strictly wider than the IIIF
+/// catch-all's own R7, which rejects NUL only; see that check's comment for
+/// why).
 async fn serve_docroot(state: Arc<AppState>, req: Request) -> Response {
     // OPTIONS is the CORS preflight (engine-independent), folded into this handler
     // so the method router stays a single closure.
@@ -1209,14 +1223,14 @@ fn static_binary(
 }
 
 /// Percent-decode a URL path suffix to an on-disk path fragment. `None` (→ the
-/// caller 400s) on invalid UTF-8 or an interior NUL / control char (the null-byte
-/// + header-injection guard the IIIF catch-all also applies).
+/// caller 400s) on invalid UTF-8 or an interior NUL / control char — a strictly
+/// wider guard than the IIIF catch-all's own R7 (NUL only; see its comment).
 fn decode_path_suffix(enc: &str) -> Option<String> {
     let decoded = percent_encoding::percent_decode_str(enc)
         .decode_utf8()
         .ok()?;
-    // `is_ascii_control` covers 0x00–0x1F and 0x7F, so the NUL-byte guard the IIIF
-    // catch-all applies is subsumed here.
+    // `is_ascii_control` covers 0x00–0x1F and 0x7F, so the IIIF catch-all's
+    // NUL-only R7 check is subsumed here (this guard is strictly wider).
     if decoded.bytes().any(|b| b.is_ascii_control()) {
         return None;
     }

--- a/test/e2e/src/lib.rs
+++ b/test/e2e/src/lib.rs
@@ -76,9 +76,7 @@ impl ServerKind {
 pub struct SipiServer {
     child: Child,
     pub http_port: u16,
-    pub ssl_port: u16,
     pub base_url: String,
-    pub ssl_base_url: String,
 }
 
 impl SipiServer {
@@ -430,9 +428,7 @@ impl SipiServer {
         SipiServer {
             child,
             http_port,
-            ssl_port,
             base_url,
-            ssl_base_url: format!("https://127.0.0.1:{}", ssl_port),
         }
     }
 

--- a/test/e2e/tests/input_validation.rs
+++ b/test/e2e/tests/input_validation.rs
@@ -101,8 +101,15 @@ fn path_traversal_mixed_case_encoded() {
 // Null Byte Injection Tests (R5-R7)
 // =============================================================================
 
+// This is a single-server pin only — there is no `differential.rs` `Case` for
+// it. The C++ oracle rejects a `%00` identifier at the transport layer
+// (`Connection.cpp`) by flushing a plaintext body before the status-line/header
+// block is written, so its response is not valid HTTP framing for this input
+// (a real HTTP client, e.g. curl or reqwest, cannot parse a status out of it —
+// only a raw byte reader doing a substring search, as below, "sees" 400). That
+// quirk lives in `src/shttps/transport/`, which is deleted wholesale at the end
+// of the cutover (DEV-6659), so it is not worth new cross-binary test machinery.
 #[test]
-#[ignore = "Phase C gap (DEV-6659 step 8): null byte on the redirect path returns 500 not 400 (Rust lacks the pre-parse substring guard) — plan 02 cluster G"]
 fn null_byte_in_iiif_url_returns_400() {
     let srv = server();
     // Use raw TCP since null byte in URL causes HTTP client issues

--- a/test/e2e/tests/server.rs
+++ b/test/e2e/tests/server.rs
@@ -477,25 +477,14 @@ fn knora_json_csv_file() {
 // Phase 3: Sipi Extension Gap Tests
 // =============================================================================
 
-#[test]
-#[ignore = "Phase C gap (DEV-6659 step 8): Rust shell serves plain HTTP only (TLS terminates at Traefik); HTTPS listener dropped — plan 02 cluster J"]
-fn ssl_endpoints() {
-    let srv = server();
-    let resp = client()
-        .get(format!("{}/unit/lena512.jp2/info.json", srv.ssl_base_url))
-        .send()
-        .expect("GET HTTPS info.json failed");
-
-    assert_eq!(resp.status().as_u16(), 200);
-
-    let json: serde_json::Value = resp.json().expect("invalid JSON");
-    let id = json["id"].as_str().expect("id must be string");
-    assert!(
-        id.starts_with("https://"),
-        "info.json id should use https:// scheme over SSL, got: {}",
-        id
-    );
-}
+// A live-TLS request (e.g. a former `ssl_endpoints` test) is deliberately not
+// covered here: the Rust shell serves plain HTTP only (TLS terminates at
+// Traefik), so it can never bind a real TLS socket. The scheme contract such a
+// test would have checked is already asserted without one:
+// `info_json_x_forwarded_proto_https` (iiif_compliance.rs) drives info.json
+// over plain HTTP with `X-Forwarded-Proto: https` and asserts the same `id`
+// scheme; the differential harness covers the same XFP-derived scheme/host on
+// info/knora and the 303 redirect scheme at full parity (DEV-6659).
 
 #[test]
 fn mime_consistency() {

--- a/tools/differential_coverage_check.sh
+++ b/tools/differential_coverage_check.sh
@@ -20,7 +20,7 @@ cd "$(dirname "$0")/.."
 # Baseline: #[test] + #[tokio::test] across test/e2e/tests/*.rs EXCLUDING the
 # differential corpus file itself. Bump this (with a corpus update) whenever an
 # e2e test is added or removed.
-EXPECTED_E2E_TESTS=275
+EXPECTED_E2E_TESTS=274
 
 # Count via awk on a concatenated stream with literal `[ \t]` + exact string
 # compare — deterministic across awk/grep implementations. (Earlier a


### PR DESCRIPTION
Part of DEV-6659.

## Motivation

Step 8 of the SIPI C++→Rust strangler cutover (the differential-parity
gate) had two remaining gaps blocking the §9 deploy gate: a `%00` in an
IIIF identifier 500'd instead of 400'ing on the image/info/knora path
(cluster G), and `server::ssl_endpoints` could never pass against the
Rust shell because it connects over a real TLS socket the shell never
binds (TLS terminates at Traefik; cluster J). Both had sat behind
`#[ignore]` since the M4 CLI-surface characterization pass.

## Summary

- An interior NUL in the IIIF identifier/prefix now returns 400 on
  every request kind (image, info.json, knora.json, redirect) instead
  of 500 on the image/info/knora path.
- `server::ssl_endpoints` is deleted — its scheme contract was already
  asserted elsewhere without a live TLS socket.
- Cleaned up two now-dead public fields on the e2e harness's
  `SipiServer` (`ssl_base_url`, `ssl_port`) found during review.

## Key Changes

### Null-byte guard (`src/server-rs/src/routes.rs`)
Added a NUL-only check at the shared IIIF chokepoint — before the R1
traversal check, the redirect branch, and the engine-pool permit
acquire — so every `RequestKind` is covered and a malformed request is
rejected before it costs a pool permit or a preflight VM invocation.
Root cause: an interior NUL reached `ffi::preflight`'s
`CString::new(identifier)`, whose failure was mapped to 500 — a bug
that only surfaced when a `pre_flight` hook was configured (as the e2e
config has), which is why the `#[ignore]` reason and the master plan's
own characterization disagreed on which path was affected. Labelled R7
to match the docroot handler's existing R7 (`decode_path_suffix`),
which is a strictly wider guard (full control-char, not NUL-only) —
narrowed the two comments describing that relationship so neither
overclaims what the IIIF catch-all actually rejects.

### HTTPS retarget (`test/e2e/tests/server.rs`, `test/e2e/src/lib.rs`)
Deleted `ssl_endpoints` outright rather than retargeting it onto an
X-Forwarded-Proto assertion as originally scoped — that assertion
already exists (`iiif_compliance.rs::info_json_x_forwarded_proto_https`
plus the differential harness's XFP `Case`s), so no new test was
needed. Removed the resulting dead fields from `SipiServer`.

### Coverage drift guard (`tools/differential_coverage_check.sh`)
`EXPECTED_E2E_TESTS` 275 → 274 (net −1 from the `ssl_endpoints`
deletion; re-enabling the null-byte test only removed its `#[ignore]`,
not its `#[test]` line, so it didn't move the count).

## Challenges and Decisions

### The C++ oracle's response to `%00` isn't valid HTTP
**Problem:** before writing the fix, needed to resolve a discrepancy the
plan flagged empirically — was the null-byte gap on the redirect path
(303-not-400, per the plan) or the image path (500-not-400, per the
`#[ignore]` reason)? And what should the differential-harness treatment
be, since the C++ oracle's own behavior for this input was never
directly confirmed.
**Investigated:** built both binaries and probed
`GET /unit/lena512%00.jp2/full/max/0/default.jpg` live via raw TCP and
curl against each. Rust: 500 on the image path (via the `CString::new`
failure), already 400 on the redirect path — so the plan's "redirect
path returns 303" claim was the stale one, not the `#[ignore]` reason.
C++: curl reported "Received HTTP/0.9 when not allowed" (status 000) —
`Connection.cpp`'s substring check writes the plaintext error body to
the raw socket *before* `flush()` triggers the status-line/header
write, so the wire bytes are body-then-headers, not valid HTTP framing.
Only a raw byte reader doing a substring search "sees" 400 in there,
which is exactly why the existing single-server e2e test uses raw
`TcpStream` instead of an HTTP client.
**Solution:** raised this to Ivan mid-session, since reqwest (what
`differential.rs`'s `diff_request`/`Case` mechanism uses) cannot parse
a `StatusCode` out of the oracle's malformed response — a typed
cross-binary pin isn't achievable for this input at all. Decision: no
new `differential.rs` `Case` or bespoke raw-TCP differential test. The
quirk lives entirely in `src/shttps/transport/`, which is deleted
wholesale at the transport-delete step (step 13), so it isn't worth
building new cross-binary test machinery against code on its way out.
The existing single-server `input_validation.rs::null_byte_in_iiif_url_returns_400`
is the sole pin, with the reasoning documented inline so a future
reader doesn't wonder why it isn't in `differential.rs` like the CRLF
test is.

### NUL-only scope, and a backward rationale caught in review
**Problem:** the guard is deliberately NUL-only, not the full
control-char set (which would also reject CRLF) — broadening it risked
silently regressing the separately-handled CRLF behavior. My first
draft of the code comment justified this by pointing at the
already-allowlisted CRLF-vs-redirect divergence.
**Tried:** a 5-lens adversarial review (Rust / C++-seam / consistency /
simplicity / security, via the `sonnet-fanout` skill) independently
verified the change against source. The C++-seam reviewer caught that
this rationale was backward: `redirect()`'s own `HeaderValue::from_str`
already rejects CRLF unconditionally, regardless of this guard's scope
— so broadening it changes *nothing* for the redirect path. The real
reason NUL-only is correct is that the image/info/knora paths have no
independent CRLF guard at all, and the C++ oracle's own null-byte check
(`Connection.cpp`) is also NUL-only — so broadening would make Rust
reject an identifier the oracle still serves, a new, unpinned
divergence on paths that today have none.
**Solution:** rewrote both comments (`routes.rs`, the IIIF catch-all
guard and the docroot handler's contrasting comment) with the corrected
rationale. The same review pass also caught two new "§5 #N"-style
plan-section cross-references the diff had introduced, violating this
repo's sparse-`DEV-XXXX`-only rule for code comments — removed and
replaced with plain behavioral descriptions. And it flagged a genuinely
dead `ssl_port` field alongside `ssl_base_url` (removed) and a
comment-placement nit in `server.rs` (fixed, so the explanatory comment
for the deleted `ssl_endpoints` test doesn't read as documentation for
the unrelated `mime_consistency` test below it).

## Gotchas

- **Don't broaden the IIIF catch-all's NUL check to a general
  control-char guard** — see the routes.rs code comment; it would
  create a new Rust-vs-C++ divergence on the image/info/knora paths
  (CRLF-in-identifier), not close one.
- **No `differential.rs` `Case` exists for the null-byte input, and
  that's intentional** — the C++ oracle's response to it isn't valid
  HTTP framing, so no typed cross-binary comparison is possible. Don't
  "fix" this by trying to add one; see the code comment in
  `input_validation.rs`.
- **`ssl_port` was dead code before this PR removed it** — nothing read
  the constructed `SipiServer.ssl_port` field; only the *local variable*
  inside `spawn()` (before construction) drives port-pair allocation and
  the `--sslport` arg. If a future test needs the subject's SSL port,
  it'll need to be re-added deliberately, not assumed to still exist.

## Test Plan

- [x] `just bazel-rustfmt-check` — clean
- [x] `just bazel-test-e2e` — 25/25 targets pass, including
      `input_validation` (null-byte test re-enabled) and `server`
      (`ssl_endpoints` gone)
- [x] `just bazel-test-differential` — green
- [x] `just differential-coverage-check` — green at `EXPECTED_E2E_TESTS=274`
- [x] `just bazel-coverage` — green
- [x] Manual: built both binaries, probed `GET /unit/lena512%00.jp2/full/max/0/default.jpg`
      live via raw TCP/curl against each — confirmed the before/after
      status change on Rust and the C++ oracle's malformed-response
      behavior, and confirmed both binaries stay healthy afterward
