### PR TITLE
feat(server-rs,cli-rs): queue requests at the engine pool instead of shedding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,8 @@ localdev config in one step.
 
 ## High-Level Architecture
 
+**Production surface vs oracle.** The **Rust axum shell** (`src/server-rs` + `src/cli-rs`, built by `just bazel-build-server`) is the production server. It drives the C++ **image engine** (`libsipi`) over the FFI seam in `src/server-rs/src/ffi.rs`. The retained C++ **server** (`src/shttps` + `src/cli/cli_app.cpp` server mode) is **oracle-only** — kept solely as the reference in the differential parity gate (`test/e2e/tests/differential.rs`), never deployed. In production Rust code, describe current Rust behavior on its own terms; do not frame it relative to the C++ server / oracle / transport (referencing the C++ *engine*, the FFI callee, is fine), and keep parity notes in the differential test, not in shell comments. See [`CONVENTIONS.md` § Production surface vs oracle](CONVENTIONS.md).
+
 ### Core Components
 
 | Component | Path | Purpose |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -7,12 +7,22 @@ For the full C++23 style guide, see `docs/src/development/cpp-style-guide.md`.
 For commit and PR conventions, see `docs/src/development/commit-conventions.md`.
 For reviewer guidelines, see `docs/src/development/reviewer-guidelines.md`.
 
+## Production surface vs oracle
+
+The **Rust axum shell** (`src/server-rs` + `src/cli-rs`) is the production server. It drives the C++ **image engine** (`libsipi`, the FFI callee) over the seam in `src/server-rs/src/ffi.rs`. The retained C++ **server** (`src/shttps` + `src/cli`) is **oracle-only**: kept solely as the reference in the differential parity test (`test/e2e/tests/differential.rs`), never deployed.
+
+Consequences for production (Rust) code:
+
+- Comments describe current, working Rust behavior on its own terms. Do **not** frame the Rust shell relative to the C++ server / oracle / transport ("matches the oracle", "the transport's X", "reconstructs shttps' Y"). Referencing the C++ **engine** (the production FFI callee) is fine — that is what the shell calls into.
+- Parity observations belong in the differential test, not in shell code comments.
+- Do not describe roadmap or in-flight history ("not yet wired", "previously", "now uses"); state what the code does today.
+
 ## Stack
 
 - C++23, Clang 15+ / GCC 13+
 - Build orchestrator: Bazel (single source of truth for CI; reproducible action graph)
 - Reproducible dev environment: Nix dev shells (`flake.nix` `devShells` only — no Nix-side build derivations)
-- HTTP framework: custom `shttps/` library (threading, SSL, connection pooling)
+- HTTP framework: Rust axum shell (`src/server-rs`, `src/cli-rs`) — the production server; the retained C++ `shttps/` library is oracle-only (see "Production surface vs oracle")
 - Image formats: libtiff, libpng, libjpeg, libwebp, Kakadu (JPEG 2000)
 - Scripting: Lua (routes, preflight checks, image manipulation)
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -2,6 +2,11 @@
 
 ## Always check
 
+### Production vs oracle
+- The Rust shell (`src/server-rs`, `src/cli-rs`) is the production server; the C++ server (`src/shttps`, `src/cli`) is oracle-only (differential parity, never deployed).
+- Flag new comments in Rust production code that frame it relative to the C++ server / oracle / transport ("matches the oracle", "the transport's X"). Comments should state current Rust behavior. Referencing the C++ **engine** (the FFI callee) is fine; parity notes belong in `test/e2e/tests/differential.rs`.
+- Flag roadmap / in-flight-history comments ("not yet wired", "previously", "now uses") — describe what the code does today.
+
 ### Security (input validation)
 - IIIF identifiers validated for path traversal (`..`, `%2e%2e`, encoded variants) before any filesystem operation
 - File paths resolved via `realpath()` and verified within `imgroot()` before `access()` or `open()`

--- a/src/cli-rs/src/commands/server/args/concurrency.rs
+++ b/src/cli-rs/src/commands/server/args/concurrency.rs
@@ -1,29 +1,27 @@
 //! Concurrency flags (the "Concurrency" `--help` heading).
 //!
