### PR TITLE
IIIF compliance fixes: corrupt-JP2 handling, profileLinkHeader, %23 identifier

### DIFF
--- a/docs/src/development/testing-strategy.md
+++ b/docs/src/development/testing-strategy.md
@@ -432,7 +432,7 @@ The following matrix maps every testable IIIF spec requirement to its test statu
 | Content-Type with Accept: ld+json | :white_check_mark: | `jsonld_media_type_with_accept` | |
 | Link header on default request | :white_check_mark: | `jsonld_default_has_link_header` | |
 | Canonical Link header | :white_check_mark: | `canonical_link_header` | |
-| Profile Link header | :x: IGNORED | `profile_link_header` | known sipi bug; test ignored pending fix |
+| Profile Link header | :white_check_mark: | `profile_link_header` | emitted on image responses (DEV-6733) |
 | X-Forwarded-Proto HTTPS rewrite | :white_check_mark: | `info_json_x_forwarded_proto_https` | |
 | Required fields structural check | :white_check_mark: | `info_json_has_required_fields` | |
 | Structural: sizes array exists | :white_check_mark: | `info_json_has_sizes_array` | |
@@ -544,7 +544,7 @@ The following matrix maps every testable IIIF spec requirement to its test statu
 | Requirement | Status | Test | Notes |
 |---|---|---|---|
 | Encoded slash `%2F` | :white_check_mark: | `id_escaped_slash_decoded` | |
-| Encoded `#` (`%23`) | :x: IGNORED | `id_escaped` | known sipi bug; test ignored pending fix |
+| Encoded `#` (`%23`) | :white_check_mark: | `id_escaped` | resolves to the on-disk `#` file (DEV-6732) |
 | Subdirectory identifier | :white_check_mark: | via server tests | |
 | Non-ASCII identifiers | :white_check_mark: | `id_non_ascii` | |
 | ARK/URN identifiers | :x: GAP | — | Not tested (may not apply — sipi identifiers are opaque path segments, not a namespaced scheme) |
@@ -597,7 +597,7 @@ Two Rust-shell features the C++-era gap list assumed are permanently **removed**
 | Memory safety (ASan/LSan) | :white_check_mark: | `sanitizer.yml` CI | e2e suite against an ASan+UBSan-instrumented binary; unit-test sanitizer coverage still pending (see Cross-Cutting section below) |
 | Thread safety (TSan) | :x: GAP | — | Untested for data races; future optional nightly variant |
 | Performance regression detection | :white_check_mark: | `latency.rs` | smoke thresholds only (info.json / cache-miss / cache-hit); load-baseline tier intentionally deferred to staging (see Cross-Cutting section) |
-| Corrupt/truncated image handling | :warning: partial | `iiif_compliance.rs::corrupt_jpeg_handling`, `corrupt_png_handling` covered; `corrupt_image_handling` (truncated JP2) `#[ignore]`'d | Kakadu's `kdu_error` handler calls `exit()` on a corrupt JP2 — bypasses all C++ exception handling, so the process terminates rather than returning an error response; a real, unresolved robustness gap, not just an untested case |
+| Corrupt/truncated image handling | :white_check_mark: | `iiif_compliance.rs::corrupt_jpeg_handling`, `corrupt_png_handling`, `corrupt_image_handling` (truncated JP2) | JP2 decode converts Kakadu's thrown error into a `SipiImageError` (like JPEG/PNG); the server returns a clean error and stays up (DEV-6731) |
 | Lua route handler errors | :white_check_mark: | `differential.rs::lua_route_error_handling` | |
 | Zero-byte / empty file upload | :white_check_mark: | `upload.rs::empty_file_upload` | |
 | Invalid server config startup | :white_check_mark: | `config.rs::invalid_config_startup` | |
@@ -661,7 +661,7 @@ Two Rust-shell features the C++-era gap list assumed are permanently **removed**
 
 | Category | Covered | Gaps | Coverage |
 |---|---|---|---|
-| Info.json fields | 22 | 1 (profile Link — sipi bug) | 96% |
+| Info.json fields | 23 | 0 | 100% |
 | Region parameters | 12 | 0 | 100% |
 | Size parameters | 15 | 0 | 100% |
 | Rotation parameters | 9 | 0 | 100% |
@@ -669,16 +669,15 @@ Two Rust-shell features the C++-era gap list assumed are permanently **removed**
 | Format parameters | 5 | 0 | 100% |
 | CORS | 5 | 0 | 100% |
 | HTTP behavior | 13 | 0 | 100% |
