### PR TITLE
feat(server-rs): bridge engine + pool metrics to OTLP observable instruments

### DIFF
--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -129,7 +129,7 @@ jobs:
             export ASAN_SYMBOLIZER_PATH=\$(command -v llvm-symbolizer)
             rc=0
             just bazel-test-unit --config=asan --config=ubsan --build_tag_filters=-no-sanitizer --test_tag_filters=-no-sanitizer ${{ steps.rbe.outputs.flags }} || rc=1
-            just bazel-test-e2e  --config=asan --config=ubsan ${{ steps.rbe.outputs.flags }} || rc=1
+            just bazel-test-e2e  --config=asan --config=ubsan --test_tag_filters=-no-sanitizer ${{ steps.rbe.outputs.flags }} || rc=1
             exit \$rc"
 
       - name: Check for sanitizer findings

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ cmake-build-relwithdebinfo-nix-develop/
 test/_test_data/cache/
 test/_test_data/cache_test_*/
 test/_test_data/config/sipi.cache-test-*.lua
+test/_test_data/config/sipi.tracing-test.lua
 
 #ignore ICC headers
 *_icc.h

--- a/docs/adr/0017-extensibility-lua-and-rust.md
+++ b/docs/adr/0017-extensibility-lua-and-rust.md
@@ -78,10 +78,11 @@ Config is a separate, declarative concern (**TOML**), not scripting.
 - **TOML config is the declarative config surface** (serde + toml). It is config,
   not the extension mechanism, and is independent of the scripting-language
   question.
-- **The script → dsp-api distributed-tracing gap is independent of the language
-  choice.** Whatever the script language, the script's outbound call to dsp-api
-  goes through a host HTTP binding; connecting it to the trace requires the host
-  to inject `traceparent` across the seam. The language choice does not affect it.
+- **The script → dsp-api distributed-tracing gap is closed host-side, so it is
+  independent of the language choice.** The host injects a W3C `traceparent`
+  across the seam onto the script's outbound call (implemented for the Lua path),
+  so a downstream service continues the trace. Because it is host-side, a future
+  scripting language inherits it unchanged.
 - **A pure-Rust Lua runtime (mlua) is low priority.** If a different scripting
   language replaces Lua, reimplementing Lua in mlua is moot; while Lua persists,
   mlua only removes the C++ `LuaServer` dependency. Not a priority either way.

--- a/docs/src/development/profiling.md
+++ b/docs/src/development/profiling.md
@@ -16,7 +16,7 @@ wastes effort.
 |------|--------------------|-------|---------------|----------|
 | **Prometheus + Grafana** | *How does the service behave for real users — latency/cache/throughput distribution, in aggregate, over time? Is it trending worse?* | All requests, aggregated | **Production**, always-on | Negligible |
 | **Sentry** | *What broke, with what stack and context?* | Individual errors | Production | Negligible |
-| **OpenTelemetry tracing** *(not yet wired in Sipi)* | *For this one slow request, which stage ate the time?* | Per-request span tree | Production / staging | Low |
+| **OpenTelemetry tracing** | *For this one slow request, which stage ate the time?* | Per-request span tree | Production / staging | Low |
 | **Tracy** *(this doc)* | *Where in the code does the time go for this workload — per function, lock, allocation, thread, at ns resolution?* | One workload, deep | **Local dev**, opt-in | High while the GUI is connected |
 | **`just bench`** ([Benchmarking](benchmarking.md)) | *Did my specific change make this operation measurably faster?* | One isolated op | Local dev | Measurement harness |
 | **`just valgrind`** | *Is there a memory error or leak?* | Correctness, not speed | Local dev | Very high |
@@ -25,9 +25,12 @@ A note on the production stack, because the three pieces are often conflated:
 **OpenTelemetry** is the instrumentation *standard* (how telemetry is emitted),
 **Prometheus** is the aggregate *metrics store* (the counters/gauges/histograms
 behind `GET /metrics`), and **Grafana** is the *visualization* layer on top.
-Sipi's production observability today is **Prometheus metrics + Sentry**; OTel
-tracing would be the per-request complement if and when it is added. None of them
-tell you which C++ function consumed the milliseconds — that is Tracy's job.
+Sipi's Rust server emits **OpenTelemetry traces + OTLP metrics** (with Sentry for
+errors): per-request spans via `OtelAxumLayer`, W3C `traceparent` continuation
+in and out (incl. propagation to dsp-api on the Lua preflight's outbound call),
+and the engine counters bridged to OTLP. The retained C++ server still exposes
+the aggregate Prometheus `GET /metrics` scrape until the strangler cutover. None
+of them tell you which C++ function consumed the milliseconds — that is Tracy's job.
 
 ## The loop
 

--- a/docs/src/lua/index.md
+++ b/docs/src/lua/index.md
@@ -975,6 +975,12 @@ Performs an HTTP request using curl. Currently implements only GET requests. Par
 
 Authentication is not yet supported.
 
+When SIPI is handling a request under an active distributed trace, `server.http`
+automatically adds a W3C `traceparent` header to the outbound request so the
+downstream service continues the same trace (e.g. a `pre_flight` authorization
+call to dsp-api). If the `header` table already contains a `traceparent`, that
+value is kept and no header is injected.
+
 The result is a table:
 
     result = {

--- a/src/ffi/metrics_snapshot.h
+++ b/src/ffi/metrics_snapshot.h
@@ -12,8 +12,10 @@
  * them to an OTel meter (the C++ Prometheus `/metrics` handler stays until the
  * cutover, then retires — OTLP-only). The seam header keeps this struct opaque
  * so the contract commits no field set it doesn't need; this header — owned by
- * the implementing translation unit — carries the layout, and Phase C's bindgen
- * reads it here.
+ * the implementing translation unit — carries the layout. The Rust shell mirrors
+ * it by hand (`#[repr(C)] SipiMetricsSnapshot` in `src/server-rs/src/ffi.rs`),
+ * not via bindgen; the two layouts are held in lock-step by the paired
+ * `static_assert` block (below) and the Rust `offset_of!`/`size_of` test.
  *
  * Plain C, flat by design: every field is a single number, so the Rust meter
  * binds each to a counter/gauge instrument without parsing. **Counters** are
@@ -34,6 +36,7 @@
 #ifndef SIPI_FFI_METRICS_SNAPSHOT_H
 #define SIPI_FFI_METRICS_SNAPSHOT_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include "ffi/sipi_ffi.h"
@@ -71,5 +74,37 @@ struct SipiMetricsSnapshot
   int64_t decode_memory_budget_bytes;
   int64_t decode_memory_used_bytes;
 };
+
+#ifdef __cplusplus
+/* Lock-step layout guard — paired with the Rust offset/size_of test in
+ * src/server-rs/src/ffi.rs. Every field is 8 bytes wide (uint64_t / int64_t),
+ * so there is no packing subtlety, but the guard still catches an accidental
+ * field reorder or insertion on either side. LP64 on every supported target. */
+static_assert(sizeof(SipiMetricsSnapshot) == 192, "SipiMetricsSnapshot size drifted from src/server-rs/src/ffi.rs");
+static_assert(offsetof(SipiMetricsSnapshot, cache_hits_total) == 0, "SipiMetricsSnapshot layout drift");
+static_assert(offsetof(SipiMetricsSnapshot, cache_misses_total) == 8, "SipiMetricsSnapshot layout drift");
+static_assert(offsetof(SipiMetricsSnapshot, cache_evictions_total) == 16, "SipiMetricsSnapshot layout drift");
+static_assert(offsetof(SipiMetricsSnapshot, cache_skips_total) == 24, "SipiMetricsSnapshot layout drift");
+static_assert(offsetof(SipiMetricsSnapshot, image_too_large_total) == 32, "SipiMetricsSnapshot layout drift");
+static_assert(offsetof(SipiMetricsSnapshot, client_disconnected_total) == 40, "SipiMetricsSnapshot layout drift");
+static_assert(offsetof(SipiMetricsSnapshot, memory_alloc_failures_total) == 48, "SipiMetricsSnapshot layout drift");
+static_assert(offsetof(SipiMetricsSnapshot, rejected_connections_total) == 56, "SipiMetricsSnapshot layout drift");
+static_assert(offsetof(SipiMetricsSnapshot, rate_limit_allowed_total) == 64, "SipiMetricsSnapshot layout drift");
+static_assert(offsetof(SipiMetricsSnapshot, rate_limit_rejected_total) == 72, "SipiMetricsSnapshot layout drift");
+static_assert(offsetof(SipiMetricsSnapshot, rate_limit_shadow_rejected_total) == 80, "SipiMetricsSnapshot layout drift");
+static_assert(offsetof(SipiMetricsSnapshot, rate_limit_near_limit_total) == 88, "SipiMetricsSnapshot layout drift");
+static_assert(offsetof(SipiMetricsSnapshot, decode_memory_acquired_total) == 96, "SipiMetricsSnapshot layout drift");
+static_assert(offsetof(SipiMetricsSnapshot, decode_memory_rejected_total) == 104, "SipiMetricsSnapshot layout drift");
+static_assert(offsetof(SipiMetricsSnapshot, decode_memory_shadow_rejected_total) == 112, "SipiMetricsSnapshot layout drift");
+static_assert(offsetof(SipiMetricsSnapshot, decode_memory_near_limit_total) == 120, "SipiMetricsSnapshot layout drift");
+static_assert(offsetof(SipiMetricsSnapshot, waiting_connections) == 128, "SipiMetricsSnapshot layout drift");
+static_assert(offsetof(SipiMetricsSnapshot, cache_size_bytes) == 136, "SipiMetricsSnapshot layout drift");
+static_assert(offsetof(SipiMetricsSnapshot, cache_files) == 144, "SipiMetricsSnapshot layout drift");
+static_assert(offsetof(SipiMetricsSnapshot, cache_size_limit_bytes) == 152, "SipiMetricsSnapshot layout drift");
+static_assert(offsetof(SipiMetricsSnapshot, cache_files_limit) == 160, "SipiMetricsSnapshot layout drift");
+static_assert(offsetof(SipiMetricsSnapshot, rate_limit_clients_tracked) == 168, "SipiMetricsSnapshot layout drift");
+static_assert(offsetof(SipiMetricsSnapshot, decode_memory_budget_bytes) == 176, "SipiMetricsSnapshot layout drift");
+static_assert(offsetof(SipiMetricsSnapshot, decode_memory_used_bytes) == 184, "SipiMetricsSnapshot layout drift");
+#endif
 
 #endif /* SIPI_FFI_METRICS_SNAPSHOT_H */

--- a/src/ffi/sipi_ffi.cpp
+++ b/src/ffi/sipi_ffi.cpp
@@ -500,4 +500,14 @@ void sipi_set_log_trace_context(const char *trace_id, const char *span_id)
   }
 }
 
