### PR TITLE
ci: repair debug-symbol extraction in the release publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,6 +83,12 @@ jobs:
         # See ci.yml for the `nix develop --command` rationale (`gh` on PATH
         # for the kakadu fetch).
         run: nix develop --command bash -c "just bazel-docker-build-${{ matrix.arch }} ${{ steps.rbe.outputs.flags }}"
+      # Exercise the release-only debug-symbol extraction in the validation
+      # stage so it can't silently break at publish time (as it did for
+      # v6.0.0). The artifact is discarded here — publish-docker rebuilds it
+      # for the actual Sentry upload.
+      - name: Extract debug symbols (validation)
+        run: nix develop --command bash -c "just bazel-docker-extract-debug ${{ matrix.arch }} ${{ steps.rbe.outputs.flags }}"
       # `:docker_smoke` rust_test loads the OCI tarball produced by
       # `//src:image_load` and runs the smoke suite against it. The Docker
       # image already loaded by the build step above is left alone.

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,9 @@ icc.zip
 # (rules_rust gen_rust_project). Holds machine-absolute Bazel paths — generated
 # per checkout, never committed.
 /rust-project.json
+# Debug-symbol file surfaced by `just bazel-docker-extract-debug <arch>` for
+# the Sentry upload; a large, ephemeral per-arch artifact, never committed.
+/sipi-*.debug
 
 # Git LFS hooks (auto-installed by `git lfs install`; configured via
 # `core.hooksPath = .githooks` in the dev shell). Per-developer state,

--- a/justfile
+++ b/justfile
@@ -491,7 +491,12 @@ bazel-docker-extract-debug arch *FLAGS='':
     # `.debug` file. The tarball layout is `lib/debug/.build-id/<xx>/<yy>.debug`;
     # the filename is the build-id with the leading two hex chars removed
     # and `.debug` appended.
-    bazel build --config=release --stamp --platforms="$PLATFORM" --verbose_failures {{FLAGS}} //src:sipi_debug_layout
+    #
+    # `--remote_download_toplevel` overrides the .bazelrc BwoB default
+    # (`--remote_download_minimal`): the genrule runs on RBE, so without this
+    # the tarball stays in the CAS and the `tar -xf` below can't open it. A
+    # no-op in local dev (no remote configured).
+    bazel build --config=release --stamp --platforms="$PLATFORM" --verbose_failures --remote_download_toplevel {{FLAGS}} //src:sipi_debug_layout
 
     # Find the single `.debug` file inside the tar. The tarball is
     # deterministic by construction, so this glob always resolves

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -766,25 +766,48 @@ cp "$$BIN" $(execpath _dbg/sipi.stripped)
 # the GNU debuglink convention that lldb/gdb/Sentry's symbolicator
 # follows. The two-character directory is the leading byte of the
 # build-id (hex); the filename is the remaining 38 hex chars + ".debug".