-| Identifiers | 3 | 2 (ARK/URN, `%23`-escape bug) | 60% |
-| Sipi extensions | 90 | 8 | 92% |
-| **Total** | **180** | **11** | **94%** |
+| Identifiers | 4 | 1 (ARK/URN) | 80% |
+| Sipi extensions | 91 | 7 | 93% |
+| **Total** | **183** | **8** | **96%** |
 
 *(Three additional Sipi-extension rows — Prometheus `/metrics`, `/api/cache`, SSL/TLS — are excluded from this count entirely: they are removed-on-the-Rust-shell features, not gaps. See the N/A note above the extension matrix.)*
 
-**Key remaining gap categories** (8 rows, all in Sipi extensions):
+**Key remaining gap categories** (7 rows, all in Sipi extensions):
 
 - **Deep metadata survival** (2 gaps): positive XMP round-trip, ICC profile HTTP-level round-trip — EXIF/IPTC now covered
-- **Corrupt-input robustness** (1 gap, **real bug, not just untested**): Kakadu's `kdu_error` handler calls `exit()` on a truncated JP2, bypassing all C++ exception handling — the process terminates instead of returning an error response. `corrupt_image_handling` documents this via `#[ignore]`; JPEG/PNG corrupt-input handling is fine
 - **Concurrency edge cases** (1 gap): thread-pool-exhaustion saturation test (`concurrent_requests`/`lua_state_thread_isolation` are written and correct, just `#[ignore]`'d for the unrelated 503-shedding reason above — not gaps)
 - **Hardening depth** (2 gaps): TSan (nightly-future), extremely long URL/header (fuzz-only today)
 - **Test-harness depth** (1 gap): a direct SImage Lua-API unit harness (vs. black-box HTTP coverage)

--- a/src/ffi/serve_image.cpp
+++ b/src/ffi/serve_image.cpp
@@ -572,7 +572,11 @@ std::expected<ServeResponse, SipiStatus>
   auto base_headers = [&] {
     std::vector<Header> h;
     h.emplace_back("Cache-Control", kCacheControl);
-    h.emplace_back("Link", canonical_header);
+    // IIIF Image API 3.0 profileLinkHeader (advertised in info.json's extraFeatures):
+    // fold the profile Link into the canonical Link's value (one header) — the Rust
+    // response sink is last-write-wins per header name, so two separate "Link"
+    // entries would drop one.
+    h.emplace_back("Link", canonical_header + R"(, <http://iiif.io/api/image/3/level2.json>;rel="profile")");
     if (content_type != nullptr) { h.emplace_back("Content-Type", content_type); }
     return h;
   };

--- a/src/formats/SipiIOJ2k.cpp
+++ b/src/formats/SipiIOJ2k.cpp
@@ -251,8 +251,19 @@ bool SipiIOJ2k::read(SipiImage *img,
   jp2_ultimate_src.open(filepath.c_str());
 
   bool essentials_from_uuid_box = false;
-  if (jpx_in.open(&jp2_ultimate_src, true)
-      < 0) {// if < 0, not compatible with JP2 or JPX.  Try opening as a raw code-stream.
+  // A corrupt JP2/JPX box structure makes jpx_in.open raise a Kakadu error
+  // (thrown as a kdu_exception by KduSipiError::flush) rather than returning
+  // < 0; convert it to a SipiImageError instead of letting a bare int unwind
+  // past the FFI seam.
+  int jpx_open_result;
+  try {
+    jpx_open_result = jpx_in.open(&jp2_ultimate_src, true);
+  } catch (kdu_exception&) {
+    jp2_ultimate_src.close();
+    throw SipiImageError(
+      "Cannot read JPEG2000 file \"" + filepath + "\": corrupt JP2/JPX structure");
+  }
+  if (jpx_open_result < 0) {// if < 0, not compatible with JP2 or JPX. Try opening as a raw code-stream.
     jp2_ultimate_src.close();
     file_in.open(filepath.c_str());
     input = &file_in;
@@ -314,19 +325,47 @@ bool SipiIOJ2k::read(SipiImage *img,
     }
 
     int stream_id = 0;
-    jpx_stream = jpx_in.access_codestream(stream_id);
-    input = jpx_stream.open_stream();
-    palette = jpx_stream.access_palette();
+    // A truncated/corrupt JP2 container reaches here with no usable codestream;
+    // Kakadu raises an error (thrown as a kdu_exception) from access_codestream /
+    // open_stream. Convert it to a SipiImageError after closing the sources, so
+    // the failure is an enriched, leak-free error rather than a bare catch-all.
+    try {
+      jpx_stream = jpx_in.access_codestream(stream_id);
+      input = jpx_stream.open_stream();
+      palette = jpx_stream.access_palette();
+    } catch (kdu_exception&) {
+      // input is live only if open_stream() returned before the throw; the
+      // codestream is not created yet. jp2_ultimate_src is released by its
+      // destructor on unwind, as on the normal path (which closes only
+      // input + jpx_in).
+      if (input != nullptr) input->close();
+      jpx_in.close();
+      throw SipiImageError(
+        "Cannot read JPEG2000 file \"" + filepath + "\": no usable codestream in JP2/JPX container");
+    }
   }
 
   kdu_core::kdu_codestream codestream;
-  codestream.create(input);
-  // codestream.set_fussy(); // Set the parsing error tolerance.
-  codestream.set_fast();// No errors expected in input
-
-  //
-  // get the
-  int maximal_reduce = codestream.get_min_dwt_levels();
+  // Corrupt or truncated input makes create()/header parsing raise a Kakadu
+  // error, which KduSipiError::flush throws as a kdu_exception. Convert it to a
+  // SipiImageError (as the JPEG/PNG handlers do) after tearing down the
+  // codestream + source, so the engine reports an enriched error rather than a
+  // bare catch-all, and no source is leaked on the failure path.
+  int maximal_reduce;
+  try {
+    codestream.create(input);
+    // codestream.set_fussy(); // Set the parsing error tolerance.
+    codestream.set_fast();// No errors expected in input
+    maximal_reduce = codestream.get_min_dwt_levels();
+  } catch (kdu_exception&) {
+    // create() can throw before the codestream exists; input is already set by
+    // the branch above. Otherwise the same teardown as the ROI/normal paths.
+    if (codestream.exists()) codestream.destroy();
+    input->close();
+    jpx_in.close();
+    throw SipiImageError(
+      "Cannot read JPEG2000 file \"" + filepath + "\": corrupt or truncated codestream");
+  }
 
   //
   // Legacy codestream-comment fallback. Only consulted when the SIPI UUID
@@ -562,7 +601,17 @@ bool SipiIOJ2k::read(SipiImage *img,
   // In order to retrieve a 16-Bit image, use kdu_uin16 *buffer and the apropriate signature of the pull_stripe method
   //
   kdu_supp::kdu_stripe_decompressor decompressor;
-  decompressor.start(codestream);
+  try {
+    decompressor.start(codestream);
+  } catch (kdu_exception&) {
+    // codestream + input are both live here (create() already succeeded);
+    // unconditional teardown, matching the ROI-error and normal-exit paths.
+    codestream.destroy();
+    input->close();
+    jpx_in.close();
+    throw SipiImageError(
+      "Cannot read JPEG2000 file \"" + filepath + "\": corrupt codestream (decompressor start failed)");
+  }
   // TODO: check image for number of components and make this dynamic
   int stripe_heights[5] = {
     dims.size.y, dims.size.y, dims.size.y, dims.size.y, dims.size.y

--- a/src/server-rs/src/routes.rs
+++ b/src/server-rs/src/routes.rs
@@ -356,6 +356,10 @@ fn dispatch_engine(
             serve_image(
                 &resolved,
                 parsed,
+                // Raw, percent-encoded request path (matches the C++ oracle's
+                // `req.request_uri`, SipiHttpServer.cpp:1302) — log/report context
+                // only; never re-parsed by the engine.
+                uri.path(),
                 headers,
                 *method == Method::HEAD,
                 &access,
@@ -528,9 +532,13 @@ fn resolve(infile: &str, resolved_root: &str) -> Result<String, Box<Response>> {
 
 /// IIIF image via `sipi_serve_image`, honouring a `restrict` decision's
 /// `size`/`watermark` from the preflight kv channel.
+// Single-caller engine-dispatch glue; the arguments are the distinct FFI inputs,
+// not a bundle worth a struct.
+#[allow(clippy::too_many_arguments)]
 fn serve_image(
     resolved: &str,
     parsed: &ParsedRequest,
+    request_uri: &str,
     headers: &HeaderMap,
     is_head: bool,
     access: &Access,
@@ -554,7 +562,7 @@ fn serve_image(
     let c_client_ip = CString::new(client_ip(headers)).unwrap_or_default();
     let c_host = CString::new(host).unwrap_or_default();
     let c_scheme = CString::new(scheme).unwrap_or_default();
-    let c_uri = CString::new(parsed_request_uri(parsed)).unwrap_or_default();
+    let c_uri = CString::new(request_uri).unwrap_or_default();
     // restrict size + watermark from the preflight kv (NULL when not restricted).
     let c_size = (access.permission == SipiPermType::Restrict)
         .then(|| access_kv_cstring(access, "size"))
@@ -1641,14 +1649,6 @@ fn client_ip(headers: &HeaderMap) -> String {
     header_str(headers, "x-forwarded-for")
         .and_then(|v| v.rsplit(',').next().map(|s| s.trim().to_owned()))
         .unwrap_or_default()
-}
-
-fn parsed_request_uri(parsed: &ParsedRequest) -> String {
-    if parsed.prefix.is_empty() {
-        format!("/{}", parsed.identifier)
-    } else {
-        format!("/{}/{}", parsed.prefix, parsed.identifier)
-    }
 }
 
 /// `Content-Disposition` for a `/file` download, mirroring the C++ oracle

--- a/test/e2e/tests/iiif_compliance.rs
+++ b/test/e2e/tests/iiif_compliance.rs
@@ -633,17 +633,18 @@ fn canonical_link_header() {
 }
 
 #[test]
-#[ignore] // sipi claims profileLinkHeader in extraFeatures but doesn't emit the header
 fn profile_link_header() {
-    // TODO: sipi lists profileLinkHeader in extraFeatures
-    // (SipiHttpServer.cpp:827) but no code emits
-    // Link: <...level2.json>;rel="profile"
-    // This test should pass once the compliance gap is fixed.
+    // IIIF Image API 3.0 places the profileLinkHeader on image responses (the
+    // feature is advertised in info.json's extraFeatures). The canonical and
+    // profile links are folded into a single Link header value.
     let srv = server();
     let resp = client()
-        .get(format!("{}/unit/lena512.jp2/info.json", srv.base_url))
+        .get(format!(
+            "{}/unit/lena512.jp2/full/max/0/default.jpg",
+            srv.base_url
+        ))
         .send()
-        .expect("GET info.json failed");
+        .expect("GET image failed");
 
     assert_eq!(resp.status().as_u16(), 200);
 
@@ -655,7 +656,7 @@ fn profile_link_header() {
         .unwrap();
     assert!(
         link.contains("http://iiif.io/api/image/3/level2.json") && link.contains("rel=\"profile\""),
-        "Link header should contain profile link, got: {}",
+        "image Link header should contain the profile link, got: {}",
         link
     );
 }

--- a/test/e2e/tests/iiif_compliance.rs
+++ b/test/e2e/tests/iiif_compliance.rs
@@ -920,13 +920,10 @@ fn unsupported_formats_rejected() {
 // --- Phase 8: Identifier and Error Handling Tests ---
 
 #[test]
-#[ignore] // sipi returns 500 for filenames containing # — compliance gap
 fn id_escaped() {
-    // test#image.jp2 is a symlink to lena512.jp2 (created in Phase 1)
-    // %23 is the URL encoding of #
-    // TODO: sipi returns 500 when trying to serve files with # in the
-    // name. The IIIF spec requires escaped characters to work
-    // (id_escaped test).
+    // test#image.jp2 is a symlink to lena512.jp2; %23 is the URL-encoding of #.
+    // A percent-escaped # in the identifier must resolve to the on-disk file
+    // (IIIF Image API 3.0 identifier escaping).
     let srv = server();
     let resp = client()
         .get(format!(

--- a/test/e2e/tests/iiif_compliance.rs
+++ b/test/e2e/tests/iiif_compliance.rs
@@ -1436,10 +1436,10 @@ fn assert_corrupt_image_handled(
 }
 
 #[test]
-#[ignore = "Kakadu calls exit() on corrupt JP2 — not catchable by C++ exception handler"]
 fn corrupt_image_handling() {
-    // Truncated JP2 — Kakadu's kdu_error handler calls exit(), bypassing
-    // both C++ exceptions and our catch-all. Separate Kakadu-specific fix needed.
+    // Truncated JP2 — Kakadu's error handler throws (SipiIOJ2k's KduSipiError),
+    // the read path converts it to a SipiImageError, and the server returns a
+    // clean error and stays up (same graceful-degradation contract as JPEG/PNG).
     assert_corrupt_image_handled("corrupt_test.jp2", "images/unit/lena512.jp2", 100, "jpg");
 }
 


### PR DESCRIPTION
Fixes DEV-6731, DEV-6732, DEV-6733

## Motivation

Three confirmed IIIF-compliance defects surfaced by the testing-strategy audit, each hiding behind an `#[ignore]`'d e2e test — real broken or mis-advertised behaviour, not just untested cases. Part of the **DEV-6659** Step-8.5 compliance cleanup (non-blocking for the cutover deploy).

## Summary

- A truncated/corrupt JP2 no longer leaks Kakadu sources or surfaces a bare 500 — it returns a clean, enriched error and the server stays up (DEV-6731).
- info.json's advertised `profileLinkHeader` is now real: image responses carry `Link: <http://iiif.io/api/image/3/level2.json>;rel="profile"` (DEV-6733).
- A percent-escaped `#` (`%23`) in an identifier resolves to the on-disk file instead of returning 500 (DEV-6732).

## Key Changes

### Corrupt-JP2 handling — `fix(formats)`
- Guard the previously-unguarded Kakadu calls in `SipiIOJ2k::read` (`jpx_in.open`, `access_codestream`/`open_stream`, `codestream.create` + header access, `decompressor.start`) with `catch (kdu_exception&)` → `SipiImageError`, tearing down the sources first. Mirrors the JPEG/PNG handlers and the existing `pull_stripe` catches. `set_fast()` is unchanged, so valid-image decode is unaffected.

### profileLinkHeader — `feat(ffi)`
- The shared engine's `base_headers()` folds the profile Link into the canonical Link's value (one header). Both binaries use `base_headers()`, so the deployed C++ server gains the header and cross-binary parity is automatic. The test moves off info.json onto an image response (IIIF 3.0 places the header there).

### %23 identifier — `test(e2e)` + `refactor(server-rs)`
- The strangler rewrite already resolved the 500; un-ignore `id_escaped` (the differential harness already asserts parity).
- Harden the engine's `request_uri` to carry the raw `uri.path()` (was a lossy `/{prefix}/{identifier}` rebuild that dropped segments and percent-escapes) — improves the shell's log/Sentry fidelity and matches the C++ oracle.

## Challenges and Decisions

### DEV-6731's filed premise was stale
**Problem:** Filed as "Kakadu calls `exit()` on corrupt JP2 — not catchable by the C++ exception handler."
**Tried / found:** A throwing `kdu_message` handler (`KduSipiError`) already exists, and the truncated-fixture test already passes on macOS — no crash reproduces. Driving `sipi convert` on a truncated JP2 exposed the real failure: an *unguarded* `access_codestream` throw unwinding as a bare `int` past the FFI seam, leaking the open sources and surfacing as "unhandled non-standard exception".
**Solution:** Add `kdu_exception`→`SipiImageError` guards for enriched, leak-free errors. The residual native-segfault class (valid header + corrupt codestream body under `set_fast()`) is left as-is — it is already accepted and monitored via out-of-process minidump per **ADR-0018**. Switching `set_fast()`→`set_resilient()` was declined to avoid a valid-decode hot-path perf cost for a rare, accepted risk.

### `serve_image` tripped clippy after the request_uri change
**Problem:** Adding the `request_uri` argument pushed `serve_image` to 8 parameters → `clippy::too_many_arguments` under `-Dwarnings` — a CI-breaker the build/test/rustfmt recipes don't catch (only `just bazel-clippy-check` does).
**Solution:** `#[allow(clippy::too_many_arguments)]` on the single-caller engine-dispatch glue.

## Gotchas

- **`set_fast()` is deliberately unchanged.** A valid-header/corrupt-body JP2 can still trigger a native Kakadu fault; that class is accepted per ADR-0018 (minidump capture), not fixed here. Do not "fix" it by switching to `set_resilient()` without a decode benchmark — it adds per-codeblock checking to the valid-image hot path.
- **Run `just bazel-clippy-check` for Rust edits.** The build/test/rustfmt recipes don't run clippy; it's a separate `-Dwarnings` gate, and adding a parameter/arm can trip it.
- **The profile Link is folded into the canonical Link's value, not a second `Link` header** — the Rust response sink is last-write-wins per header name, so two `Link` entries would drop one.
- **The four JP2 guards have deliberately different cleanup** (guard 2 may hold an open `input`; guards 3/4 mirror the ROI/normal unconditional teardown) — each matches what is actually live at that call site; see the inline comments.

## Test Plan

- [x] `just bazel-clippy-check`, `just bazel-rustfmt-check`
- [x] `just bazel-build` + `just bazel-build-server` (both binaries)
- [x] `just bazel-test-unit` (24/24), `just bazel-test-approval` (JP2/ICC goldens unchanged)
- [x] `just bazel-test-e2e` (26/26; the three formerly-ignored tests now active)
- [x] `just bazel-test-differential` (cross-binary parity, including the new image Link header)
- [x] `just differential-coverage-check` (274)
- [x] Direct `sipi convert` on a valid JP2 (success) and a truncated JP2 (clean enriched error, exit 1, no crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