+void sipi_set_outbound_traceparent(const char *traceparent)
+{
+  // Void + cannot meaningfully fail; swallow any allocation failure so no C++
+  // exception crosses the boundary (the boundary contract is uniform).
+  try {
+    ::set_outbound_traceparent(traceparent);
+  } catch (...) {
+  }
+}
+
 }// extern "C"

--- a/src/ffi/sipi_ffi.h
+++ b/src/ffi/sipi_ffi.h
@@ -649,6 +649,15 @@ SIPI_FFI_NODISCARD int sipi_cli_main(int argc, char **argv);
  *  thread, so the thread-local scope is correct. */
 void sipi_set_log_trace_context(const char *trace_id, const char *span_id);
 
+/*! Stamp the CALLING thread's outbound-HTTP trace-propagation context: the W3C
+ *  `traceparent` the Lua `server.http` client injects on outbound requests so a
+ *  downstream service (dsp-api) continues the Rust shell's trace. The shell sets
+ *  it from the active span before a preflight/route call and clears it after
+ *  (NULL). NULL/empty/malformed clears it (nothing is injected). Thread-local,
+ *  like `sipi_set_log_trace_context`; kept separate because propagation needs
+ *  the full formatted header (incl. the sampling flag). */
+void sipi_set_outbound_traceparent(const char *traceparent);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/logging/logger.cpp
+++ b/src/logging/logger.cpp
@@ -24,6 +24,12 @@ static LogLevel g_log_level = LL_INFO;
 // scopes the context; empty means "no active trace" (the keys are then omitted).
 static thread_local std::string g_trace_id;
 static thread_local std::string g_span_id;
+// The W3C `traceparent` this thread injects on outbound Lua HTTP calls, so a
+// downstream service continues the trace. Set by the Rust shell from the active
+// span before a preflight/route FFI call and cleared after; empty means "do not
+// inject". Distinct from the log ids above: propagation needs the full header
+// (incl. the sampling flag), log lines need only the raw ids.
+static thread_local std::string g_outbound_traceparent;
 
 void set_cli_mode(bool cli) { g_cli_mode = cli; }
 bool is_cli_mode() { return g_cli_mode; }
@@ -60,6 +66,33 @@ void set_log_trace_context(const char *trace_id, const char *span_id)
     g_span_id.clear();
   }
 }