-//! `nthreads`, `max_waiting`, and `queue_timeout` are all parse-only: the Rust
-//! shell bounds concurrent engine work with a tokio semaphore (shed-load →
-//! 503) sized from the Lua/TOML config's `nthreads` key
-//! (`server-rs/routes.rs`'s `ffi::nthreads()`), not from a CLI/env override —
-//! thread count is one of the "transport knobs the shell does not own",
-//! grouped with TLS/hostname/keep-alive/logfile in the TOML schema
-//! (`server-rs/config_file.rs`), and the CLI stays consistent with that.
-//! `max_waiting`/`queue_timeout` are unread for a different reason: the
-//! semaphore model has no queue to size.
+//! All three configure the engine-work pool directly from CLI/env
+//! (`SIPI_NTHREADS`/`SIPI_MAX_WAITING`/`SIPI_QUEUE_TIMEOUT`), handed to
+//! `sipi::run`; the Lua config does not set them. `nthreads` sizes the pool
+//! (0 or unset = auto-detect from CPU cores). `max_waiting` bounds the wait queue
+//! in front of it (default 2×nthreads) and `queue_timeout` bounds how long each
+//! request waits before a 503 (default 5s). See `server-rs/routes.rs`'s
+//! `AppState::load` and `acquire_or_shed`.
 
 use clap::Args;
 
 #[derive(Args, Debug)]
 #[command(next_help_heading = "Concurrency")]
 pub struct ConcurrencyArgs {
-    /// Worker thread count (0 = auto-detect from CPU cores; parse-only — sizes
-    /// the engine-work semaphore only from the Lua/TOML config, not the CLI).
-    /// Also accepts the C++ oracle's `-t` short form.
+    /// Worker thread count that sizes the engine-work pool (0 = auto-detect from
+    /// CPU cores). Also accepts the `-t` short form.
     #[arg(long, short = 't', env = "SIPI_NTHREADS", value_name = "N")]
     pub nthreads: Option<u32>,
-    /// Max waiting connections before 503 (parse-only: semaphore model).
+    /// Max requests queued for a worker before 503 (0 = no queue, shed
+    /// immediately; default 2×nthreads).
     #[arg(long, env = "SIPI_MAX_WAITING", value_name = "N")]
     pub max_waiting: Option<u64>,
-    /// Max seconds a request waits in queue before 503 (parse-only).
+    /// Max seconds a queued request waits for a worker before 503 (default 5).
     #[arg(long, env = "SIPI_QUEUE_TIMEOUT", value_name = "SECS")]
     pub queue_timeout: Option<u32>,
 }

--- a/src/cli-rs/src/commands/server/mod.rs
+++ b/src/cli-rs/src/commands/server/mod.rs
@@ -18,10 +18,13 @@ use std::process::ExitCode;
 
 impl From<&ServerArgs> for ServerOverrides {
     fn from(args: &ServerArgs) -> Self {
-        // Engine-behaviour flags forward; transport flags the Rust shell owns
-        // (sslport/sslcert/sslkey, keepalive, max-waiting/queue-timeout,
-        // hostname, nthreads, logfile) parse for CLI parity but are never
-        // forwarded (the forward/parse-only split). The deprecated
+        // Engine-behaviour flags forward into this overrides bag; flags the shell
+        // does not act on (sslport/sslcert/sslkey, keepalive, hostname, logfile)
+        // are accepted but not forwarded. `--nthreads`, `--max-waiting`, and
+        // `--queue-timeout` are handled separately: Rust-owned serve knobs handed
+        // straight to `sipi::run` below (like `--drain-timeout`), not layered onto
+        // the engine config. The
+        // deprecated
         // cache aliases (--cachedir/--cachesize/--cachenfiles) collapse onto
         // their canonical field here — canonical wins if both are somehow set
         // (matches the C++ oracle's last-write-wins on the shared `optCache*`
@@ -88,8 +91,16 @@ pub fn run(server_argv: &[String]) -> ExitCode {
         }
     };
 
-    // `--drain-timeout` is a Rust-owned serve knob, not a config override, so it
-    // is handed straight to `sipi::run`.
+    // `--drain-timeout` and the concurrency knobs (`--nthreads`, `--max-waiting`,
+    // `--queue-timeout`) are Rust-owned serve knobs, not config overrides, so they
+    // are handed straight to `sipi::run` rather than layered onto the engine config.
     let overrides = ServerOverrides::from(&args);
-    sipi::run(args.config, overrides, args.drain_timeout)
+    sipi::run(
+        args.config,
+        overrides,
+        args.drain_timeout,
+        args.concurrency.nthreads,
+        args.concurrency.max_waiting,
+        args.concurrency.queue_timeout,
+    )
 }

--- a/src/server-rs/src/config.rs
+++ b/src/server-rs/src/config.rs
@@ -25,9 +25,11 @@ use std::os::raw::{c_char, c_int};
 /// wins).
 ///
 /// Only engine-behaviour flags are forwarded. Transport flags the Rust shell
