### PR TITLE
build: ship the Rust cli-rs binary with file:line crash symbolication

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -101,6 +101,32 @@ build:release --copt=-U_FORTIFY_SOURCE
 build:release --copt=-D_FORTIFY_SOURCE=2
 build:release --per_file_copt=libmagic@-U_FORTIFY_SOURCE
 
+# Debug info for crash symbolication (DEV-6659). `-c opt` emits no DWARF on
+# its own, so a stripped-minidump crash resolved to bare addresses / at best
+# function names from `.symtab`. Line tables (C++ `-gline-tables-only` + Rust
+# `-Cdebuginfo=1`) make the release binary carry the address→file:line DWARF a
+# crash backtrace needs; `//src:sipi_debug_split` splits it out with
+# `--only-keep-debug` into the `.debug` uploaded to Sentry and ships the
+# stripped binary in the image (`:sipi_bin_layer`), so the DWARF lives only in
+# the uploaded symbols, never in the shipped binary. Line-tables-only (not full
+# `-g`) keeps the `.debug` and the release link an order of magnitude smaller
+# while preserving file:line frames; it omits inlined-frame expansion + locals,
+# which a stack symbolication does not need. Restores the file:line the
+# pre-Bazel (Nix `separateDebugInfo`) build had.
+build:release --copt=-gline-tables-only
+# Emit Rust line tables (`debuginfo=1`) AND override rules_rust's opt-mode
+# `-Cstrip=debuginfo`, which otherwise strips the DWARF (both Rust's and the
+# linked-in C++ engine's) out of the final rust_binary link — Bazel's
+# `--strip=never` does NOT reach the rustc link. rustc `-C` options are
+# last-wins and these are appended after the rule defaults, so `strip=none`
+# wins; `:sipi_debug_split` then has DWARF to extract and re-strips the
+# shipped binary itself. (Repeating the flag overrides, so both go in one
+# comma-separated value.)
+build:release --@rules_rust//rust/settings:extra_rustc_flags=-Cdebuginfo=1,-Cstrip=none
+# --strip=never keeps DWARF through the C++ (clang-driven) link of //src/cli:sipi
+# for the same reason (that path DOES honour Bazel --strip).
+build:release --strip=never
+
 # Linux-only: stack-clash-protection is a clang-on-Linux feature (warns
 # harmlessly on a darwin cross-compile). Its companion `-Wl,-z,now` linkopt
 # lives in //src:sipi_lib's (and :engine's) target-keyed linkopts select

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -819,18 +819,22 @@ tar --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner \\
 # `docker run --entrypoint ffprobe daschswiss/sipi …` (video metadata).
 # Per-arch layer selection is via `select()` on the host CPU below.
 