+
+// A W3C `traceparent` is `<version>-<trace-id>-<parent-id>-<flags>` with fixed
+// widths — version 2 hex, trace-id 32 hex, parent-id 16 hex, flags 2 hex, dashes
+// at positions 2/35/52 (55 chars total). Validating the whole shape at this FFI
+// boundary lets CurlConnection splice it into an outbound header without escaping
+// and makes header injection impossible: any CR/LF or non-hex byte fails.
+static bool is_w3c_traceparent(const std::string &tp)
+{
+  if (tp.size() != 55) return false;
+  if (tp[2] != '-' || tp[35] != '-' || tp[52] != '-') return false;
+  return is_lower_hex(tp.substr(0, 2), 2)     // version
+         && is_lower_hex(tp.substr(3, 32), 32)// trace-id
+         && is_lower_hex(tp.substr(36, 16), 16)// parent-id
+         && is_lower_hex(tp.substr(53, 2), 2);// flags
+}
+
+void set_outbound_traceparent(const char *traceparent)
+{
+  const std::string tp = (traceparent != nullptr) ? traceparent : "";
+  if (is_w3c_traceparent(tp)) {
+    g_outbound_traceparent = tp;
+  } else {
+    g_outbound_traceparent.clear();
+  }
+}
+
+std::string get_outbound_traceparent() { return g_outbound_traceparent; }
 
 std::string escape_json_str(const std::string &s)
 {

--- a/src/logging/logger.h
+++ b/src/logging/logger.h
@@ -39,4 +39,23 @@ bool is_json_mode();
  */
 void set_log_trace_context(const char *trace_id, const char *span_id);
 
+/*!
+ * Stamp this thread's outbound-HTTP trace-propagation context: the W3C
+ * `traceparent` the Lua `server.http` client (`CurlConnection`) injects on
+ * outbound requests so a downstream service (dsp-api) continues this trace. The
+ * Rust shell sets it — from the active OpenTelemetry span — before a preflight /
+ * route FFI call and clears it after; engine work runs on the same thread, so a
+ * thread-local is the right scope. NULL / empty / malformed clears it (nothing
+ * is injected). Kept separate from `set_log_trace_context` because propagation
+ * needs the full formatted header incl. the sampling flag, while log lines carry
+ * only the raw trace/span ids.
+ */
+void set_outbound_traceparent(const char *traceparent);
+
+/*!
+ * The W3C `traceparent` set for this thread, or empty when none is active. Read
+ * by the Lua HTTP client to inject the header on outbound requests.
+ */
+std::string get_outbound_traceparent();
+
 #endif

--- a/src/server-rs/BUILD.bazel
+++ b/src/server-rs/BUILD.bazel
@@ -35,6 +35,7 @@ rust_library(
         "src/iiif.rs",
         "src/info.rs",
         "src/lib.rs",
+        "src/metrics.rs",
         "src/path.rs",
         "src/routes.rs",
         "src/sink.rs",

--- a/src/server-rs/src/ffi.rs
+++ b/src/server-rs/src/ffi.rs
@@ -147,6 +147,47 @@ pub struct SipiImageErrorReport {
 /// `SipiServeRequest::report_ctx`.
 pub type SipiReportErrorFn = extern "C" fn(ctx: *mut c_void, err: *const SipiImageErrorReport);
 
+/// Flat snapshot of the engine metrics singleton — mirrors `SipiMetricsSnapshot`
+/// in `src/ffi/metrics_snapshot.h`. Monotonic counters are `u64`; gauges are
+/// `i64` (signed: `cache_size_limit_bytes` is `-1` when unlimited). Every field
+/// is 8 bytes wide, so there is no interior padding; the ABI is guarded below
+/// against an accidental field reorder or insertion. The OTel meter bridge
+/// (`crate::metrics`) reads this each collection.
+///
+/// Two counters are populated only by the retained C++ transport's connection
+/// adapter, never on the FFI serve path, so they stay zero under the Rust shell
+/// and the bridge does not expose them: `rejected_connections_total` (its Rust
+/// analog is `sipi.pool.load_shed`) and `waiting_connections` (the semaphore
+/// sheds immediately rather than queuing).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SipiMetricsSnapshot {
+    pub cache_hits_total: u64,
+    pub cache_misses_total: u64,
+    pub cache_evictions_total: u64,
+    pub cache_skips_total: u64,
+    pub image_too_large_total: u64,
+    pub client_disconnected_total: u64,
+    pub memory_alloc_failures_total: u64,
+    pub rejected_connections_total: u64,
+    pub rate_limit_allowed_total: u64,
+    pub rate_limit_rejected_total: u64,
+    pub rate_limit_shadow_rejected_total: u64,
+    pub rate_limit_near_limit_total: u64,
+    pub decode_memory_acquired_total: u64,
+    pub decode_memory_rejected_total: u64,
+    pub decode_memory_shadow_rejected_total: u64,
+    pub decode_memory_near_limit_total: u64,
+    pub waiting_connections: i64,
+    pub cache_size_bytes: i64,
+    pub cache_files: i64,
+    pub cache_size_limit_bytes: i64,
+    pub cache_files_limit: i64,
+    pub rate_limit_clients_tracked: i64,
+    pub decode_memory_budget_bytes: i64,
+    pub decode_memory_used_bytes: i64,
+}
+
 /// The IIIF serve request — mirrors `SipiServeRequest` in `sipi_ffi.h`. All
 /// `*const c_char` fields are caller-owned and must outlive the (synchronous)
 /// `sipi_serve_image` call; null is allowed where the header documents it.
@@ -296,6 +337,12 @@ extern "C" {
     /// fallback below `--serverport`/`SIPI_SERVERPORT`/`SIPI_RS_PORT` (plan 02
     /// §6 R3). Returns 0, or 500 if `sipi_init` has not run.
     pub fn sipi_port(out: *mut c_int) -> c_int;
+
+    /// Snapshot the engine metrics singleton (cache / rate-limiter /
+    /// decode-memory / admission counters + gauges) into `out`, a caller-owned
+    /// buffer. A pure `sipi_guard`-only read — no response sink, no fallible
+    /// pre-commit step. Returns 0, or non-zero on an internal error.
+    pub fn sipi_metrics_snapshot(out: *mut SipiMetricsSnapshot) -> c_int;
 
     /// Enumerate the configured Lua routes (method/route/script) installed by
     /// `sipi_init`, one `emit` call per route. Returns 0, or 500 if `sipi_init`
@@ -615,6 +662,21 @@ pub fn port() -> Result<u16, i32> {
         return Err(code);
     }
     Ok(v.clamp(0, i32::from(u16::MAX)) as u16)
+}
+
+/// Read the engine metrics singleton into a flat snapshot for the OTel meter.
+/// Returns `None` on an internal FFI error — the caller then observes nothing
+/// this collection cycle (fail-safe, never a panic on the collection thread).
+#[must_use]
+pub fn metrics_snapshot() -> Option<SipiMetricsSnapshot> {
+    let mut snap = SipiMetricsSnapshot::default();
+    // SAFETY: `out` is a valid, writable pointer; the seam guards exceptions.
+    let code = unsafe { sipi_metrics_snapshot(&mut snap) };
+    if code == 0 {
+        Some(snap)
+    } else {
+        None
+    }
 }
 
 /// One configured Lua route: HTTP method, the route prefix, and the resolved
@@ -1316,5 +1378,89 @@ mod image_error_layout {
         assert_eq!(offset_of!(SipiImageErrorReport, channels), 72);
         assert_eq!(offset_of!(SipiImageErrorReport, bps), 80);
         assert_eq!(offset_of!(SipiImageErrorReport, file_size_bytes), 88);
+    }
+}
+
+// Lock-step layout guard — paired with the C++ static_assert/offsetof block in
+// src/ffi/metrics_snapshot.h. Every field is 8 bytes wide (u64 / i64), so there
+// is no packing subtlety, but the guard still catches an accidental field
+// reorder or insertion on either side. LP64 on every supported target.
+#[cfg(test)]
+mod metrics_snapshot_layout {
+    use super::SipiMetricsSnapshot;
+    use std::mem::{align_of, offset_of, size_of};
+
+    #[test]
+    fn repr_c_matches_metrics_snapshot_h() {
+        assert_eq!(size_of::<usize>(), 8, "layout assumes an LP64 target");
+        assert_eq!(align_of::<SipiMetricsSnapshot>(), 8);
+        assert_eq!(size_of::<SipiMetricsSnapshot>(), 192);
+
+        assert_eq!(offset_of!(SipiMetricsSnapshot, cache_hits_total), 0);
+        assert_eq!(offset_of!(SipiMetricsSnapshot, cache_misses_total), 8);
+        assert_eq!(offset_of!(SipiMetricsSnapshot, cache_evictions_total), 16);
+        assert_eq!(offset_of!(SipiMetricsSnapshot, cache_skips_total), 24);
+        assert_eq!(offset_of!(SipiMetricsSnapshot, image_too_large_total), 32);
+        assert_eq!(
+            offset_of!(SipiMetricsSnapshot, client_disconnected_total),
+            40
+        );
+        assert_eq!(
+            offset_of!(SipiMetricsSnapshot, memory_alloc_failures_total),
+            48
+        );
+        assert_eq!(
+            offset_of!(SipiMetricsSnapshot, rejected_connections_total),
+            56
+        );
+        assert_eq!(
+            offset_of!(SipiMetricsSnapshot, rate_limit_allowed_total),
+            64
+        );
+        assert_eq!(
+            offset_of!(SipiMetricsSnapshot, rate_limit_rejected_total),
+            72
+        );
+        assert_eq!(
+            offset_of!(SipiMetricsSnapshot, rate_limit_shadow_rejected_total),
+            80
+        );
+        assert_eq!(
+            offset_of!(SipiMetricsSnapshot, rate_limit_near_limit_total),
+            88
+        );
+        assert_eq!(
+            offset_of!(SipiMetricsSnapshot, decode_memory_acquired_total),
+            96
+        );
+        assert_eq!(
+            offset_of!(SipiMetricsSnapshot, decode_memory_rejected_total),
+            104
+        );
+        assert_eq!(
+            offset_of!(SipiMetricsSnapshot, decode_memory_shadow_rejected_total),
+            112
+        );
+        assert_eq!(
+            offset_of!(SipiMetricsSnapshot, decode_memory_near_limit_total),
+            120
+        );
+        assert_eq!(offset_of!(SipiMetricsSnapshot, waiting_connections), 128);
+        assert_eq!(offset_of!(SipiMetricsSnapshot, cache_size_bytes), 136);
+        assert_eq!(offset_of!(SipiMetricsSnapshot, cache_files), 144);
+        assert_eq!(offset_of!(SipiMetricsSnapshot, cache_size_limit_bytes), 152);
+        assert_eq!(offset_of!(SipiMetricsSnapshot, cache_files_limit), 160);
+        assert_eq!(
+            offset_of!(SipiMetricsSnapshot, rate_limit_clients_tracked),
+            168
+        );
+        assert_eq!(
+            offset_of!(SipiMetricsSnapshot, decode_memory_budget_bytes),
+            176
+        );
+        assert_eq!(
+            offset_of!(SipiMetricsSnapshot, decode_memory_used_bytes),
+            184
+        );
     }
 }

--- a/src/server-rs/src/ffi.rs
+++ b/src/server-rs/src/ffi.rs
@@ -466,6 +466,11 @@ extern "C" {
     /// the active trace context (lowercase-hex `trace_id`/`span_id`); both NULL
     /// clears it. See `sipi_ffi.h`.
     pub fn sipi_set_log_trace_context(trace_id: *const c_char, span_id: *const c_char);
+
+    /// Stamp the calling thread's outbound `traceparent` — the W3C header the
+    /// engine's Lua `server.http` client injects on outbound requests so a
+    /// downstream service continues this trace. NULL clears it. See `sipi_ffi.h`.
+    pub fn sipi_set_outbound_traceparent(traceparent: *const c_char);
 }
 
 /// Stamps the C++ engine's logs (on the current thread) with a trace context for
@@ -499,6 +504,49 @@ impl Drop for LogTraceScope {
         if self.active {
             // SAFETY: NULL clears the thread-local; the seam guards exceptions.
             unsafe { sipi_set_log_trace_context(std::ptr::null(), std::ptr::null()) };
+        }
+    }
+}
+
+/// Stamps the C++ engine's outbound Lua HTTP calls (on the current thread) with a
+/// W3C `traceparent` for the guard's lifetime, clearing on drop. Held around a
+/// preflight/route FFI call so the engine's `server.http` request to dsp-api
+/// carries the active trace context and dsp-api continues the trace; cleared on
+/// drop so a reused `spawn_blocking` thread never leaks a stale traceparent onto
+/// the next request.
+///
+/// **Not nestable:** `Drop` clears the thread-local, it does not restore a prior
+/// value. Only one scope may be live per thread at a time — the preflight,
+/// file-preflight, and lua-route call sites are mutually exclusive, so this holds
+/// by construction. A future nested use would need a save/restore stack instead.
+pub struct OutboundTraceScope {
+    active: bool,
+}
+
+impl OutboundTraceScope {
+    /// Set the current thread's outbound `traceparent` (from the active OTel
+    /// span, via [`crate::telemetry::current_traceparent`]). Returns a guard that
+    /// clears it on drop.
+    #[must_use]
+    pub fn set(traceparent: &str) -> Self {
+        match CString::new(traceparent) {
+            Ok(tp) => {
+                // SAFETY: valid NUL-terminated string for the call; the engine
+                // validates + copies it into a thread-local; the seam guards
+                // exceptions.
+                unsafe { sipi_set_outbound_traceparent(tp.as_ptr()) };
+                Self { active: true }
+            }
+            Err(_) => Self { active: false },
+        }
+    }
+}
+
+impl Drop for OutboundTraceScope {
+    fn drop(&mut self) {
+        if self.active {
+            // SAFETY: NULL clears the thread-local; the seam guards exceptions.
+            unsafe { sipi_set_outbound_traceparent(std::ptr::null()) };
         }
     }
 }