-/// owns (`--sslport`/`--sslcert`/`--sslkey`, `--keepalive`,
-/// `--max-waiting`/`--queue-timeout`, `--hostname`) parse for CLI parity but are
-/// never forwarded, so they are absent here.
+/// owns (`--sslport`/`--sslcert`/`--sslkey`, `--keepalive`, `--hostname`) parse
+/// for CLI parity but are never forwarded, so they are absent here.
+/// `--max-waiting`/`--queue-timeout` are also absent here, but for the opposite
+/// reason: the shell honors them as Rust-owned serve knobs passed straight to
+/// [`crate::run`] (like `--drain-timeout`), not layered onto the engine config.
 #[derive(Debug, Default, Clone)]
 pub struct ServerOverrides {
     /// HTTP listen port (`--serverport` / `SIPI_SERVERPORT`). `None` → fall back

--- a/src/server-rs/src/ffi.rs
+++ b/src/server-rs/src/ffi.rs
@@ -154,11 +154,10 @@ pub type SipiReportErrorFn = extern "C" fn(ctx: *mut c_void, err: *const SipiIma
 /// against an accidental field reorder or insertion. The OTel meter bridge
 /// (`crate::metrics`) reads this each collection.
 ///
-/// Two counters are populated only by the retained C++ transport's connection
-/// adapter, never on the FFI serve path, so they stay zero under the Rust shell
-/// and the bridge does not expose them: `rejected_connections_total` (its Rust
-/// analog is `sipi.pool.load_shed`) and `waiting_connections` (the semaphore
-/// sheds immediately rather than queuing).
+/// Two counters are never written on the FFI serve path, so they stay zero and
+/// the bridge does not expose them: `rejected_connections_total` and
+/// `waiting_connections`. The shell tracks its own equivalents Rust-side instead
+/// (`sipi.pool.load_shed` and `sipi.pool.waiting` — its bounded wait queue).
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default)]
 pub struct SipiMetricsSnapshot {
@@ -324,10 +323,6 @@ extern "C" {
     /// The `prefix_as_path` config knob (`*out` = 1/0). Returns 0, or 500 if
     /// `sipi_init` has not run.
     pub fn sipi_prefix_as_path(out: *mut c_int) -> c_int;
-
-    /// The configured worker-thread count (`*out`); 0 = auto. Returns 0, or 500
-    /// if `sipi_init` has not run.
-    pub fn sipi_nthreads(out: *mut c_int) -> c_int;
 
     /// The configured max POST body size in bytes (`*out`); 0 = unlimited.
     /// Returns 0, or 500 if `sipi_init` has not run.
@@ -671,19 +666,6 @@ pub fn prefix_as_path() -> Result<bool, i32> {
         return Err(code);
     }
     Ok(v != 0)
-}
-
-/// The configured worker-thread count (the Lua config `nthreads`). `0` means the
-/// operator left it auto — the caller sizes its blocking pool from the host
-/// parallelism. `Err` carries the FFI status (500 if `sipi_init` has not run).
-pub fn nthreads() -> Result<u32, i32> {
-    let mut v: c_int = 0;
-    // SAFETY: `out` is a valid pointer; the seam guards exceptions.
-    let code = unsafe { sipi_nthreads(&mut v) };
-    if code != 0 {
-        return Err(code);
-    }
-    Ok(v.max(0) as u32)
 }
 
 /// The configured max POST body size in bytes (`max_post_size`). `0` means

--- a/src/server-rs/src/lib.rs
+++ b/src/server-rs/src/lib.rs
@@ -54,14 +54,20 @@ static START: OnceLock<Instant> = OnceLock::new();
 /// flags and calls this; a downstream crate can call it directly.
 /// `config` is the bootstrap config file path — `.lua` (engine Lua VM) or `.toml`
 /// (parsed Rust-side); it selects the base config the `overrides` layer onto.
-/// `drain_timeout` is the Rust-owned graceful-drain
-/// deadline in seconds (default 30). Blocks until shutdown; returns the process
-/// exit code. Telemetry init lives in [`server_main`] (inside the runtime)
-/// because the OTLP batch exporter needs a tokio runtime.
+/// `drain_timeout` is the Rust-owned graceful-drain deadline in seconds
+/// (default 30). `nthreads`/`max_waiting`/`queue_timeout` are the Rust-owned
+/// engine-pool knobs (`--nthreads`/`--max-waiting`/`--queue-timeout`): the worker
+/// count that sizes the pool, how many requests may queue for a worker, and how
+/// long each waits, before the shell sheds with 503. Blocks until shutdown;
+/// returns the process exit code. Telemetry init lives in [`server_main`] (inside
+/// the runtime) because the OTLP batch exporter needs a tokio runtime.
 pub fn run(
     config: Option<String>,
     overrides: ServerOverrides,
     drain_timeout: Option<u64>,
+    nthreads: Option<u32>,
+    max_waiting: Option<u64>,
+    queue_timeout: Option<u32>,
 ) -> ExitCode {
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.enable_all();
@@ -87,7 +93,14 @@ pub fn run(
         }
     };
 
-    rt.block_on(server_main(config, overrides, drain_timeout))
+    rt.block_on(server_main(
+        config,
+        overrides,
+        drain_timeout,
+        nthreads,
+        max_waiting,
+        queue_timeout,
+    ))
 }
 
 /// The async server lifecycle inside the tokio runtime: install telemetry, prove
