### PR TITLE
ci: run the cross-built arm64 image push under x86_64 emulation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -190,6 +190,17 @@ jobs:
         run: nix develop --command bash -c "just bazel-docker-extract-debug ${{ matrix.arch }} ${{ steps.rbe.outputs.flags }}"
       - name: Run Docker smoke tests
         run: nix develop --command bash -c "just bazel-test-smoke ${{ steps.rbe.outputs.flags }}"
+      # `oci_push` runs `jq` as an exec-platform tool. The arm64 image is
+      # cross-built on the x86_64 RBE worker (exec = x86_64), so the push
+      # script bundles the x86_64 `jq`, which can't execute on this arm64
+      # runner. Register binfmt_misc so the kernel runs that x86_64 tool
+      # under qemu emulation — the push is network-bound (crane uploads
+      # layers) with only trivial jq work, so the emulation cost is
+      # negligible and we keep the fast worker cross-build. amd64 runs the
+      # push natively and needs none of this.
+      - name: Enable x86_64 emulation for the cross-built push tooling
+        if: matrix.arch == 'arm64'
+        run: sudo apt-get update && sudo apt-get install -y qemu-user-static
       - name: Push image to Docker Hub
         run: nix develop --command bash -c "just bazel-docker-push-${{ matrix.arch }} ${{ steps.rbe.outputs.flags }}"
 


### PR DESCRIPTION
## Motivation

The `v6.0.0` publish failed at the arm64 image push and left the release
half-published: `daschswiss/sipi:v6.0.0-amd64` + `latest-amd64` were pushed,
but no `v6.0.0-arm64`, no multi-arch `v6.0.0` manifest, and no `:latest`
manifest — so `docker pull daschswiss/sipi:v6.0.0` does not resolve.

## Summary

- Register `binfmt_misc` (qemu) on the arm64 publish leg so the cross-built,
  x86_64-hosted `oci_push` tooling can run there.

## Key Changes

### publish.yml
- New `Enable x86_64 emulation for the cross-built push tooling` step,
  gated to `matrix.arch == 'arm64'`, before `Push image to Docker Hub`.
  Installs `qemu-user-static` so the kernel runs the bundled x86_64 `jq`
  under emulation.

## Challenges and Decisions

### arm64 push died with `Exec format error` (exit 126)
**Problem:** `oci_push` runs `jq` as an *exec-platform* tool. The arm64 image
is cross-built on the x86_64 RBE worker (exec = x86_64, via the `bazel-rbe`
composite action's `--host_platform=//platforms:linux_x86_64`), so the push
script bundles the **x86_64** `jq`. On the arm64 runner that binary can't
execute. amd64 was unaffected because there exec-arch == runner-arch.

**Tried / rejected:**
- *Run `oci_push` natively on arm64 (drop the cross flags).* Would give a
  native `jq`, but the image build then goes native on the runner (different
  exec config → can't reuse the worker/cache artifacts → full recompile).
  Timings show the push is ~20s and network-bound while the build is the
  expensive part (80s warm, 172s in validate, far more cold) — not worth
  moving the costly stage to fix the cheap one.
- *Push both arches from an amd64 job.* Works, but adds a job (setup
  duplication + serialization) and can't run on the arm64 runner as intended.
- *Replace `oci_push` with `crane`.* Viable (crane already stitches the
  manifest) but discards the deliberate Bazel-native push.

**Solution:** emulate. `jq` does trivial JSON work and `crane` uploads
already-built layers (network-bound), so qemu overhead is negligible. Keeps
the fast worker cross-build and `oci_push` untouched; one small, arm64-only
step.

## Gotchas

- The emulation step is **arm64-only** (`if: matrix.arch == 'arm64'`); amd64
  pushes natively — do not drop the guard.
- This does **not** touch the smoke test: it runs the arm64 binary natively
  and never used `jq`. The step is placed *after* smoke, so smoke stays a true
  native test with zero interaction with binfmt.
- Systemic gap, not fixed here: `validate-docker` re-runs only build + smoke —
  it never exercises push / manifest / sentry, so those irreversible stages
  are first tested by a real release. Each release attempt has failed one
  stage further (extract-debug → push). Worth making the gate actually
  exercise the push (e.g. against a scratch/local registry) as a follow-up.

## Test Plan

- [ ] Re-run the failed `v6.0.0` publish (idempotent) and confirm
      `publish-docker / arm64` push succeeds under emulation.
- [ ] Confirm the never-yet-run downstream stages go green: arm64 Docker
      Scout, arm64 Sentry symbol upload, `manifest` (`crane index append`),
      `sentry` release.
- [ ] Verify `docker pull daschswiss/sipi:v6.0.0` resolves to a multi-arch
      manifest and `:latest` points at it.