-# Sipi binary at /sbin/sipi — the Rust `cli-rs` shell (the deployed
-# entrypoint; the C++ //src/cli:sipi transport is retained in-tree only as
-# the differential oracle, DEV-6659). Kept at /sbin/sipi so the entrypoint
-# and the `sipi health` Docker HEALTHCHECK are unchanged. Linux-only because
-# the binary itself is Linux ELF; on darwin :sipi is Mach-O and not consumed
-# here.
+# Sipi binary at /sbin/sipi — the STRIPPED Rust `cli-rs` shell. Ships the
+# `:sipi_debug_split` stripped output (not the raw `//src/cli-rs:sipi`), so
+# the DWARF built under `--config=release` lives only in the `.debug`
+# uploaded to Sentry (`:sipi_debug_layout`), never in the shipped image; the
+# stripped binary keeps its `.note.gnu.build-id` + an embedded debuglink so
+# Sentry matches crash minidumps back to those symbols. cli-rs is the
+# deployed entrypoint; the C++ //src/cli:sipi transport stays in-tree only as
+# the differential oracle (DEV-6659). Kept at /sbin/sipi so the entrypoint +
+# `sipi health` HEALTHCHECK are unchanged. Linux-only (the binary is Linux
+# ELF; on darwin :sipi is Mach-O and not consumed here).
 tar(
     name = "sipi_bin_layer",
-    srcs = ["//src/cli-rs:sipi"],
+    srcs = [":_dbg/sipi.stripped"],
     mtree = [
         "./sbin type=dir mode=0755 time=0",
-        "./sbin/sipi type=file mode=0755 time=0 content=$(execpath //src/cli-rs:sipi)",
+        "./sbin/sipi type=file mode=0755 time=0 content=$(execpath :_dbg/sipi.stripped)",
     ],
     target_compatible_with = ["@platforms//os:linux"],
 )

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -720,7 +720,7 @@ expand_template(
 # "incompatible target" message rather than a confusing failure.
 genrule(
     name = "sipi_debug_split",
-    srcs = ["//src/cli:sipi"],
+    srcs = ["//src/cli-rs:sipi"],
     outs = [
         "_dbg/sipi.stripped",
         "_dbg/sipi.debug",
@@ -730,7 +730,7 @@ genrule(
 set -euo pipefail
 OBJCOPY=$(execpath //bazel:llvm-objcopy)
 READELF=$(execpath //bazel:llvm-readelf)
-BIN=$(execpath //src/cli:sipi)
+BIN=$(execpath //src/cli-rs:sipi)
 
 # Build-id is encoded in `.note.gnu.build-id`; llvm-readelf -n prints
 # something like:
@@ -747,10 +747,9 @@ echo "$$BUILD_ID" > $(execpath _dbg/sipi_build_id.txt)
 # embeds the .debug filename + CRC32, both finalised once stripping
 # is done).
 #
-# The output is in a `_dbg/` subdir so the stripped artifact's basename
-# stays `sipi.stripped` (matching the implicit `<binary>.stripped` output
-# Bazel generates for cc_binary, just at a different path) without
-# colliding with the cc_binary's own implicit-output declaration.
+# The output is in a `_dbg/` subdir purely to namespace these three
+# genrule outputs away from the `//src/cli-rs:sipi` binary's own output
+# names; the basenames (`sipi.stripped`, `sipi.debug`) stay conventional.
 "$$OBJCOPY" --only-keep-debug "$$BIN" $(execpath _dbg/sipi.debug)
 cp "$$BIN" $(execpath _dbg/sipi.stripped)
 "$$OBJCOPY" --strip-debug --strip-unneeded $(execpath _dbg/sipi.stripped)
@@ -820,15 +819,18 @@ tar --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner \\
 # `docker run --entrypoint ffprobe daschswiss/sipi …` (video metadata).
 # Per-arch layer selection is via `select()` on the host CPU below.
 
-# Sipi binary at /sbin/sipi. Linux-only because the binary itself is
-# Linux ELF (cc_binary //src/cli:sipi target_compatible_with linux for the
-# image-build path; on darwin :sipi is Mach-O and not consumed here).
+# Sipi binary at /sbin/sipi — the Rust `cli-rs` shell (the deployed
+# entrypoint; the C++ //src/cli:sipi transport is retained in-tree only as
+# the differential oracle, DEV-6659). Kept at /sbin/sipi so the entrypoint
+# and the `sipi health` Docker HEALTHCHECK are unchanged. Linux-only because
+# the binary itself is Linux ELF; on darwin :sipi is Mach-O and not consumed
+# here.
 tar(
     name = "sipi_bin_layer",
-    srcs = ["//src/cli:sipi"],
+    srcs = ["//src/cli-rs:sipi"],
     mtree = [
         "./sbin type=dir mode=0755 time=0",
-        "./sbin/sipi type=file mode=0755 time=0 content=$(execpath //src/cli:sipi)",
+        "./sbin/sipi type=file mode=0755 time=0 content=$(execpath //src/cli-rs:sipi)",
     ],
     target_compatible_with = ["@platforms//os:linux"],
 )

--- a/src/cli-rs/BUILD.bazel
+++ b/src/cli-rs/BUILD.bazel
@@ -37,6 +37,16 @@ _CPP_STDLIB_LINK = select({
         "-Clink-arg=-lc++",
     ],
     "@platforms//os:linux": [
+        # Content-addressed build-id, mirroring //src/cli:sipi's linkopt.
+        # `//src:sipi_debug_split` reads this from `.note.gnu.build-id` to
+        # split stripped binary + `.debug` and lay the debug file out under
+        # `lib/debug/.build-id/<xx>/<yy>.debug` for `sentry-cli debug-files
+        # upload`. `=sha1` derives the id from the binary's content hash
+        # (not a wall-clock random), so identical inputs ↔ identical build-id
+        # — the gate for byte-reproducible OCI tarballs. Without it the split
+        # genrule errors ("no Build ID"). ELF-only: ld64 on macOS rejects
+        # `--build-id` (macOS uses dSYM bundles, out of scope here).
+        "-Clink-arg=-Wl,--build-id=sha1",
         "-Clink-arg=-Wl,-Bstatic",
         "-Clink-arg=-lc++",
         "-Clink-arg=-lc++abi",


### PR DESCRIPTION
Part of DEV-6659

## Motivation

Step 10 of the SIPI C++→Rust strangler migrated crash reporting to the Rust `sentry` crate + out-of-process minidump, but the Docker image and the Sentry debug-symbol pipeline still pointed at the retired C++ binary. On top of that, `--config=release` emitted no DWARF, so crash reports symbolicated to function names at best (no file:line) — for the current C++ production binary too. This PR makes the shipped artifact the Rust `cli-rs` shell and restores file:line crash symbolication.

The C++ `//src/cli:sipi` transport is **intentionally retained** in-tree as the differential-testing oracle; only the shipped and symbol-uploaded artifact changes here.

## Summary

- The Docker image entrypoint and the Sentry debug-symbol upload now target the Rust `cli-rs` binary.
- The image ships a **stripped** binary (fixing a latent bug where it shipped the raw one); DWARF is split out for Sentry upload only.
- Release builds now carry line-table DWARF, so Sentry resolves both Rust and C++ crash frames to `file:line`.

## Key Changes

### cli-rs as the shipped binary
- `-Wl,--build-id=sha1` on the linux `cli-rs` link (mirrors `//src/cli:sipi`) so `:sipi_debug_split` can content-address and split its debug info.
- `:sipi_debug_split` and `:sipi_bin_layer` repointed from `//src/cli:sipi` → `//src/cli-rs:sipi`; kept at `/sbin/sipi` so the entrypoint + `sipi health` HEALTHCHECK are unchanged.
- `:sipi_bin_layer` now packages `:_dbg/sipi.stripped` (was: the raw binary).

### DWARF / symbolication (`.bazelrc` release config)
- `--copt=-gline-tables-only` (C++/C) + Rust `-Cdebuginfo=1`.
- `-Cstrip=none` overrides rules_rust's opt-mode `-Cstrip=debuginfo`.
- `--strip=never` keeps DWARF through the clang-linked `//src/cli:sipi` path.

## Challenges and Decisions

### Sentry symbolication was name-only in release
**Problem:** `--config=release` emitted no DWARF, so the split `.debug` was symtab-only and crash frames resolved to `??:0:0`. This affected the current C++ production binary too — a silent regression from the pre-Bazel Nix `separateDebugInfo` build.
**Solution:** enable line tables. Chose `-gline-tables-only` over full `-g` after measuring both on the linux-aarch64 release build: full `-g` → 215 MB `.debug` and a ~635 s link critical path; line-tables-only → same `file:line` frames with a 158 MB `.debug` and a 72 s link critical path. Inlined-frame expansion + locals are dropped, neither of which a crash backtrace needs.

### DWARF was stripped out of the rust_binary link
**Problem:** even with `-g`, the linked binary had zero DWARF, although the C++ `.o` files carried it.
**Tried:** `--strip=never` — no effect on the `rust_binary` link (pure cache hit). Bazel's `--strip` only governs the clang-linked `cc_binary` path (the C++ `//src/cli:sipi` binary *did* keep DWARF under it).
**Solution:** the culprit is rules_rust injecting `-Cstrip=debuginfo` in opt mode. Overrode it with `-Cstrip=none` via `extra_rustc_flags` (rustc `-C` options are last-wins, and `extra_rustc_flags` is appended after the rule defaults).

### Shipping the stripped binary
**Problem:** `:sipi_bin_layer` packaged the raw binary; the split's stripped output (`:_dbg/sipi.stripped`, produced with a `--add-gnu-debuglink`) was orphaned.
**Solution:** point the layer at the stripped output. It keeps `.note.gnu.build-id` + `.gnu_debuglink`, so Sentry matches crash minidumps to the uploaded `.debug`, and DWARF never ships in the image.

## Gotchas

- `--@rules_rust//rust/settings:extra_rustc_flags` does **not** accumulate on repeat — a second `--flag=…` overrides the first. Put multiple flags in one comma-separated value (`-Cdebuginfo=1,-Cstrip=none`).
- Bazel `--strip` does not reach the `rust_binary` (rustc-driven) link — use rustc's `-Cstrip` for that path.
- `:sipi_debug_layout`'s final `tar --sort=name` needs GNU tar and fails on a macOS host (BSD tar wins the PATH); it is a CI/linux-only step, unaffected by this PR.

## Test Plan

- [x] linux-aarch64 release: sha1 build-id present; split `.debug` carries `.debug_line`/`.debug_info`; `llvm-symbolizer` resolves a C++ frame (`essentials.cpp:131`) and a Rust frame (hyper `server.rs:548`) to `file:line`.
- [x] shipped stripped binary: no DWARF, keeps build-id + debuglink (40 MB); `//src:image` builds with it at `/sbin/sipi`.
- [ ] CI: Docker smoke (cli-rs entrypoint serves + `sipi health`), differential parity gate, 3-platform matrix.
- [ ] Operator: `sentry-cli debug-files upload` + confirm server-side symbolication of a real minidump against the live Sentry project; staging `kill -SEGV` → symbolicated event + clean restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhHzQM9bcU7rdE4Bb4ZuWn