@@ -97,6 +110,9 @@ async fn server_main(
     config: Option<String>,
     overrides: ServerOverrides,
     drain_timeout: Option<u64>,
+    nthreads: Option<u32>,
+    max_waiting: Option<u64>,
+    queue_timeout: Option<u32>,
 ) -> ExitCode {
     // Stamp the process start for /health uptime before anything else.
     let _ = START.set(Instant::now());
@@ -190,6 +206,9 @@ async fn server_main(
         lua_config_port,
         drain_deadline,
         configured_routes,
+        nthreads,
+        max_waiting,
+        queue_timeout,
     )
     .await;
 
@@ -306,12 +325,20 @@ async fn serve(
     lua_config_port: Option<u16>,
     drain_timeout: Duration,
     configured_routes: Option<Vec<ffi::RouteEntry>>,
+    nthreads: Option<u32>,
+    max_waiting: Option<u64>,
+    queue_timeout: Option<u32>,
 ) -> std::io::Result<()> {
     // Read the cached engine config once (image root + prefix_as_path); a
     // not-ready state (no --config) leaves the serve routes returning 503.
     // `configured_routes` is `Some` for a TOML config (routes sourced Rust-side),
     // `None` for a Lua config (routes read back from the engine via the seam).
-    let state = Arc::new(routes::AppState::load(configured_routes));
+    let state = Arc::new(routes::AppState::load(
+        configured_routes,
+        nthreads,
+        max_waiting,
+        queue_timeout,
+    ));
     // Bind the OTel observable instruments now that the engine pool exists (the
     // concurrency gauges read its permits). A no-op when no meter provider was
     // installed (no OTLP endpoint), so it is safe to call unconditionally.
@@ -434,7 +461,7 @@ mod app_tests {
     // serve routes 503. The full serve path (real images via the FFI) is covered
     // by the manual smoke run and the reqwest e2e suite targeting //src/cli-rs:sipi.
     fn test_app() -> Router {
-        app(Arc::new(routes::AppState::load(None)))
+        app(Arc::new(routes::AppState::load(None, None, None, None)))
     }
 
     async fn status_of(uri: &str) -> StatusCode {

--- a/src/server-rs/src/metrics.rs
+++ b/src/server-rs/src/metrics.rs
@@ -14,11 +14,11 @@
 //! Instrument names are OTel-idiomatic (`sipi.cache.hits`), which the standard
 //! OTLP→Prometheus normalization at the collector renders as the existing
 //! dashboard names (`sipi_cache_hits_total`). Two snapshot fields are **not**
-//! bridged — `rejected_connections_total` and `waiting_connections` are written
-//! only by the retained C++ transport's connection adapter, never on the FFI
-//! serve path (see [`crate::ffi::SipiMetricsSnapshot`]). `rejected_connections_total`'s
-//! Rust-shell analog is `sipi.pool.load_shed` below; `waiting_connections` has no
-//! equivalent (the semaphore sheds rather than queues).
+//! bridged — `rejected_connections_total` and `waiting_connections` are never
+//! written on the FFI serve path, so they stay zero (see
+//! [`crate::ffi::SipiMetricsSnapshot`]); the shell exposes its own analogs
+//! instead, `sipi.pool.load_shed` and `sipi.pool.waiting` (the bounded wait queue
+//! in front of the pool), both below.
 //!
 //! opentelemetry 0.31 has no batch-observer API (`register_callback` was
 //! removed), so each instrument carries its own callback and each snapshots the
@@ -57,10 +57,9 @@ pub(crate) fn register(pool: Arc<Semaphore>, permits_total: usize) {
         gauge(&meter, name, description, unit, *extract);
     }
 
-    // ── Rust-shell concurrency metrics (the transport the shell now owns) ────
-    // Engine-pool permits in flight: total − currently-available. The gauge the
-    // dead `waiting_connections` can't provide (the semaphore sheds, never
-    // queues), and the real saturation signal.
+    // ── Engine-pool concurrency metrics ─────────────────────────────────────
+    // Engine-pool permits in flight: total − currently-available — the real
+    // saturation signal.
     meter
         .i64_observable_gauge("sipi.pool.permits_in_use")
         .with_description("Engine-pool permits currently held (blocking engine work in flight)")
@@ -75,12 +74,26 @@ pub(crate) fn register(pool: Arc<Semaphore>, permits_total: usize) {
         .with_description("Engine-pool total permit count (the configured worker count)")
         .with_callback(move |observer| observer.observe(permits_total as i64, &[]))
         .build();
-    // 503 load-shed count — the Rust-shell analog of the transport's dead
-    // `rejected_connections_total`.
+    // 503 load-shed count: every backpressure shed (immediate + queue-timeout).
     meter
         .u64_observable_counter("sipi.pool.load_shed")
         .with_description("Requests shed with 503 because the engine pool was saturated")
         .with_callback(|observer| observer.observe(routes::load_shed_total(), &[]))
+        .build();
+    // Requests currently parked in the wait queue for a permit. With
+    // `permits_in_use` (== permits_total under load) this is the full saturation
+    // picture: a rising `waiting` is sustained overload approaching the shed edge.
+    meter
+        .i64_observable_gauge("sipi.pool.waiting")
+        .with_description("Requests currently waiting for an engine-pool permit")
+        .with_callback(|observer| observer.observe(routes::waiting(), &[]))
+        .build();
+    // Queue-timeout sheds — the subset of `load_shed` that waited past
+    // `queue_timeout` rather than shedding immediately on a full queue.
+    meter
+        .u64_observable_counter("sipi.pool.queue_timeout")
+        .with_description("Requests shed with 503 after waiting past the queue timeout")
+        .with_callback(|observer| observer.observe(routes::queue_timeout_total(), &[]))
         .build();
 }
 

--- a/src/server-rs/src/routes.rs
+++ b/src/server-rs/src/routes.rs
@@ -11,8 +11,9 @@
 
 use std::ffi::CString;
 use std::io::Write;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::body::{to_bytes, Body};
 use axum::extract::{DefaultBodyLimit, FromRequest, Multipart, OriginalUri, Request, State};
@@ -20,7 +21,7 @@ use axum::http::{header, HeaderMap, HeaderValue, Method, StatusCode, Uri};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{on, MethodFilter, MethodRouter};
 use tempfile::NamedTempFile;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, OwnedSemaphorePermit};
 
 use crate::ffi::{self, PreflightOutcome, SipiPermType, SipiResponse, SipiServeRequest};
 use crate::iiif::{self, ParsedRequest, RequestKind};
@@ -56,6 +57,14 @@ pub struct AppState {
     /// baseline: `permits - available_permits()` = engine work in flight).
     /// Fixed after startup; `Semaphore` exposes only the live available count.
     permits: usize,
+    /// How many requests may queue for a permit before the shell sheds
+    /// immediately (`--max-waiting`). A permit that frees admits the oldest
+    /// waiter; beyond this many waiters a new request 503s at once. `0` disables
+    /// queuing entirely (a full pool then sheds immediately).
+    max_waiting: usize,
+    /// How long a queued request waits for a permit before it is shed with 503
+    /// (`--queue-timeout`).
+    queue_timeout: Duration,
     /// Configured Lua routes (method/route/script), registered as axum routes by
     /// [`crate::app`]. Empty when the engine is uninstalled.
     pub routes: Vec<ffi::RouteEntry>,
@@ -78,16 +87,30 @@ impl AppState {
     /// `[[routes]]` table Rust-side and composed each script path); `None` for a
     /// Lua config, where the routes are read back from the engine via
     /// [`ffi::routes`] after `sipi_init` installed them.
+    ///
+    /// `nthreads`/`max_waiting`/`queue_timeout` are the
+    /// `--nthreads`/`--max-waiting`/`--queue-timeout` serve knobs (`None` → the
+    /// defaults below).
     #[must_use]
-    pub fn load(configured_routes: Option<Vec<ffi::RouteEntry>>) -> Self {
-        // Bound concurrent engine work to the configured worker count (the shttps
-        // thread-per-connection bound, reconstructed). 0/uninitialised → size from
-        // the host parallelism.
-        let permits = ffi::nthreads()
-            .ok()
+    pub fn load(
+        configured_routes: Option<Vec<ffi::RouteEntry>>,
+        nthreads: Option<u32>,
+        max_waiting: Option<u64>,
+        queue_timeout: Option<u32>,
+    ) -> Self {
+        // Bound concurrent engine work with a semaphore sized from
+        // `--nthreads`/`SIPI_NTHREADS`; unset (or 0 = auto) sizes it from the host
+        // parallelism.
+        let permits = nthreads
             .filter(|n| *n > 0)
             .map_or_else(default_pool_size, |n| n as usize);
         let pool = Arc::new(tokio::sync::Semaphore::new(permits));
+        // Bounded wait queue in front of the pool: how many requests may park for
+        // a permit and how long each waits before a 503. `max_waiting` defaults to
+        // 2×workers and `queue_timeout` to 5s; `max_waiting == 0` disables queuing
+        // (a full pool then sheds immediately).
+        let max_waiting = max_waiting.map_or_else(|| permits.saturating_mul(2), |n| n as usize);
+        let queue_timeout = Duration::from_secs(u64::from(queue_timeout.unwrap_or(5)));
         match (
             ffi::imgroot(false),
             ffi::imgroot(true),
@@ -104,6 +127,8 @@ impl AppState {
                 has_file_preflight: ffi::has_file_preflight().unwrap_or(false),
                 pool,
                 permits,
+                max_waiting,
+                queue_timeout,
                 // TOML config supplies routes directly; a Lua config has them
                 // read back from the engine via the seam.
                 routes: configured_routes.unwrap_or_else(|| ffi::routes().unwrap_or_default()),
@@ -122,6 +147,8 @@ impl AppState {
                 has_file_preflight: false,
                 pool,
                 permits,
+                max_waiting,
+                queue_timeout,
                 routes: Vec::new(),
                 max_post_size: 0,
                 docroot: String::new(),
@@ -141,8 +168,7 @@ impl AppState {
 
 /// Cumulative 503 load-shed count: incremented every time the engine pool is
 /// saturated and a request is shed ([`busy_response`]). Read by the OTel bridge
-/// ([`crate::metrics`]) as an observable counter — the Rust-shell analog of the
-/// C++ transport's `rejected_connections_total` (dead under the shell). A plain
+/// ([`crate::metrics`]) as the `sipi.pool.load_shed` observable counter. A plain
 /// atomic (not an OTel sync counter) so the shed path holds no meter handle and
 /// the count is correct regardless of whether metrics export is enabled.
 static LOAD_SHED_TOTAL: AtomicU64 = AtomicU64::new(0);
@@ -150,6 +176,83 @@ static LOAD_SHED_TOTAL: AtomicU64 = AtomicU64::new(0);
 /// The cumulative 503 load-shed count for the OTel observable counter.
 pub(crate) fn load_shed_total() -> u64 {
     LOAD_SHED_TOTAL.load(Ordering::Relaxed)
+}
+
+/// Requests currently parked in the wait queue for a pool permit. Read by the
+/// OTel bridge as the `sipi.pool.waiting` gauge; maintained by [`WaitGuard`].
+static WAITING: AtomicUsize = AtomicUsize::new(0);
+
+/// The live wait-queue depth for the OTel observable gauge.
+pub(crate) fn waiting() -> i64 {
+    // The count never exceeds `max_waiting` (a small config value), so the
+    // usize→i64 cast cannot overflow.
+    WAITING.load(Ordering::Relaxed) as i64
+}
+
+/// Cumulative 503s from requests that waited past `queue_timeout` (a subset of
+/// [`LOAD_SHED_TOTAL`], which counts every backpressure shed). Read by the OTel
+/// bridge as the `sipi.pool.queue_timeout` counter.
+static QUEUE_TIMEOUT_TOTAL: AtomicU64 = AtomicU64::new(0);
+
+/// The cumulative queue-timeout shed count for the OTel observable counter.
+pub(crate) fn queue_timeout_total() -> u64 {
+    QUEUE_TIMEOUT_TOTAL.load(Ordering::Relaxed)
+}
+
+/// RAII bump of the [`WAITING`] gauge: incremented while a request is parked for
+/// a permit, decremented on every exit (permit acquired, timeout, or panic).
+struct WaitGuard;
+impl WaitGuard {
+    fn new() -> Self {
+        WAITING.fetch_add(1, Ordering::Relaxed);
+        WaitGuard
+    }
+}
+impl Drop for WaitGuard {
+    fn drop(&mut self) {
+        WAITING.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+/// The admission decision for a request that needs the engine pool.
+enum Admission {
+    /// A permit was acquired (immediately or after waiting); held for the dispatch.
+    Admitted(OwnedSemaphorePermit),
+    /// The pool is full and the wait queue is at capacity (or disabled) — shed now.
+    Shed,
+    /// Parked for a permit but `queue_timeout` elapsed first.
+    TimedOut,
+}
+
+/// Admit a request to the engine pool, or shed it. Fast path: a free permit is
+/// taken without waiting (the common case). Otherwise, if the wait queue has room
+/// (`WAITING < max_waiting`), park for up to `queue_timeout` for a permit; a full
+/// (or disabled, `max_waiting == 0`) queue sheds immediately, and an elapsed wait
+/// sheds as [`Admission::TimedOut`].
+async fn acquire_or_shed(
+    pool: Arc<tokio::sync::Semaphore>,
+    max_waiting: usize,
+    queue_timeout: Duration,
+) -> Admission {
+    if let Ok(permit) = Arc::clone(&pool).try_acquire_owned() {
+        return Admission::Admitted(permit);
+    }
+    // A small overshoot from a racing check-then-park is harmless: the bound is
+    // a soft cap on queue depth, not an invariant.
+    if max_waiting == 0 || WAITING.load(Ordering::Relaxed) >= max_waiting {
+        return Admission::Shed;
+    }
+    let _guard = WaitGuard::new();
+    match tokio::time::timeout(queue_timeout, pool.acquire_owned()).await {
+        Ok(Ok(permit)) => Admission::Admitted(permit),
+        // The semaphore is never closed in normal operation; treat a closed pool
+        // (only reachable on teardown) as a shed rather than a panic.
+        Ok(Err(_)) => Admission::Shed,
+        Err(_) => {
+            QUEUE_TIMEOUT_TOTAL.fetch_add(1, Ordering::Relaxed);
+            Admission::TimedOut
+        }
+    }
 }
 
 /// Pool size when the configured `nthreads` is 0 (auto) or unreadable: the host
@@ -215,12 +318,19 @@ pub async fn iiif(
 
     // Everything else drives the blocking C++ engine (the per-call preflight VM,
     // realpath, decode/encode). Bound concurrency on the pool and run the work on
-    // a blocking thread so the async runtime stays responsive; a full pool sheds
-    // load with 503 + Retry-After. /health, /favicon, and OPTIONS are
-    // separate routes that never reach here.
-    let permit = match Arc::clone(&state.pool).try_acquire_owned() {
-        Ok(permit) => permit,
-        Err(_) => return busy_response(),
+    // a blocking thread so the async runtime stays responsive; when the pool is
+    // full the request queues for up to `queue_timeout`, then sheds with 503 +
+    // Retry-After. /health, /favicon, and OPTIONS are separate routes that never
+    // reach here.
+    let permit = match acquire_or_shed(
+        Arc::clone(&state.pool),
+        state.max_waiting,
+        state.queue_timeout,
+    )
+    .await
+    {
+        Admission::Admitted(permit) => permit,
+        Admission::Shed | Admission::TimedOut => return busy_response(),
     };
     // Shell-set headers on the streamed (success) response, captured before the
     // request is moved onto the blocking thread: the CORS Origin echo + credentials
@@ -832,10 +942,17 @@ async fn serve_lua_script(
     }
 
     // Bound concurrency on the engine pool, then run the (blocking) Lua VM off the
-    // async runtime. A full pool sheds load with 503 + Retry-After.
-    let permit = match Arc::clone(&state.pool).try_acquire_owned() {
-        Ok(permit) => permit,
-        Err(_) => return busy_response(),
+    // async runtime. A full pool queues for up to `queue_timeout`, then sheds with
+    // 503 + Retry-After.
+    let permit = match acquire_or_shed(
+        Arc::clone(&state.pool),
+        state.max_waiting,
+        state.queue_timeout,
+    )
+    .await
+    {
+        Admission::Admitted(permit) => permit,
+        Admission::Shed | Admission::TimedOut => return busy_response(),
     };
     let (outcome_tx, outcome_rx) = oneshot::channel::<Outcome>();
     let (body_tx, body_rx) = mpsc::channel::<axum::body::Bytes>(sink::BODY_CHANNEL_CAP);
@@ -1871,6 +1988,74 @@ mod tests {
         let resp = busy_response();
         assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(resp.headers().get(header::RETRY_AFTER).unwrap(), "1");
+    }
+
+    /// A current-thread runtime with the timer driver, so `acquire_or_shed`'s
+    /// `tokio::time::timeout` works without the `#[tokio::test]` macro.
+    fn timed_rt() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn acquire_or_shed_admits_when_permit_free() {
+        timed_rt().block_on(async {
+            let pool = Arc::new(tokio::sync::Semaphore::new(2));
+            let admission = acquire_or_shed(Arc::clone(&pool), 4, Duration::from_secs(5)).await;
+            assert!(matches!(admission, Admission::Admitted(_)));
+        });
+    }
+
+    #[test]
+    fn acquire_or_shed_sheds_immediately_when_queue_disabled() {
+        timed_rt().block_on(async {
+            let pool = Arc::new(tokio::sync::Semaphore::new(1));
+            // Exhaust the pool and hold the permit for the whole test.
+            let _held = Arc::clone(&pool).try_acquire_owned().unwrap();
+            // max_waiting == 0 → no queue → shed without waiting.
+            let admission = acquire_or_shed(Arc::clone(&pool), 0, Duration::from_secs(5)).await;
+            assert!(matches!(admission, Admission::Shed));
+        });
+    }
+
+    #[test]
+    fn acquire_or_shed_times_out_when_pool_stays_full() {
+        timed_rt().block_on(async {
+            let pool = Arc::new(tokio::sync::Semaphore::new(1));
+            let _held = Arc::clone(&pool).try_acquire_owned().unwrap();
+            // A generous queue depth so a concurrent test's waiters cannot push us
+            // over max_waiting; the held permit never frees, so we must time out.
+            let admission =
+                acquire_or_shed(Arc::clone(&pool), 1000, Duration::from_millis(50)).await;
+            assert!(matches!(admission, Admission::TimedOut));
+        });
+    }
+
+    #[test]
+    fn acquire_or_shed_sheds_when_wait_queue_full() {
+        timed_rt().block_on(async {
+            let pool = Arc::new(tokio::sync::Semaphore::new(1));
+            let _held = Arc::clone(&pool).try_acquire_owned().unwrap(); // pool empty
+                                                                        // Park one waiter to fill the single queue slot (the permit never
+                                                                        // frees, so it stays parked holding its WaitGuard).
+            let bg = Arc::clone(&pool);
+            tokio::spawn(async move {
+                let _ = acquire_or_shed(bg, 1, Duration::from_secs(60)).await;
+            });
+            // Let the spawned task reach its park point (WaitGuard incremented).
+            for _ in 0..1000 {
+                if waiting() >= 1 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+            assert!(waiting() >= 1, "background waiter did not park");
+            // Queue full (waiters ≥ max_waiting) → the next request sheds at once.
+            let admission = acquire_or_shed(Arc::clone(&pool), 1, Duration::from_millis(50)).await;
+            assert!(matches!(admission, Admission::Shed));
+        });
     }
 
     #[test]

--- a/test/e2e/src/lib.rs
+++ b/test/e2e/src/lib.rs
@@ -468,9 +468,26 @@ impl SipiServer {
 
     /// Start with the default test config.
     /// Sipi auto-creates the cache directory if missing.
+    ///
+    /// Sizes the engine-pool knobs so the concurrency tests (10 parallel requests)
+    /// are served rather than shed, even under the ASan build's much slower image
+    /// decodes: enough workers to drain the burst (`SIPI_NTHREADS`), a deep queue
+    /// (`SIPI_MAX_WAITING`), and a wait long enough that a queued request is not
+    /// shed before a worker frees (`SIPI_QUEUE_TIMEOUT`, well above the drain time
+    /// and above the 30s client timeout that is the real hang guard). Also
+    /// exercises the concurrency env wiring end-to-end.
     pub fn start_default() -> Self {
         let test_data = test_data_dir();
-        Self::start("config/sipi.e2e-test-config.lua", &test_data)
+        Self::start_env(
+            "config/sipi.e2e-test-config.lua",
+            &test_data,
+            &[],
+            &[
+                ("SIPI_NTHREADS", "8"),
+                ("SIPI_MAX_WAITING", "256"),
+                ("SIPI_QUEUE_TIMEOUT", "60"),
+            ],
+        )
     }
 
     /// Get the OS PID of the server process.

--- a/test/e2e/tests/server.rs
+++ b/test/e2e/tests/server.rs
@@ -308,9 +308,10 @@ fn lua_read_write() {
 }
 
 #[test]
-#[ignore = "engine-pool semaphore sheds load → 503 under concurrent bursts — an intentional divergence from the C++ oracle; revisit permit-release in future concurrency work (DEV-6659)"]
 fn concurrent_requests() {
-    // Python: test_concurrency — verify sipi handles parallel image requests
+    // Python: test_concurrency — verify sipi handles parallel image requests.
+    // The bounded wait queue (default server sets a generous SIPI_MAX_WAITING)
+    // now serves the burst instead of shedding it (was DEV-6659).
     let srv = server();
     let base_url = srv.base_url.clone();
 
@@ -1010,8 +1011,9 @@ fn thumbnail_convert_from_file() {
 }
 
 #[test]
-#[ignore = "engine-pool semaphore sheds load → 503 under concurrent bursts — an intentional divergence from the C++ oracle; revisit permit-release in future concurrency work (DEV-6659)"]
 fn lua_state_thread_isolation() {
+    // The bounded wait queue (default server sets a generous SIPI_MAX_WAITING)
+    // now serves the parallel burst instead of shedding it (was DEV-6659).
     let srv = server();
     let base_url = srv.base_url.clone();
 

--- a/test/e2e/tests/snapshots/cli__sipi-server-help.snap
+++ b/test/e2e/tests/snapshots/cli__sipi-server-help.snap
@@ -15,9 +15,9 @@ Network:
       --keepalive <SECS>   HTTP/1.1 keep-alive timeout in seconds (parse-only: tokio is async, so the knob is unread) [env: SIPI_KEEPALIVE=]
 
 Concurrency:
-  -t, --nthreads <N>          Worker thread count (0 = auto-detect from CPU cores; parse-only — sizes the engine-work semaphore only from the Lua/TOML config, not the CLI). Also accepts the C++ oracle's `-t` short form [env: SIPI_NTHREADS=]
-      --max-waiting <N>       Max waiting connections before 503 (parse-only: semaphore model) [env: SIPI_MAX_WAITING=]
-      --queue-timeout <SECS>  Max seconds a request waits in queue before 503 (parse-only) [env: SIPI_QUEUE_TIMEOUT=]
+  -t, --nthreads <N>          Worker thread count that sizes the engine-work pool (0 = auto-detect from CPU cores). Also accepts the `-t` short form [env: SIPI_NTHREADS=]
+      --max-waiting <N>       Max requests queued for a worker before 503 (0 = no queue, shed immediately; default 2×nthreads) [env: SIPI_MAX_WAITING=]
+      --queue-timeout <SECS>  Max seconds a queued request waits for a worker before 503 (default 5) [env: SIPI_QUEUE_TIMEOUT=]
 
 Limits:
       --maxpost <SIZE>             Max POST body size, e.g. "300M" (engine parses the suffix) [env: SIPI_MAXPOSTSIZE=]


### PR DESCRIPTION
Part of DEV-6659

## Motivation
On dev-01 the IIIF viewer got HTTP 503 on ~half of its tile requests. The Rust shell bounds concurrent engine work with a semaphore sized to the worker count and acquired it non-blocking (`try_acquire_owned`), so any request that could not grab a permit immediately was shed with `503 + Retry-After`. A viewer opens an image and fires 10–40 parallel tile GETs; with only N workers and no queue, everything past the N in-flight was shed. dev-01 ran `nthreads=2`, so ~50% of a burst 503'd. The retained C++ server queued excess connections; the shell did not.

## Summary
- The engine pool now has a **bounded wait queue** in front of it: a request waits up to `queue_timeout` for a permit and only sheds (503) when the queue is full or the wait elapses.
- The three pool knobs are configured **from CLI/env, not the Lua config**: `SIPI_NTHREADS` (pool size, 0/unset = auto-detect), `SIPI_MAX_WAITING` (queue depth, default 2×nthreads, 0 = shed immediately), `SIPI_QUEUE_TIMEOUT` (per-request wait, default 5s).
- Two OTLP metrics added: `sipi.pool.waiting` (live queue depth) and `sipi.pool.queue_timeout` (timed-out sheds).

## Key Changes
### Bounded-wait admission (`server-rs/routes.rs`)
- New `acquire_or_shed` helper returns `Admitted` / `Shed` / `TimedOut`: fast-path `try_acquire_owned`, else park up to `queue_timeout` when the queue (`WAITING < max_waiting`) has room, tracked by a RAII `WaitGuard`. Both engine-dispatch sites use it.

### Config sourcing (`cli-rs`, `server-rs/lib.rs`)
- `--nthreads`/`--max-waiting`/`--queue-timeout` are threaded as direct `sipi::run` serve knobs (like `--drain-timeout`), not layered onto the engine config. The pool no longer reads `ffi::nthreads()`; the `sipi_nthreads` FFI binding is dropped Rust-side.

### Observability (`server-rs/metrics.rs`)
- `sipi.pool.waiting` gauge + `sipi.pool.queue_timeout` counter, alongside the existing `load_shed` (which now counts every backpressure shed).

### Docs (separate commit)
- CLAUDE.md / CONVENTIONS.md / REVIEW.md: the C++ server is oracle-only, the Rust shell is production; production Rust comments describe current behaviour on their own terms.

## Gotchas
- `SIPI_MAX_WAITING=0` disables queuing (the old instant-shed behaviour).
- The e2e default server sets a generous `SIPI_MAX_WAITING` so the (now un-ignored) `concurrent_requests` / `lua_state_thread_isolation` tests are deterministic on low-core runners.
- OTLP metrics only reach Grafana once the deployment sets `OTEL_EXPORTER_OTLP_ENDPOINT` (ops-deploy PR #1381).

## Test Plan
- [x] `just bazel-build-server`, `bazel-rustfmt-check`, `bazel-clippy-check`
- [x] server-rs + cli-rs unit tests (incl. new `acquire_or_shed` cases)
- [x] `//test/e2e:cli` (help snapshot) + `//test/e2e:server` (un-ignored concurrency tests run & pass)
- [x] full e2e suite (26/26) + differential parity gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)