--- a/src/server-rs/src/lib.rs
+++ b/src/server-rs/src/lib.rs
@@ -22,6 +22,7 @@ pub mod config_file;
 pub mod ffi;
 pub mod iiif;
 pub mod info;
+pub mod metrics;
 pub mod path;
 pub mod routes;
 pub mod sink;
@@ -311,6 +312,10 @@ async fn serve(
     // `configured_routes` is `Some` for a TOML config (routes sourced Rust-side),
     // `None` for a Lua config (routes read back from the engine via the seam).
     let state = Arc::new(routes::AppState::load(configured_routes));
+    // Bind the OTel observable instruments now that the engine pool exists (the
+    // concurrency gauges read its permits). A no-op when no meter provider was
+    // installed (no OTLP endpoint), so it is safe to call unconditionally.
+    state.register_metrics();
     // Precedence (plan 02 §6 R3): `SIPI_RS_PORT` (dev/test-only — lets the e2e
     // harness spawn parallel shells without a `--serverport`) beats
     // `--serverport`/`SIPI_SERVERPORT` (`port`, clap's own `CLI > env`), which

--- a/src/server-rs/src/metrics.rs
+++ b/src/server-rs/src/metrics.rs
@@ -1,0 +1,250 @@
+//! The OTLP metrics bridge: engine counters + the shell's own concurrency
+//! signals, exported as OTel observable instruments.
+//!
+//! The C++ engine keeps its own metrics singleton (cache / rate-limiter /
+//! decode-memory / admission counters + gauges), read across the seam as a flat
+//! [`SipiMetricsSnapshot`]. This module registers an OTel **observable** (async)
+//! instrument per field: on each collection the SDK invokes the callback, which
+//! snapshots the singleton and reports the current value — a pull, not a push,
+//! matching the engine side's pure `sipi_guard`-only read. The meter provider
+//! itself is built in [`crate::telemetry`] (fail-open on
+//! `OTEL_EXPORTER_OTLP_ENDPOINT`); with no provider installed the global meter is
+//! a no-op and every instrument here silently does nothing.
+//!
+//! Instrument names are OTel-idiomatic (`sipi.cache.hits`), which the standard
+//! OTLP→Prometheus normalization at the collector renders as the existing
+//! dashboard names (`sipi_cache_hits_total`). Two snapshot fields are **not**
+//! bridged — `rejected_connections_total` and `waiting_connections` are written
+//! only by the retained C++ transport's connection adapter, never on the FFI
+//! serve path (see [`crate::ffi::SipiMetricsSnapshot`]). `rejected_connections_total`'s
+//! Rust-shell analog is `sipi.pool.load_shed` below; `waiting_connections` has no
+//! equivalent (the semaphore sheds rather than queues).
+//!
+//! opentelemetry 0.31 has no batch-observer API (`register_callback` was
+//! removed), so each instrument carries its own callback and each snapshots the
+//! singleton. The read is a cheap singleton copy and collection runs at the
+//! reader interval (60s), so the ~22 reads per cycle are immaterial.
+
+use std::sync::Arc;
+
+use opentelemetry::global;
+use opentelemetry::metrics::Meter;
+use tokio::sync::Semaphore;
+
+use crate::ffi::{self, SipiMetricsSnapshot};
+use crate::routes;
+
+/// Register the engine + pool observable instruments against the global meter.
+/// Safe to call unconditionally: with no meter provider installed (no OTLP
+/// endpoint) the global meter is a no-op and this registers nothing observable.
+/// Call once, after [`crate::telemetry::init`] has set the global provider and
+/// after the [`crate::routes::AppState`] pool exists (its permit count feeds the
+/// concurrency gauges).
+///
+/// The instrument handles are intentionally dropped: `build()` registers the
+/// callback with the SDK meter pipeline, which owns it for the meter provider's
+/// lifetime; the returned handle carries none of that state.
+pub(crate) fn register(pool: Arc<Semaphore>, permits_total: usize) {
+    let meter = global::meter("sipi");
+
+    // ── Engine counters (monotonic) ─────────────────────────────────────────
+    for (name, description, extract) in COUNTERS {
+        counter(&meter, name, description, *extract);
+    }
+
+    // ── Engine gauges ───────────────────────────────────────────────────────
+    for (name, description, unit, extract) in GAUGES {
+        gauge(&meter, name, description, unit, *extract);
+    }
+
+    // ── Rust-shell concurrency metrics (the transport the shell now owns) ────
+    // Engine-pool permits in flight: total − currently-available. The gauge the
+    // dead `waiting_connections` can't provide (the semaphore sheds, never
+    // queues), and the real saturation signal.
+    meter
+        .i64_observable_gauge("sipi.pool.permits_in_use")
+        .with_description("Engine-pool permits currently held (blocking engine work in flight)")
+        .with_callback(move |observer| {
+            let in_use = permits_total.saturating_sub(pool.available_permits());
+            observer.observe(in_use as i64, &[]);
+        })
+        .build();
+    // Total permits (the configured worker count); fixed after startup.
+    meter
+        .i64_observable_gauge("sipi.pool.permits_total")
+        .with_description("Engine-pool total permit count (the configured worker count)")
+        .with_callback(move |observer| observer.observe(permits_total as i64, &[]))
+        .build();
+    // 503 load-shed count — the Rust-shell analog of the transport's dead
+    // `rejected_connections_total`.
+    meter
+        .u64_observable_counter("sipi.pool.load_shed")
+        .with_description("Requests shed with 503 because the engine pool was saturated")
+        .with_callback(|observer| observer.observe(routes::load_shed_total(), &[]))
+        .build();
+}
+
+/// The 15 live monotonic counters: OTel name, description, and the field to read
+/// from a snapshot. (`rejected_connections_total` is omitted — transport-dead.)
+type CounterRow = (&'static str, &'static str, fn(&SipiMetricsSnapshot) -> u64);
+const COUNTERS: &[CounterRow] = &[
+    ("sipi.cache.hits", "Cache hits", |s| s.cache_hits_total),
+    ("sipi.cache.misses", "Cache misses", |s| {
+        s.cache_misses_total
+    }),
+    ("sipi.cache.evictions", "Cache entries evicted", |s| {
+        s.cache_evictions_total
+    }),
+    (
+        "sipi.cache.skips",
+        "Files too large to cache (skipped)",
+        |s| s.cache_skips_total,
+    ),
+    (
+        "sipi.image_too_large",
+        "Requests rejected by the output pixel limit",
+        |s| s.image_too_large_total,
+    ),
+    (
+        "sipi.client_disconnected",
+        "Requests aborted by client disconnect",
+        |s| s.client_disconnected_total,
+    ),
+    (
+        "sipi.memory_alloc_failures",
+        "Allocation failures during image processing",
+        |s| s.memory_alloc_failures_total,
+    ),
+    (
+        "sipi.rate_limit.allowed",
+        "Rate-limiter: requests allowed",
+        |s| s.rate_limit_allowed_total,
+    ),
+    (
+        "sipi.rate_limit.rejected",
+        "Rate-limiter: requests rejected",
+        |s| s.rate_limit_rejected_total,
+    ),
+    (
+        "sipi.rate_limit.shadow_rejected",
+        "Rate-limiter: shadow-mode rejections",
+        |s| s.rate_limit_shadow_rejected_total,
+    ),
+    (
+        "sipi.rate_limit.near_limit",
+        "Rate-limiter: times a client exceeded 80% of its budget",
+        |s| s.rate_limit_near_limit_total,
+    ),
+    (
+        "sipi.decode_memory.acquired",
+        "Decode-memory budget: acquisitions",
+        |s| s.decode_memory_acquired_total,
+    ),
+    (
+        "sipi.decode_memory.rejected",
+        "Decode-memory budget: rejections",
+        |s| s.decode_memory_rejected_total,
+    ),
+    (
+        "sipi.decode_memory.shadow_rejected",
+        "Decode-memory budget: shadow-mode rejections",
+        |s| s.decode_memory_shadow_rejected_total,
+    ),
+    (
+        "sipi.decode_memory.near_limit",
+        "Decode-memory budget: times usage exceeded 80% of budget",
+        |s| s.decode_memory_near_limit_total,
+    ),
+];
+
+/// The 7 live gauges: OTel name, description, unit (`""` = none), and the field.
+/// (`waiting_connections` is omitted — transport-dead.)
+type GaugeRow = (
+    &'static str,
+    &'static str,
+    &'static str,
+    fn(&SipiMetricsSnapshot) -> i64,
+);
+const GAUGES: &[GaugeRow] = &[
+    ("sipi.cache.size_bytes", "Current cache size", "By", |s| {
+        s.cache_size_bytes
+    }),
+    ("sipi.cache.files", "Current cached file count", "", |s| {
+        s.cache_files
+    }),
+    (
+        "sipi.cache.size_limit_bytes",
+        "Configured cache size limit (-1 = unlimited)",
+        "By",
+        |s| s.cache_size_limit_bytes,
+    ),
+    (
+        "sipi.cache.files_limit",
+        "Configured cache file-count limit (0 = none)",
+        "",
+        |s| s.cache_files_limit,
+    ),
+    (
+        "sipi.rate_limit.clients_tracked",
+        "Active client entries in the rate limiter",
+        "",
+        |s| s.rate_limit_clients_tracked,
+    ),
+    (
+        "sipi.decode_memory.budget_bytes",
+        "Configured decode-memory budget",
+        "By",
+        |s| s.decode_memory_budget_bytes,
+    ),
+    (
+        "sipi.decode_memory.used_bytes",
+        "Decode memory currently in use",
+        "By",
+        |s| s.decode_memory_used_bytes,
+    ),
+];
+
+/// Build one observable `u64` counter whose callback snapshots the engine
+/// metrics and reports `extract`'s field. A failed snapshot observes nothing
+/// (fail-safe on the collection thread). The handle is dropped (see
+/// [`register`]).
+fn counter(
+    meter: &Meter,
+    name: &'static str,
+    description: &'static str,
+    extract: fn(&SipiMetricsSnapshot) -> u64,
+) {
+    meter
+        .u64_observable_counter(name)
+        .with_description(description)
+        .with_callback(move |observer| {
+            if let Some(snap) = ffi::metrics_snapshot() {
+                observer.observe(extract(&snap), &[]);
+            }
+        })
+        .build();
+}
+
+/// Build one observable `i64` gauge (see [`counter`]); `unit` is applied only
+/// when non-empty (byte gauges pass `"By"`).
+fn gauge(
+    meter: &Meter,
+    name: &'static str,
+    description: &'static str,
+    unit: &'static str,
+    extract: fn(&SipiMetricsSnapshot) -> i64,
+) {
+    let mut builder = meter
+        .i64_observable_gauge(name)
+        .with_description(description);
+    if !unit.is_empty() {
+        builder = builder.with_unit(unit);
+    }
+    builder
+        .with_callback(move |observer| {
+            if let Some(snap) = ffi::metrics_snapshot() {
+                observer.observe(extract(&snap), &[]);
+            }
+        })
+        .build();
+}

--- a/src/server-rs/src/routes.rs
+++ b/src/server-rs/src/routes.rs
@@ -417,8 +417,18 @@ fn iiif_access(
     if state.has_preflight {
         let ctx = build_ctx(method, uri, headers)
             .ok_or_else(|| Box::new(sink::error_response(StatusCode::BAD_REQUEST)))?;
-        let result = ffi::preflight(&parsed.prefix, &parsed.identifier, &ctx)
-            .map_err(|_| Box::new(sink::error_response(StatusCode::INTERNAL_SERVER_ERROR)))?;
+        // Run the hook under a `sipi.preflight` span and stamp the outbound
+        // `traceparent` from it, so the hook's dsp-api call nests under this span.
+        // (Engine log lines stay correlated to the parent `sipi.serve` span — the
+        // scopes clear on drop rather than restore, so re-stamping the log context
+        // here would need a save/restore stack; same trace either way.)
+        let result = {
+            let _span = tracing::info_span!("sipi.preflight").entered();
+            let _tp =
+                crate::telemetry::current_traceparent().map(|tp| ffi::OutboundTraceScope::set(&tp));
+            ffi::preflight(&parsed.prefix, &parsed.identifier, &ctx)
+        }
+        .map_err(|_| Box::new(sink::error_response(StatusCode::INTERNAL_SERVER_ERROR)))?;
         if let Some(dr) = result.direct_response {
             return Err(Box::new(preflight_direct_response(dr)));
         }
@@ -464,8 +474,17 @@ fn file_access(
     }
     let ctx = build_ctx(method, uri, headers)
         .ok_or_else(|| Box::new(sink::error_response(StatusCode::BAD_REQUEST)))?;
-    let result = ffi::file_preflight(&built, &ctx)
-        .map_err(|_| Box::new(sink::error_response(StatusCode::INTERNAL_SERVER_ERROR)))?;
+    // Run the hook under a `sipi.file_preflight` span and stamp the outbound
+    // `traceparent` from it, so the hook's dsp-api call nests under this span.
+    // (Engine log lines stay correlated to the parent `sipi.serve` span — see the
+    // note in `iiif_access`.)
+    let result = {
+        let _span = tracing::info_span!("sipi.file_preflight").entered();
+        let _tp =
+            crate::telemetry::current_traceparent().map(|tp| ffi::OutboundTraceScope::set(&tp));
+        ffi::file_preflight(&built, &ctx)
+    }
+    .map_err(|_| Box::new(sink::error_response(StatusCode::INTERNAL_SERVER_ERROR)))?;
     if let Some(dr) = result.direct_response {
         return Err(Box::new(preflight_direct_response(dr)));
     }
@@ -886,6 +905,9 @@ fn run_lua_route_blocking(
     let _enter = span.enter();
     let _trace =
         crate::telemetry::current_trace_context().map(|(t, s)| ffi::LogTraceScope::set(&t, &s));
+    // Any `server.http` the route makes carries this span's `traceparent`, so a
+    // downstream service continues the trace.
+    let _tp = crate::telemetry::current_traceparent().map(|tp| ffi::OutboundTraceScope::set(&tp));
 
     // secure = false: SIPI runs plain HTTP behind Traefik (matches conn.secure()).
     let Some(ctx) = ffi::build_request_context(ffi::RequestFields {

--- a/src/server-rs/src/routes.rs
+++ b/src/server-rs/src/routes.rs
@@ -11,6 +11,7 @@
 
 use std::ffi::CString;
 use std::io::Write;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use axum::body::{to_bytes, Body};
@@ -51,6 +52,10 @@ pub struct AppState {
     /// of each blocking engine dispatch, reconstructing the shttps
     /// thread-per-connection bound. Shared (`Arc`) across all requests.
     pool: Arc<tokio::sync::Semaphore>,
+    /// The total permit count the pool was sized to (an observable-gauge
+    /// baseline: `permits - available_permits()` = engine work in flight).
+    /// Fixed after startup; `Semaphore` exposes only the live available count.
+    permits: usize,
     /// Configured Lua routes (method/route/script), registered as axum routes by
     /// [`crate::app`]. Empty when the engine is uninstalled.
     pub routes: Vec<ffi::RouteEntry>,
@@ -98,6 +103,7 @@ impl AppState {
                 has_preflight: ffi::has_preflight().unwrap_or(false),
                 has_file_preflight: ffi::has_file_preflight().unwrap_or(false),
                 pool,
+                permits,
                 // TOML config supplies routes directly; a Lua config has them
                 // read back from the engine via the seam.
                 routes: configured_routes.unwrap_or_else(|| ffi::routes().unwrap_or_default()),
@@ -115,6 +121,7 @@ impl AppState {
                 has_preflight: false,
                 has_file_preflight: false,
                 pool,
+                permits,
                 routes: Vec::new(),
                 max_post_size: 0,
                 docroot: String::new(),
@@ -122,6 +129,27 @@ impl AppState {
             },
         }
     }
+
+    /// Register the OTel observable instruments for the engine + pool metrics
+    /// against the global meter (a no-op when no meter provider is installed, so
+    /// it is safe to call unconditionally). Hands the metrics module the shared
+    /// pool + its total-permit count for the concurrency gauges.
+    pub(crate) fn register_metrics(&self) {
+        crate::metrics::register(Arc::clone(&self.pool), self.permits);
+    }
+}
+
+/// Cumulative 503 load-shed count: incremented every time the engine pool is
+/// saturated and a request is shed ([`busy_response`]). Read by the OTel bridge
+/// ([`crate::metrics`]) as an observable counter — the Rust-shell analog of the
+/// C++ transport's `rejected_connections_total` (dead under the shell). A plain
+/// atomic (not an OTel sync counter) so the shed path holds no meter handle and
+/// the count is correct regardless of whether metrics export is enabled.
+static LOAD_SHED_TOTAL: AtomicU64 = AtomicU64::new(0);
+
+/// The cumulative 503 load-shed count for the OTel observable counter.
+pub(crate) fn load_shed_total() -> u64 {
+    LOAD_SHED_TOTAL.load(Ordering::Relaxed)
 }
 
 /// Pool size when the configured `nthreads` is 0 (auto) or unreadable: the host
@@ -365,6 +393,7 @@ fn complete(outcome_tx: oneshot::Sender<Outcome>, response: Response) {
 /// Pool-full backpressure: a bare 503 with `Retry-After: 1` — no body,
 /// no internal detail. The client should retry shortly.
 fn busy_response() -> Response {
+    LOAD_SHED_TOTAL.fetch_add(1, Ordering::Relaxed);
     let mut response = sink::error_response(StatusCode::SERVICE_UNAVAILABLE);
     response
         .headers_mut()

--- a/src/server-rs/src/telemetry.rs
+++ b/src/server-rs/src/telemetry.rs
@@ -29,10 +29,11 @@ use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
 
-/// Owns the trace (and, in local dev, log) providers so their batch exporters
+/// Owns the trace, metric, and (in local dev) log providers so their exporters
 /// flush on shutdown. Each is `None` when not configured (fail-open).
 pub struct Telemetry {
     provider: Option<SdkTracerProvider>,
+    meter_provider: Option<opentelemetry_sdk::metrics::SdkMeterProvider>,
     logger_provider: Option<opentelemetry_sdk::logs::SdkLoggerProvider>,
 }
 
@@ -42,6 +43,9 @@ impl Telemetry {
     pub fn shutdown(self) {
         if let Some(provider) = self.provider {
             let _ = provider.shutdown();
+        }
+        if let Some(meter_provider) = self.meter_provider {
+            let _ = meter_provider.shutdown();
         }
         if let Some(logger_provider) = self.logger_provider {
             let _ = logger_provider.shutdown();
@@ -71,6 +75,15 @@ pub fn init() -> Telemetry {
         .as_ref()
         .map(|p| tracing_opentelemetry::layer().with_tracer(p.tracer("sipi")));
 
+    // The metric meter provider (same fail-open endpoint gate). Set it as the
+    // global provider so `crate::metrics::register` (called later, once the
+    // engine pool exists) binds its observable instruments to it. The instrument
+    // callbacks then export the engine + pool metrics on the reader interval.
+    let meter_provider = build_meter_provider();
+    if let Some(mp) = meter_provider.as_ref() {
+        global::set_meter_provider(mp.clone());
+    }
+
     // Local-dev only: also export logs over OTLP so they land in a local LGTM
     // stack. The bridge attaches the active trace context, and a target filter
     // keeps the OTel SDK's own logs out (no export feedback loop).
@@ -98,6 +111,7 @@ pub fn init() -> Telemetry {
 
     Telemetry {
         provider,
+        meter_provider,
         logger_provider,
     }
 }
@@ -163,6 +177,32 @@ fn build_tracer_provider() -> Option<SdkTracerProvider> {
     Some(
         SdkTracerProvider::builder()
             .with_batch_exporter(exporter)
+            .with_resource(resource)
+            .build(),
+    )
+}
+
+/// Build the OTLP (gRPC-tonic) meter provider, or `None` when no endpoint is
+/// configured. Mirrors [`build_tracer_provider`]: the exporter reads the
+/// standard `OTEL_EXPORTER_OTLP_*` env, and `with_periodic_exporter` installs a
+/// periodic reader (60s default) that invokes the observable callbacks and
+/// pushes each collection over OTLP.
+fn build_meter_provider() -> Option<opentelemetry_sdk::metrics::SdkMeterProvider> {
+    std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok()?;
+    let exporter = match opentelemetry_otlp::MetricExporter::builder()
+        .with_tonic()
+        .build()
+    {
+        Ok(exporter) => exporter,
+        Err(e) => {
+            tracing::warn!(error = %e, "OTLP metric exporter init failed; metric export disabled");
+            return None;
+        }
+    };
+    let resource = otel_resource();
+    Some(
+        opentelemetry_sdk::metrics::SdkMeterProvider::builder()
+            .with_periodic_exporter(exporter)
             .with_resource(resource)
             .build(),
     )

--- a/src/server-rs/src/telemetry.rs
+++ b/src/server-rs/src/telemetry.rs
@@ -239,19 +239,38 @@ fn build_logger_provider() -> Option<opentelemetry_sdk::logs::SdkLoggerProvider>
     )
 }
 
+/// The active span's OTel context, or `None` when there is no valid active span.
+/// The shared extraction behind [`current_trace_context`] + [`current_traceparent`].
+fn active_span_context() -> Option<opentelemetry::trace::SpanContext> {
+    let cx = tracing::Span::current().context();
+    let sc = cx.span().span_context().clone();
+    sc.is_valid().then_some(sc)
+}
+
 /// The current span's trace context as lowercase-hex `(trace_id, span_id)`, or
 /// `None` when there is no valid active span (so the keys are omitted rather than
 /// emitted empty). Used both by the log formatter and the cross-seam stamping.
 #[must_use]
 pub fn current_trace_context() -> Option<(String, String)> {
-    let cx = tracing::Span::current().context();
-    let span = cx.span();
-    let sc = span.span_context();
-    if sc.is_valid() {
-        Some((sc.trace_id().to_string(), sc.span_id().to_string()))
-    } else {
-        None
-    }
+    active_span_context().map(|sc| (sc.trace_id().to_string(), sc.span_id().to_string()))
+}
+
+/// The active span's context as a W3C `traceparent` header value
+/// (`00-{trace_id}-{span_id}-{flags}`), or `None` when there is no valid active
+/// span (so nothing is propagated). Used to stamp the engine's outbound Lua HTTP
+/// calls (the preflight's dsp-api request) across the seam, so the downstream
+/// service continues this trace. The flag byte is the real sampling decision
+/// from the span context, so a downstream sampler honours it.
+#[must_use]
+pub fn current_traceparent() -> Option<String> {
+    active_span_context().map(|sc| {
+        format!(
+            "00-{}-{}-{:02x}",
+            sc.trace_id(),
+            sc.span_id(),
+            sc.trace_flags().to_u8()
+        )
+    })
 }
 
 /// Custom event formatter producing the shared `{level, message, target,

--- a/src/shttps/lua/LuaServer.cpp
+++ b/src/shttps/lua/LuaServer.cpp
@@ -1272,8 +1272,26 @@ public:
 
       struct curl_slist *chunk = nullptr;
 
+      bool has_traceparent = false;
       for (const auto &header : requestHeaders) {
         std::string headerStr = header.first + ": " + header.second;
+        chunk = curl_slist_append(chunk, headerStr.c_str());
+        if (!has_traceparent) {
+          std::string name = header.first;
+          std::transform(name.begin(), name.end(), name.begin(), [](unsigned char c) {
+            return static_cast<char>(std::tolower(c));
+          });
+          if (name == "traceparent") { has_traceparent = true; }
+        }
+      }
+
+      // Continue the caller's distributed trace: inject the W3C `traceparent`
+      // the Rust shell stamped for this thread (from the active span), unless the
+      // script set its own. Empty when no trace is active — and in the C++ CLI,
+      // which never sets it — so this is a no-op off the Rust server path.
+      const std::string traceparent = get_outbound_traceparent();
+      if (!traceparent.empty() && !has_traceparent) {
+        const std::string headerStr = "traceparent: " + traceparent;
         chunk = curl_slist_append(chunk, headerStr.c_str());
       }
 

--- a/test/e2e/BUILD.bazel
+++ b/test/e2e/BUILD.bazel
@@ -9,7 +9,7 @@ Layout:
   * `:sipi_e2e`        `rust_library` exposing the shared helpers
                        (`SipiServer`, `repo_root`, `http_client`, …)
                        consumed by every test binary.
-  * 25 × `rust_test`   one target per non-docker `tests/<name>.rs`,
+  * 26 × `rust_test`   one target per non-docker `tests/<name>.rs`,
                        defined via `sipi_e2e_test()` (see
                        `sipi_e2e_test.bzl`). The macro injects the
                        shared `data`/`env`/`args`/`tags` so the
@@ -23,7 +23,7 @@ Layout:
   * `:docker_smoke`    inline `rust_test` — its data shape (OCI image
                        tarball) and tags (`requires-docker`) diverge
                        from the macro's defaults.
-  * `:all_e2e`         `test_suite` aggregating the 25 non-docker
+  * `:all_e2e`         `test_suite` aggregating the 26 non-docker
                        targets (not `:differential` / `:docker_smoke`).
                        `just bazel-test-e2e` wraps `bazel test
                        //test/e2e:all_e2e`.
@@ -148,6 +148,20 @@ sipi_e2e_test(name = "shutdown", deps = _e2e_test_deps)
 sipi_e2e_test(name = "smoke", deps = _e2e_test_deps)
 
 sipi_e2e_test(name = "toml_config", deps = _e2e_test_deps)
+
+# `no-sanitizer`: the only e2e test that activates the OTLP exporter (it sets
+# `OTEL_EXPORTER_OTLP_ENDPOINT` so the shell produces span contexts to propagate).
+# Under ASan the exporter's tonic/tokio background threads trip the known
+# thread-registry false positive (`sanitizer_thread_arg_retval.cpp` CHECK), which
+# aborts the server at startup — an ASan-runtime artifact, not a real bug, and
+# ASan is not a production config. The propagation code itself is ASan-covered by
+# the `logger` unit test (validation) and by every other e2e test exercising
+# `CurlConnection`; only the OTLP-exporter-active path is excluded here.
+sipi_e2e_test(
+    name = "tracing",
+    deps = _e2e_test_deps,
+    extra_tags = ["no-sanitizer"],
+)
 
 sipi_e2e_test(name = "upload", deps = _e2e_test_deps)
 
@@ -287,6 +301,7 @@ test_suite(
         ":shutdown",
         ":smoke",
         ":toml_config",
+        ":tracing",
         ":upload",
     ],
     visibility = ["//visibility:public"],

--- a/test/e2e/tests/tracing.rs
+++ b/test/e2e/tests/tracing.rs
@@ -1,0 +1,161 @@
+//! Distributed-trace propagation: the Lua preflight's outbound HTTP call to
+//! dsp-api must carry a W3C `traceparent` in SIPI's trace, so dsp-api continues
+//! the trace instead of starting a disconnected root (DEV-6104 §4).
+//!
+//! The `knora` `pre_flight` (`config/sipi.init-knora-test.lua`) issues
+//! `server.http("GET", "http://<knora_path>:<knora_port>/v1/files/<id>", …)`.
+//! We point `knora_path`/`knora_port` at a throwaway loopback listener, drive a
+//! `/knora/…` request, and assert the captured outbound request carries a
+//! well-formed `traceparent` whose trace-id equals the one SIPI stamped on its
+//! own response (`OtelInResponseLayer`) — i.e. the outbound call is in the same
+//! trace. `OTEL_EXPORTER_OTLP_ENDPOINT` is set (to a dead address) so the OTel
+//! layer produces span contexts; export failures are fail-open and dropped.
+
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use sipi_e2e::{http_client, test_data_dir, SipiServer};
+
+/// The 32-hex trace-id out of a `traceparent` header value
+/// (`00-<32hex>-<16hex>-<2hex>`), or `None` if it doesn't parse.
+fn trace_id_of(traceparent: &str) -> Option<String> {
+    let parts: Vec<&str> = traceparent.trim().split('-').collect();
+    if parts.len() == 4 && parts[0] == "00" && parts[1].len() == 32 {
+        Some(parts[1].to_string())
+    } else {
+        None
+    }
+}
+
+/// The `traceparent` header value from a raw HTTP/1.1 request head (case-insensitive).
+fn traceparent_in_request(raw: &str) -> Option<String> {
+    raw.lines()
+        .find(|l| l.to_ascii_lowercase().starts_with("traceparent:"))
+        .map(|l| l[l.find(':').unwrap() + 1..].trim().to_string())
+}
+
+#[test]
+fn preflight_propagates_traceparent_to_outbound_http() {
+    let test_data = test_data_dir();
+
+    // Throwaway "dsp-api": capture the first request's head, reply 200, exit.
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock dsp-api");
+    let mock_port = listener.local_addr().unwrap().port();
+    let (tx, rx) = mpsc::channel::<String>();
+    let mock = std::thread::spawn(move || {
+        listener.set_nonblocking(true).ok();
+        let deadline = Instant::now() + Duration::from_secs(20);
+        loop {
+            match listener.accept() {
+                Ok((mut stream, _)) => {
+                    stream.set_nonblocking(false).ok();
+                    stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
+                    // Read until the end of the request head (`\r\n\r\n`) so the
+                    // capture can't be truncated across TCP segments (or the read
+                    // times out / EOFs).
+                    let mut req = Vec::new();
+                    let mut chunk = [0u8; 1024];
+                    loop {
+                        match stream.read(&mut chunk) {
+                            Ok(0) => break,
+                            Ok(n) => {
+                                req.extend_from_slice(&chunk[..n]);
+                                if req.windows(4).any(|w| w == b"\r\n\r\n") {
+                                    break;
+                                }
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                    let _ = stream.write_all(
+                        b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}",
+                    );
+                    let _ = tx.send(String::from_utf8_lossy(&req).into_owned());
+                    return;
+                }
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    if Instant::now() > deadline {
+                        return;
+                    }
+                    std::thread::sleep(Duration::from_millis(20));
+                }
+                Err(_) => return,
+            }
+        }
+    });
+
+    // A knora-preflight config whose outbound dsp-api call targets the mock.
+    let config = format!(
+        r#"sipi = {{
+    port = 1024,
+    nthreads = 4,
+    imgroot = './images',
+    prefix_as_path = true,
+    subdir_levels = 0,
+    initscript = './config/sipi.init-knora-test.lua',
+    cache_dir = './cache',
+    cache_size = '20M',
+    cache_nfiles = 8,
+    scriptdir = './scripts',
+    tmpdir = '/tmp',
+    max_temp_file_age = 86400,
+    knora_path = '127.0.0.1',
+    knora_port = '{mock_port}',
+    jwt_secret = '',
+    loglevel = "DEBUG"
+}}
+
+fileserver = {{ docroot = './server', wwwroute = '/server' }}
+
+routes = {{}}
+"#
+    );
+    let config_path = test_data.join("config/sipi.tracing-test.lua");
+    std::fs::write(&config_path, config).expect("write tracing config");
+
+    // A dead OTLP endpoint: the OTel layer still produces span contexts (needed
+    // to inject the traceparent); export attempts are refused + dropped.
+    let srv = SipiServer::start_env(
+        "config/sipi.tracing-test.lua",
+        &test_data,
+        &[],
+        &[("OTEL_EXPORTER_OTLP_ENDPOINT", "http://127.0.0.1:1")],
+    );
+    let client = http_client();
+
+    // Drive a knora request; the preflight fires the outbound call to the mock.
+    // The IIIF outcome is irrelevant — the outbound call happens first.
+    let resp = client
+        .get(format!(
+            "{}/knora/test.jpg/full/max/0/default.jpg",
+            srv.base_url
+        ))
+        .send()
+        .expect("request to sipi");
+    let resp_traceparent = resp
+        .headers()
+        .get("traceparent")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+
+    let captured = rx
+        .recv_timeout(Duration::from_secs(25))
+        .expect("mock dsp-api received the preflight's outbound request");
+    let _ = mock.join();
+
+    // The outbound call must carry a well-formed traceparent...
+    let outbound = traceparent_in_request(&captured)
+        .unwrap_or_else(|| panic!("outbound request carries no traceparent:\n{captured}"));
+    let outbound_tid = trace_id_of(&outbound)
+        .unwrap_or_else(|| panic!("outbound traceparent is malformed: {outbound}"));
+
+    // ...in the same trace SIPI stamped on its own response.
+    let resp_tp = resp_traceparent.expect("sipi response carries a traceparent");
+    let resp_tid = trace_id_of(&resp_tp).expect("response traceparent well-formed");
+    assert_eq!(
+        outbound_tid, resp_tid,
+        "outbound dsp-api call must be in SIPI's trace (outbound={outbound}, response={resp_tp})"
+    );
+}

--- a/test/unit/logger/logger.cpp
+++ b/test/unit/logger/logger.cpp
@@ -413,3 +413,50 @@ TEST_F(LoggerTest, LogFormatRespectsFiltering)
   auto out = capture_stdout([]() { log_format(LL_INFO, "should be filtered"); });
   EXPECT_TRUE(out.empty()) << "log_format should respect level filtering";
 }
+
+// ================================================================
+// Outbound traceparent (distributed-trace propagation) tests
+// ================================================================
+//
+// The Rust shell stamps the outbound `traceparent` here; the Lua HTTP client
+// reads it back and injects it on outbound requests. The setter validates the
+// W3C shape at this FFI boundary, so a malformed or injected value can never
+// reach a header. These run on the test thread; each clears the thread-local
+// when done.
+
+static const char *const kValidTraceparent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+
+TEST_F(LoggerTest, OutboundTraceparentValidRoundTrips)
+{
+  set_outbound_traceparent(kValidTraceparent);
+  EXPECT_EQ(get_outbound_traceparent(), std::string(kValidTraceparent));
+  set_outbound_traceparent(nullptr);
+}
+
+TEST_F(LoggerTest, OutboundTraceparentNullClears)
+{
+  set_outbound_traceparent(kValidTraceparent);
+  set_outbound_traceparent(nullptr);
+  EXPECT_TRUE(get_outbound_traceparent().empty());
+}
+
+TEST_F(LoggerTest, OutboundTraceparentRejectsMalformed)
+{
+  const char *bad[] = {
+    "",// empty
+    "not-a-traceparent",
+    "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331",// missing flags
+    "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-1",// 1-char flags
+    "00_0af7651916cd43dd8448eb211c80319c_b7ad6b7169203331_01",// wrong separators
+    "00-0AF7651916CD43DD8448EB211C80319C-b7ad6b7169203331-01",// uppercase hex
+    "00-0af7651916cd43dd8448eb211c80319g-b7ad6b7169203331-01",// non-hex 'g'
+    "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01\r\nEvil: 1",// CRLF injection
+  };
+  for (const char *v : bad) {
+    // Start from a known-good value; a rejected set must CLEAR it, never keep it.
+    set_outbound_traceparent(kValidTraceparent);
+    set_outbound_traceparent(v);
+    EXPECT_TRUE(get_outbound_traceparent().empty()) << "should reject: " << v;
+  }
+  set_outbound_traceparent(nullptr);
+}

--- a/tools/differential_coverage_check.sh
+++ b/tools/differential_coverage_check.sh
@@ -20,7 +20,7 @@ cd "$(dirname "$0")/.."
 # Baseline: #[test] + #[tokio::test] across test/e2e/tests/*.rs EXCLUDING the
 # differential corpus file itself. Bump this (with a corpus update) whenever an
 # e2e test is added or removed.
-EXPECTED_E2E_TESTS=273
+EXPECTED_E2E_TESTS=274
 
 # Count via awk on a concatenated stream with literal `[ \t]` + exact string
 # compare — deterministic across awk/grep implementations. (Earlier a


### PR DESCRIPTION
Part of DEV-6659. Advances DEV-6104 (basic OTLP metrics visibility; full metric-value parity restoration remains, deferred to the post-deploy tail).

## Motivation

The C++→Rust strangler cutover needs production metrics visibility over OTLP before deploy — the second of the two production "eyes" alongside crash reporting (Sentry, already migrated). Today the Rust shell exports traces + logs but has **no metrics pipeline**: the C++ engine keeps filling its `Sipi::observability::Metrics` singleton on every FFI-served request, yet the shell has no `/metrics` route and never reads the counters. This bridges those engine counters — plus the shell's own concurrency signals — to OpenTelemetry, and prepares Grafana Application Observability support.

## Summary

- Cache / rate-limiter / decode-memory engine counters + gauges are now visible over OTLP.
- New Rust-native pool metrics (`sipi.pool.permits_in_use` / `permits_total` / `load_shed`) — the transport-layer signals the shell now owns.
- Fail-open: with no `OTEL_EXPORTER_OTLP_ENDPOINT` no meter provider is built and serving is unaffected.

## Key Changes

### FFI seam + lock-step ABI guard
- Bound the existing `sipi_metrics_snapshot` seam: a hand-written `#[repr(C)] SipiMetricsSnapshot` mirror + safe `metrics_snapshot()` wrapper in `ffi.rs`.
- Added a `static_assert`/`offsetof` block in `src/ffi/metrics_snapshot.h` paired with a Rust `offset_of!`/`size_of` test (24 fields, 192 bytes) — matching the existing `SipiImageErrorReport` guard. Fixed the header's stale "bindgen reads it here" comment.

### Metrics bridge (`src/server-rs/src/metrics.rs`, new)
- Registers the 22 live engine fields (15 counters + 7 gauges) as OTel observable instruments, plus the 3 pool metrics, via one `register()` called once the engine pool exists.
- OTel-idiomatic names (`sipi.cache.hits`) that round-trip to the existing Prometheus dashboard names (`sipi_cache_hits_total`) via the collector's standard OTLP→Prometheus normalization.

### Meter provider (`telemetry.rs`)
- `build_meter_provider()` mirrors `build_tracer_provider()` (same fail-open endpoint gate, `with_periodic_exporter`, shared resource), set as the global provider and flushed on shutdown.

### Rust-native pool metrics (`routes.rs`)
- A `LOAD_SHED_TOTAL` atomic incremented in `busy_response()` (the sole 503 shed path), and a retained `permits` total on `AppState` for the saturation gauges.

## Challenges and Decisions

### Not every snapshot field is live under the Rust shell
**Problem:** the 24-field snapshot was designed against the C++ server. **Found:** `rejected_connections_total` and `waiting_connections` are written only by `SipiConnectionMetricsAdapter`, installed only by the C++ shttps transport — never on the FFI serve path. Under the Rust shell they would export as flatlined zeros. **Solution:** bridge only the 22 live fields; `sipi.pool.load_shed` is the Rust analog of `rejected_connections_total`, and `waiting_connections` has no analog (the tokio semaphore sheds immediately rather than queuing).

### opentelemetry 0.31 removed the batch-observer API
**Problem:** the plan assumed one batch callback reading the snapshot once per collection. **Found:** 0.31 removed `register_callback`/`Observer`. **Solution:** per-instrument observable callbacks, each doing one cheap snapshot read. ~22 reads per 60s collection is immaterial.

### Grafana Application Observability is span-metrics driven
**Decision:** APM's RED panels come from the collector's span-metrics connector (which the shell already feeds via `OtelAxumLayer` spans) + `target_info` from resource attributes — not a native `http.server.request.duration`. So no new in-process HTTP metric; APM support is resource attributes (`OTEL_RESOURCE_ATTRIBUTES`, ops-deploy) + Alloy config.

## Gotchas

- **OTLP metric export is on a 60s periodic reader.** When verifying locally, set `OTEL_METRIC_EXPORT_INTERVAL` and/or wait a cycle before querying.
- **Don't rename instruments to chase dashboard names.** The OTel-idiomatic names are intentional; the collector normalization produces the existing `sipi_*_total` Prometheus names. Reconcile any mismatch at the collector.
- **ops-deploy + Alloy changes are required for this to light up in prod** (operator-only): add `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_RESOURCE_ATTRIBUTES` (`service.namespace`, `service.instance.id`) to the `iiif` service env; enable Alloy's span-metrics connector + `target_info`; repoint the Grafana SIPI dashboards/alerts off the Prometheus `/metrics` scrape.
- **`--nthreads` is parse-only** (sized from config `nthreads`, per the earlier M7 decision) — confirmed incidentally: `sipi.pool.permits_total` reflects the config value, not the flag.

## Test Plan

- [x] `just bazel-build-server`, `just bazel-build` (C++ `static_assert` + Rust compile)
- [x] `sipi_unit_test` incl. the lock-step layout guard
- [x] `just bazel-test-e2e` (25/25)
- [x] `just bazel-test-differential` (parity gate, both binaries)
- [x] `just bazel-rustfmt-check`, `just differential-coverage-check`
- [x] Live OTLP end-to-end vs `grafana/otel-lgtm`: all 25 series arrive with correct values (`load_shed` matched the observed 503 count), `target_info` present for APM; fail-open confirmed with no / unreachable collector
- [ ] ops-deploy + Alloy + Grafana dashboard migration (operator)