+#
+# The layout path is build-id-derived, so it's only known at build time.
+# `tar()`'s mtree can't be a static literal here — instead this genrule
+# emits the mtree spec (parent dirs + the one file, with the build-id
+# baked into the path), and `:sipi_debug_layout` feeds it to the
+# `tar.bzl` `tar()` rule. That rule uses the hermetic bsdtar toolchain,
+# so the archive is byte-deterministic AND the action runs on any host —
+# a bare `tar` here shelled out to the host's tar (GNU on the RBE Linux
+# workers, BSD on a darwin cross-build), and BSD tar rejects `--sort`.
 genrule(
-    name = "sipi_debug_layout",
+    name = "sipi_debug_mtree",
     srcs = [
         ":_dbg/sipi.debug",
         ":_dbg/sipi_build_id.txt",
     ],
-    outs = ["sipi_debug_layout.tar"],
+    outs = ["sipi_debug_layout.mtree"],
     cmd = """
 set -euo pipefail
 ID=$$(cat $(execpath :_dbg/sipi_build_id.txt))
 PREFIX=$${ID:0:2}
 SUFFIX=$${ID:2}
-mkdir -p out/lib/debug/.build-id/$$PREFIX
-cp $(execpath :_dbg/sipi.debug) out/lib/debug/.build-id/$$PREFIX/$$SUFFIX.debug
-# Deterministic tar — same flags as @tar.bzl uses internally so two
-# builds with identical inputs produce identical bytes.
-tar --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner \\
-    -cf $(OUTS) -C out lib
+{
+    echo "#mtree"
+    echo "./lib type=dir mode=0755 time=0"
+    echo "./lib/debug type=dir mode=0755 time=0"
+    echo "./lib/debug/.build-id type=dir mode=0755 time=0"
+    echo "./lib/debug/.build-id/$$PREFIX type=dir mode=0755 time=0"
+    echo "./lib/debug/.build-id/$$PREFIX/$$SUFFIX.debug type=file mode=0644 time=0 content=$(execpath :_dbg/sipi.debug)"
+} > $@
 """,
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
+# `compress = None` keeps the output an uncompressed `sipi_debug_layout.tar`
+# (the recipe + Sentry-upload contract expect that name). `tar()` otherwise
+# defaults to gzip under `-c opt`, which `--config=release` selects, and would
+# emit `sipi_debug_layout.tar.gz`.
+tar(
+    name = "sipi_debug_layout",
+    srcs = [":_dbg/sipi.debug"],
+    mtree = ":sipi_debug_mtree",
+    compress = None,
     target_compatible_with = ["@platforms//os:linux"],
 )
 


### PR DESCRIPTION
## Motivation

The `v6.0.0` `publish` run failed: both `publish-docker` legs died at the
`Extract debug symbols for Sentry upload` step, before the image was pushed. No
Docker image was published for `v6.0.0`, and the `manifest` + `sentry` jobs were
skipped. The step is release-only, so PR CI never exercised it.

## Summary

- Fix the release-only debug-symbol extraction so `publish-docker` can push again.
- Make the debug-layout tar hermetic so the recipe also runs on a macOS host.
- Exercise the extraction in the `validate-docker` gate so it can't silently break at publish time again.

## Key Changes

### `bazel-docker-extract-debug` recipe (`justfile`)
- Add `--remote_download_toplevel` to the recipe's `bazel build`. Under RBE the
  `//src:sipi_debug_layout` genrule runs remotely and, with the `.bazelrc`
  `--remote_download_minimal` (build-without-the-bytes) default, its tarball
  stays in the CAS and never lands on the runner — so the recipe's `tar -xf`
  couldn't open it. A no-op in local dev (no remote configured).

### Hermetic debug-layout tar (`src/BUILD.bazel`)
- Replace the `sipi_debug_layout` genrule's host `tar --sort=name …` with the
  repo's `tar.bzl` `tar()` rule (hermetic bsdtar toolchain, already used for
  every OCI layer). A new `sipi_debug_mtree` genrule emits the mtree spec at
  build time because the `.build-id/<xx>/<yy>.debug` path is build-id-derived
  and can't be a static literal. `compress = None` keeps the output an
  uncompressed `sipi_debug_layout.tar` to match the recipe + Sentry filename
  contract.

### Validation coverage (`.github/workflows/publish.yml`)
- Run `bazel-docker-extract-debug` in `validate-docker` (both arches), before
  `release-gate`, so the release-only path is proven before any publish side
  effect.

### `.gitignore`
- Ignore the per-arch `sipi-*.debug` the (now locally runnable) recipe drops at
  the repo root.

## Challenges and Decisions

### Output not on disk despite a green build
**Problem:** Bazel reported `//src:sipi_debug_layout` up-to-date at
`bazel-bin/src/sipi_debug_layout.tar`, yet `tar` reported "No such file".
**Solution:** `--remote_download_minimal` (BwoB) leaves remotely-produced outputs
in the CAS. `--remote_download_toplevel` forces the top-level output local — the
same fix `fuzz.yml` already uses for its `bazel build`.

### `pkg_tar` vs `tar.bzl`
**Tried:** `rules_pkg`'s `pkg_tar`.
**Solution:** `rules_pkg` isn't a direct `bazel_dep`; `tar.bzl`'s `tar()` is
already the repo standard (5 uses in `src/BUILD.bazel`). Reused it to avoid a
redundant second tar mechanism.

### Only surfaced at release time
**Problem:** `validate-docker` built + smoke-tested the image but never extracted
debug symbols, so the break was invisible until the `v6.0.0` tag was cut.
**Solution:** added the extraction to `validate-docker`.

## Gotchas

- `tar.bzl`'s `tar()` **gzips by default under `-c opt`** (which `--config=release`
  selects). Any consumer expecting a plain `.tar` must set `compress = None`, or
  the output is silently named `*.tar.gz`.
- The debug-layout genrules stay `target_compatible_with = linux` (ELF debuglink).
  The tar action, however, now runs via the hermetic toolchain, so a darwin host
  cross-building the linux target no longer hits BSD tar.

## Test Plan

- [x] `just bazel-docker-extract-debug arm64` on macOS (darwin host, linux_aarch64
      target) produces `sipi-arm64.debug` (valid ELF arm64, not stripped, BuildID
      present) with the tar laid out at `lib/debug/.build-id/<xx>/<yy>.debug`.
- [x] `just bazel-build` on macOS (build-completeness invariant).
- [ ] `publish` run on the next tag: `validate-docker` extraction green on both
      arches; `publish-docker` pushes both arches; `sentry-cli debug-files upload`
      succeeds.
