### PR TITLE
feat(server-rs,ffi): trace engine serve phases as child spans

### DIFF
--- a/src/ffi/BUILD.bazel
+++ b/src/ffi/BUILD.bazel
@@ -15,8 +15,8 @@ within the package use the bare quote form (`#include "sipi_ffi.h"`).
 
 The target hosts the C++ side of the seam; its `srcs` grow as the engine is
 carved behind the FFI (today: `sipi_serve_file` / `sipi_serve_image` /
-`sipi_metrics_snapshot` and the Lua preflight `sipi_preflight` /
-`sipi_file_preflight`).
+`sipi_serve_timings_take` / `sipi_phase_count` / `sipi_metrics_snapshot` and the
+Lua preflight `sipi_preflight` / `sipi_file_preflight`).
 """
 
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
@@ -44,6 +44,7 @@ cc_library(
         "run_lua_route.cpp",
         "serve_image.cpp",
         "serve_response.cpp",
+        "serve_timings.cpp",
         "sipi_ffi.cpp",
     ],
     hdrs = [
@@ -56,6 +57,7 @@ cc_library(
         "run_lua_route.h",
         "serve_image.h",
         "serve_response.h",
+        "serve_timings.h",
         "sipi_ffi.h",
     ],
     strip_include_prefix = "/src",
@@ -128,6 +130,18 @@ cc_test(
     deps = [
         ":sipi_ffi",
         "//test:test_paths",
+        "@googletest//:gtest_main",
+    ],
+)
+
+# Co-located unit test for the per-phase serve-timing accumulator: exercises
+# serve_timings_reset/export + the RAII PhaseTimer directly (present/failed flags,
+# overwrite-on-retime, reset clearing, out-of-range no-op), without a transport.
+cc_test(
+    name = "serve_timings_test",
+    srcs = ["serve_timings_test.cpp"],
+    deps = [
+        ":sipi_ffi",
         "@googletest//:gtest_main",
     ],
 )

--- a/src/ffi/serve_image.cpp
+++ b/src/ffi/serve_image.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "ffi/serve_image.h"
+#include "ffi/serve_timings.h"// PhaseTimer (per-phase serve timings for the shell's child spans)
 
 #include <sys/stat.h>
 #include <unistd.h>
@@ -287,6 +288,9 @@ namespace {
                                : OutputSink{ socket };
 
       try {
+        // Spans the encode AND the streamed write to the sink, so a slow client's
+        // back-pressure counts toward this phase's duration (see SipiServeTimings).
+        PhaseTimer phase_timer(SIPI_PHASE_ENCODE);
         switch (format_) {
         case SipiQualityFormat::JPG: {
           SipiCompressionParams qp = { { JPEG_QUALITY, std::to_string(jpeg_quality_) } };
@@ -469,6 +473,7 @@ std::expected<ServeResponse, SipiStatus>
   SipiImgInfo info;
   try {
     SipiImage probe;
+    PhaseTimer phase_timer(SIPI_PHASE_SHAPE);
     info = probe.read_shape(infile);
   } catch (SipiImageError &err) {
     ImageContext sentry_ctx;
@@ -669,6 +674,7 @@ std::expected<ServeResponse, SipiStatus>
 
   SipiImage img;
   try {
+    PhaseTimer phase_timer(SIPI_PHASE_DECODE);
     img.read(infile, region, size, quality_format.format() == SipiQualityFormat::JPG, eng.scaling_quality);
   } catch (const std::bad_alloc &) {
     Metrics::instance().memory_alloc_failures_total.Increment();
@@ -694,6 +700,7 @@ std::expected<ServeResponse, SipiStatus>
       return std::unexpected(SipiStatus::ClientGone);
     }
     try {
+      PhaseTimer phase_timer(SIPI_PHASE_ROTATE);
       img.rotate(angle, mirror);
     } catch (const std::bad_alloc &) {
       Metrics::instance().memory_alloc_failures_total.Increment();
@@ -713,6 +720,7 @@ std::expected<ServeResponse, SipiStatus>
       Metrics::instance().client_disconnected_total.Increment();
       return std::unexpected(SipiStatus::ClientGone);
     }
+    PhaseTimer phase_timer(SIPI_PHASE_QUALITY);
     switch (quality_format.quality()) {
     case SipiQualityFormat::COLOR:
       img.convertToIcc(Icc(icc_sRGB), 8);
@@ -734,6 +742,7 @@ std::expected<ServeResponse, SipiStatus>
       return std::unexpected(SipiStatus::ClientGone);
     }
     try {
+      PhaseTimer phase_timer(SIPI_PHASE_WATERMARK);
       img.add_watermark(watermark);
     } catch (Sipi::SipiError &err) {
       ImageContext sentry_ctx;

--- a/src/ffi/serve_timings.cpp
+++ b/src/ffi/serve_timings.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2016 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+ * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "ffi/serve_timings.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+
+// Pin the `SipiServeTimings` layout the Rust shell mirrors by hand
+// (`server-rs/src/ffi.rs`), held in lock-step with the Rust `offset_of!`/
+// `size_of` test there. The literal `sizeof` (not one derived from
+// SIPI_PHASE_COUNT) is deliberate: it fails to compile if the phase count is
+// bumped here without the Rust mirror, catching a one-sided drift the offset
+// asserts (self-consistent against either side's own count) cannot. The Rust
+// test pairs a `sipi_phase_count()` check for the same reason.
+static_assert(offsetof(SipiServeTimings, start_ns) == 0, "SipiServeTimings.start_ns offset");
+static_assert(offsetof(SipiServeTimings, dur_ns) == SIPI_PHASE_COUNT * sizeof(uint64_t),
+  "SipiServeTimings.dur_ns offset");
+static_assert(offsetof(SipiServeTimings, present) == 2 * SIPI_PHASE_COUNT * sizeof(uint64_t),
+  "SipiServeTimings.present offset");
+static_assert(offsetof(SipiServeTimings, failed) == 2 * SIPI_PHASE_COUNT * sizeof(uint64_t) + SIPI_PHASE_COUNT,
+  "SipiServeTimings.failed offset");
+static_assert(sizeof(SipiServeTimings) == 112, "SipiServeTimings size drifted from src/server-rs/src/ffi.rs");
+
+namespace Sipi::ffi {
+
+namespace {
+
+//! One worker thread's phase accumulator (see `serve_timings.h`). `t0` is the
+//! offset origin stamped by `serve_timings_reset`; each phase records its start
+//! offset + duration relative to it.
+struct Accumulator
+{
+  std::chrono::steady_clock::time_point t0;
+  std::array<std::uint64_t, SIPI_PHASE_COUNT> start_ns{};
+  std::array<std::uint64_t, SIPI_PHASE_COUNT> dur_ns{};
+  std::array<std::uint8_t, SIPI_PHASE_COUNT> present{};
+  std::array<std::uint8_t, SIPI_PHASE_COUNT> failed{};
+};
+
+thread_local Accumulator g_accum;
+
+//! Clamp a possibly-negative tick count to a non-negative nanosecond value.
+std::uint64_t clamp_ns(std::chrono::steady_clock::duration d)
+{
+  const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(d).count();
+  return ns < 0 ? 0 : static_cast<std::uint64_t>(ns);
+}
+
+}// namespace
+
+void serve_timings_reset()
+{
+  g_accum.t0 = std::chrono::steady_clock::now();
+  g_accum.start_ns.fill(0);
+  g_accum.dur_ns.fill(0);
+  g_accum.present.fill(0);
+  g_accum.failed.fill(0);
+}
+
+void serve_timings_export(SipiServeTimings *out)
+{
+  if (out == nullptr) { return; }
+  for (int i = 0; i < SIPI_PHASE_COUNT; ++i) {
+    out->start_ns[i] = g_accum.start_ns[static_cast<std::size_t>(i)];
+    out->dur_ns[i] = g_accum.dur_ns[static_cast<std::size_t>(i)];
+    out->present[i] = g_accum.present[static_cast<std::size_t>(i)];
+    out->failed[i] = g_accum.failed[static_cast<std::size_t>(i)];
+  }
+}
+
+PhaseTimer::PhaseTimer(SipiPhase phase)
+  : phase_(phase), uncaught_on_entry_(std::uncaught_exceptions()), start_(std::chrono::steady_clock::now())
+{
+}
+
+PhaseTimer::~PhaseTimer()
+{
+  if (phase_ < 0 || phase_ >= SIPI_PHASE_COUNT) { return; }
+  const auto end = std::chrono::steady_clock::now();
+  const auto idx = static_cast<std::size_t>(phase_);
+  g_accum.start_ns[idx] = clamp_ns(start_ - g_accum.t0);
+  g_accum.dur_ns[idx] = clamp_ns(end - start_);
+  g_accum.present[idx] = 1;
+  // More exceptions in flight than at construction → this scope is unwinding
+  // because the phase's work threw. Mark it so the shell flags the span errored.
+  g_accum.failed[idx] = std::uncaught_exceptions() > uncaught_on_entry_ ? 1 : 0;
+}
+
+}// namespace Sipi::ffi

--- a/src/ffi/serve_timings.h
+++ b/src/ffi/serve_timings.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2016 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+ * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/*!
+ * Per-phase timing capture for one `sipi_serve_image` call (strangler-fig; ADR-0013).
+ *
+ * The engine emits no OpenTelemetry spans of its own — only the Rust shell runs
+ * an OTel tracer + exporter. To break the opaque `sipi.serve` span into
+ * read/decode/rotate/quality/watermark/encode phases in the Tempo waterfall
+ * WITHOUT an in-engine SDK, the engine merely *times* each phase into a
+ * thread-local accumulator; the shell reads it back over the seam
+ * (`sipi_serve_timings_take`) and mints one child span per phase with explicit
+ * start/end timestamps.
+ *
+ * Thread-local because the seam is synchronous and single-threaded per call: the
+ * shell resets the accumulator implicitly at each `sipi_serve_image` entry, the
+ * phase timers run on that same worker thread (decode/convert in
+ * `build_image_response`, encode in the streamed producer's `produce`, all
+ * before the call returns), and the shell reads it on the same thread right
+ * after. The pattern mirrors the trace-context thread-locals in `logging/logger`.
+ */
+#ifndef SIPI_FFI_SERVE_TIMINGS_H
+#define SIPI_FFI_SERVE_TIMINGS_H
+
+#include <chrono>
+
+#include "ffi/sipi_ffi.h"
+
+namespace Sipi::ffi {
+
+/*! Clear the calling thread's accumulator and stamp the phase-offset origin.
+ *  Called at the top of `sipi_serve_image`, before any [`PhaseSpanTimer`]. */
+void serve_timings_reset();
+
+/*! Copy the calling thread's accumulator into `*out` (no-op on NULL). Backs the
+ *  `sipi_serve_timings_take` seam entry. */
+void serve_timings_export(SipiServeTimings *out);
+
+/*! RAII timer for one serve phase: records `[construction, destruction)` against
+ *  `phase` in the thread-local accumulator, as an offset from the last
+ *  [`serve_timings_reset`] plus a duration. If the scope exits via an exception,
+ *  the phase is also marked failed (detected in the destructor via
+ *  `std::uncaught_exceptions()`). Re-timing a phase overwrites it; an
+ *  out-of-range index is ignored. Times only — it mints no OTel span; the shell
+ *  does that from the exported timings. */
+class PhaseTimer
+{
+public:
+  explicit PhaseTimer(SipiPhase phase);
+  ~PhaseTimer();
+  PhaseTimer(const PhaseTimer &) = delete;
+  PhaseTimer &operator=(const PhaseTimer &) = delete;
+  PhaseTimer(PhaseTimer &&) = delete;
+  PhaseTimer &operator=(PhaseTimer &&) = delete;
+
+private:
+  SipiPhase phase_;
+  int uncaught_on_entry_;
+  std::chrono::steady_clock::time_point start_;
+};
+
+}// namespace Sipi::ffi
+
+#endif// SIPI_FFI_SERVE_TIMINGS_H

--- a/src/ffi/serve_timings_test.cpp
+++ b/src/ffi/serve_timings_test.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2016 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+ * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "ffi/serve_timings.h"
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+
+using Sipi::ffi::PhaseTimer;
+using Sipi::ffi::serve_timings_export;
+using Sipi::ffi::serve_timings_reset;
+
+namespace {
+
+SipiServeTimings take()
+{
+  SipiServeTimings out{};
+  serve_timings_export(&out);
+  return out;
+}
+
+// A reset accumulator exports as all-absent / all-zero.
+TEST(ServeTimings, ResetClearsEverything)
+{
+  {
+    PhaseTimer t(SIPI_PHASE_DECODE);
+  }
+  serve_timings_reset();
+  const SipiServeTimings out = take();
+  for (int i = 0; i < SIPI_PHASE_COUNT; ++i) {
+    EXPECT_EQ(out.present[i], 0) << "phase " << i;
+    EXPECT_EQ(out.failed[i], 0) << "phase " << i;
+    EXPECT_EQ(out.dur_ns[i], 0u) << "phase " << i;
+    EXPECT_EQ(out.start_ns[i], 0u) << "phase " << i;
+  }
+}
+
+// A timed phase marks only its own slot present, not failed.
+TEST(ServeTimings, SinglePhasePresent)
+{
+  serve_timings_reset();
+  {
+    PhaseTimer t(SIPI_PHASE_DECODE);
+  }
+  const SipiServeTimings out = take();
+  EXPECT_EQ(out.present[SIPI_PHASE_DECODE], 1);
+  EXPECT_EQ(out.failed[SIPI_PHASE_DECODE], 0);
+  for (int i = 0; i < SIPI_PHASE_COUNT; ++i) {
+    if (i == SIPI_PHASE_DECODE) { continue; }
+    EXPECT_EQ(out.present[i], 0) << "phase " << i;
+  }
+}
+
+// The phase set a resize request drives: shape + decode + encode present, the
+// transform phases (rotate/quality/watermark) absent.
+TEST(ServeTimings, MultiplePhasesPresent)
+{
+  serve_timings_reset();
+  {
+    PhaseTimer s(SIPI_PHASE_SHAPE);
+  }
+  {
+    PhaseTimer d(SIPI_PHASE_DECODE);
+  }
+  {
+    PhaseTimer e(SIPI_PHASE_ENCODE);
+  }
+  const SipiServeTimings out = take();
+  EXPECT_EQ(out.present[SIPI_PHASE_SHAPE], 1);
+  EXPECT_EQ(out.present[SIPI_PHASE_DECODE], 1);
+  EXPECT_EQ(out.present[SIPI_PHASE_ENCODE], 1);
+  EXPECT_EQ(out.present[SIPI_PHASE_ROTATE], 0);
+  EXPECT_EQ(out.present[SIPI_PHASE_QUALITY], 0);
+  EXPECT_EQ(out.present[SIPI_PHASE_WATERMARK], 0);
+}
+
+// A phase whose scope unwinds via an exception is marked failed but still present.
+TEST(ServeTimings, ExceptionMarksPhaseFailed)
+{
+  serve_timings_reset();
+  try {
+    PhaseTimer t(SIPI_PHASE_ENCODE);
+    throw std::runtime_error("boom");
+  } catch (const std::exception &) {
+    // swallowed — the timer's destructor already ran during unwind
+  }
+  const SipiServeTimings out = take();
+  EXPECT_EQ(out.present[SIPI_PHASE_ENCODE], 1);
+  EXPECT_EQ(out.failed[SIPI_PHASE_ENCODE], 1);
+}
+
+// Re-timing a phase overwrites the prior record (present stays set, failed clears
+// on a subsequent clean pass).
+TEST(ServeTimings, RetimeOverwrites)
+{
+  serve_timings_reset();
+  try {
+    PhaseTimer t(SIPI_PHASE_DECODE);
+    throw std::runtime_error("boom");
+  } catch (const std::exception &) {
+  }
+  ASSERT_EQ(take().failed[SIPI_PHASE_DECODE], 1);
+  {
+    PhaseTimer t(SIPI_PHASE_DECODE);
+  }
+  const SipiServeTimings out = take();
+  EXPECT_EQ(out.present[SIPI_PHASE_DECODE], 1);
+  EXPECT_EQ(out.failed[SIPI_PHASE_DECODE], 0);
+}
+
+// serve_timings_export tolerates a NULL out (the FFI take passes a real pointer,
+// but the contract is a documented no-op on NULL).
+TEST(ServeTimings, ExportNullIsNoop)
+{
+  serve_timings_reset();
+  serve_timings_export(nullptr);
+}
+
+}// namespace

--- a/src/ffi/sipi_ffi.cpp
+++ b/src/ffi/sipi_ffi.cpp
@@ -22,6 +22,7 @@
 #include "ffi/run_lua_route.h"
 #include "ffi/serve_image.h"
 #include "ffi/serve_response.h"
+#include "ffi/serve_timings.h"// serve_timings_reset/export (sipi_serve_timings_take)
 #include "logging/logger.h"// set_log_trace_context (sipi_set_log_trace_context)
 #include "observability/metrics.h"
 #include "shttps/lua/request_context.h"// shttps::RequestContext (the opaque SipiRequestContext)
@@ -108,6 +109,10 @@ int sipi_serve_image(const SipiServeRequest *req, const SipiResponse *resp)
   // no-throw guard. A return of 499 (SipiStatus::ClientGone) means the client
   // vanished mid-decode and nothing was emitted — the caller renders no error.
   return Sipi::ffi::sipi_guard([&] {
+    // Reset the per-phase timing accumulator for this thread; the phase timers in
+    // build_image_response + the streamed encode fill it, and the shell reads it
+    // back via sipi_serve_timings_take right after this returns.
+    Sipi::ffi::serve_timings_reset();
     const auto cancelled = [resp] { return resp->cancelled != nullptr && resp->cancelled(resp->ctx) != 0; };
     auto result = Sipi::ffi::build_image_response(*req, Sipi::ffi::engine_context(), cancelled);
     if (!result) { return static_cast<int>(result.error()); }
@@ -115,6 +120,10 @@ int sipi_serve_image(const SipiServeRequest *req, const SipiResponse *resp)
     return static_cast<int>(Sipi::ffi::SipiStatus::Ok);
   });
 }
+
+void sipi_serve_timings_take(SipiServeTimings *out) { Sipi::ffi::serve_timings_export(out); }
+
+int sipi_phase_count(void) { return SIPI_PHASE_COUNT; }
 
 int sipi_preflight(const char *prefix,
   const char *identifier,

--- a/src/ffi/sipi_ffi.h
+++ b/src/ffi/sipi_ffi.h
@@ -423,12 +423,57 @@ typedef void (*SipiRouteFn)(void *ctx, const char *method, const char *route, co
  *  known together or not at all. */
 typedef void (*SipiEssentialsFn)(void *ctx, const char *orig_mimetype, const char *orig_filename);
 
+/* ── Per-phase serve timings ─────────────────────────────────────────────────
+ * Nanosecond timings for the phases of one `sipi_serve_image` call, relative to
+ * the call's start. The engine accumulates them in a thread-local during the
+ * call; `sipi_serve_timings_take` reads that accumulator, so the caller must
+ * call it on the SAME thread immediately after `sipi_serve_image` returns. A
+ * `present[i]` of 0 means the phase did not run (a cache hit or passthrough
+ * skips decode/encode; a rotate-free request skips ROTATE, etc.); a `failed[i]`
+ * of 1 means the phase started but exited via a C++ exception (a decode/encode
+ * error), so the shell marks that span `Status=Error`. Purely observational: the
+ * Rust shell mints one child span per present phase under its request span — the
+ * engine emits no spans of its own.
+ *
+ * Caveat: SIPI_PHASE_ENCODE spans the streamed encode *and* the write to the
+ * response sink, so a slow/back-pressured HTTP client inflates its `dur_ns` with
+ * client-side wait, not just codec CPU. */
+typedef enum {
+  SIPI_PHASE_SHAPE = 0, /* header/shape probe (source open, no full decode) */
+  SIPI_PHASE_DECODE = 1, /* SipiImage::read — decode + region + scale */
+  SIPI_PHASE_ROTATE = 2, /* rotate / mirror */
+  SIPI_PHASE_QUALITY = 3, /* colour/gray ICC or bitonal conversion */
+  SIPI_PHASE_WATERMARK = 4, /* watermark overlay */
+  SIPI_PHASE_ENCODE = 5, /* encode + write (streamed tail) */
+  SIPI_PHASE_COUNT = 6 /* sentinel: number of phases, not a phase index */
+} SipiPhase;
+
+typedef struct
+{
+  uint64_t start_ns[SIPI_PHASE_COUNT]; /* offset from the serve call's start */
+  uint64_t dur_ns[SIPI_PHASE_COUNT];
+  uint8_t present[SIPI_PHASE_COUNT];
+  uint8_t failed[SIPI_PHASE_COUNT]; /* 1 = phase exited via an exception */
+} SipiServeTimings;
+
 /* ── Entry points ───────────────────────────────────────────────────────────
  * All return 0 on success / an error code on failure; none let a C++ exception
  * cross the boundary. */
 
 /*! IIIF decode→transform→encode→stream; honours the restrict size/watermark. */
 SIPI_FFI_NODISCARD int sipi_serve_image(const SipiServeRequest *req, const SipiResponse *resp);
+
+/*! Copy the current thread's per-phase serve timings (see `SipiServeTimings`)
+ *  into `*out`. Call on the SAME thread right after `sipi_serve_image` returns;
+ *  a NULL `out` is a no-op. Never fails and emits nothing; the accumulator is
+ *  reset at the next `sipi_serve_image` entry on the thread. */
+void sipi_serve_timings_take(SipiServeTimings *out);
+
+/*! The engine's serve-phase count (`SIPI_PHASE_COUNT`). The Rust shell mirrors
+ *  `SipiServeTimings` by hand, so it asserts its own `PHASE_COUNT` against this
+ *  at test time — a one-sided phase-count change then fails loudly instead of
+ *  writing past a stale-sized `SipiServeTimings`. */
+int sipi_phase_count(void);
 
 /*! Raw `/file` passthrough incl. HTTP Range / 206 — no decode. Owns the serve
  *  *policy* (stat, MIME → Content-Type, Range parse → status + Content-Range)

--- a/src/server-rs/src/ffi.rs
+++ b/src/server-rs/src/ffi.rs
@@ -273,6 +273,69 @@ pub struct SipiRequestContext {
     _private: [u8; 0],
 }
 
+/// Number of serve phases — matches the C `SIPI_PHASE_COUNT`. The
+/// `serve_timings_layout` test asserts this equals the engine's own
+/// `sipi_phase_count()` so a one-sided change fails loudly.
+pub const PHASE_COUNT: usize = 6;
+
+/// Serve phase, mirroring the C `SipiPhase` enum (`ffi/sipi_ffi.h`) index-for-
+/// index. Used to index [`PHASE_SPAN_NAMES`] and the `SipiServeTimings` arrays;
+/// the order is guarded against the span names by the `serve_timings_layout`
+/// test.
+#[repr(C)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum SipiPhase {
+    Shape = 0,
+    Decode = 1,
+    Rotate = 2,
+    Quality = 3,
+    Watermark = 4,
+    Encode = 5,
+}
+
+/// Low-cardinality child-span name per phase index, matching the [`SipiPhase`]
+/// order (shape, decode, rotate, quality, watermark, encode).
+pub const PHASE_SPAN_NAMES: [&str; PHASE_COUNT] = [
+    "sipi.engine.shape",
+    "sipi.engine.decode",
+    "sipi.engine.rotate",
+    "sipi.engine.quality",
+    "sipi.engine.watermark",
+    "sipi.engine.encode",
+];
+
+/// Per-phase engine timings for one `sipi_serve_image` call — the hand-mirrored
+/// layout of the C `SipiServeTimings` (`ffi/sipi_ffi.h`). `start_ns[i]`/`dur_ns[i]`
+/// are nanosecond offset-from-call-start + duration for phase `i`; `present[i]`
+/// is 0 when the phase did not run, and `failed[i]` is 1 when the phase exited
+/// via an exception (the shell then marks that span errored). Kept in lock-step
+/// with the C struct by the `serve_timings_layout` test below.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct SipiServeTimings {
+    pub start_ns: [u64; PHASE_COUNT],
+    pub dur_ns: [u64; PHASE_COUNT],
+    pub present: [u8; PHASE_COUNT],
+    pub failed: [u8; PHASE_COUNT],
+}
+
+/// Take the calling thread's per-phase serve timings. Call right after
+/// [`sipi_serve_image`] on the same thread; every `present` is 0 when the engine
+/// recorded nothing (e.g. a cache hit or HEAD, which skip decode/encode).
+#[must_use]
+pub fn serve_timings_take() -> SipiServeTimings {
+    let mut out = SipiServeTimings {
+        start_ns: [0; PHASE_COUNT],
+        dur_ns: [0; PHASE_COUNT],
+        present: [0; PHASE_COUNT],
+        failed: [0; PHASE_COUNT],
+    };
+    // SAFETY: `out` is a valid, fully-initialised SipiServeTimings; the FFI only
+    // writes its fields for the duration of the call and never retains the pointer.
+    unsafe { sipi_serve_timings_take(&mut out) };
+    out
+}
+
 extern "C" {
     /// IIIF decode→transform→encode→stream; honours the restrict size/watermark.
     /// Returns 0 when the response was emitted via the sink, or an HTTP status
@@ -280,6 +343,16 @@ extern "C" {
     /// response). The engine reads `engine_context()`, so `sipi_init` must have
     /// run first.
     pub fn sipi_serve_image(req: *const SipiServeRequest, resp: *const SipiResponse) -> c_int;
+
+    /// Copy the current thread's per-phase serve timings into `*out`. Call on the
+    /// same thread right after [`sipi_serve_image`] returns; a null `out` is a
+    /// no-op. Never fails, emits nothing.
+    pub fn sipi_serve_timings_take(out: *mut SipiServeTimings);
+
+    /// The engine's serve-phase count (`SIPI_PHASE_COUNT`), asserted equal to
+    /// [`PHASE_COUNT`] by the layout test so a one-sided phase-count change fails
+    /// loudly instead of overflowing the Rust-sized [`SipiServeTimings`].
+    pub fn sipi_phase_count() -> c_int;
 
     /// Raw `/file` passthrough incl. HTTP Range / 206 — no decode.
     /// `resolved_path` is an already-validated absolute path; `range` is the raw
@@ -1382,9 +1455,63 @@ pub fn has_file_preflight() -> Result<bool, i32> {
 }
 
 // Lock-step layout guard — paired with the C++ static_assert/offsetof block in
-// sipi_ffi.h. All fields are 8-byte-wide (pointers / u64), so there is no
-// packing subtlety, but the guard still catches an accidental field reorder
-// or insertion on either side. LP64 on every supported target.
+// src/ffi/serve_timings.cpp. The offset asserts catch a field reorder; the
+// `size_of` literal and the `sipi_phase_count()` cross-check catch a one-sided
+// phase-count change (which the self-consistent offset asserts on either side
+// would miss) before it overflows the Rust-sized struct. LP64 on every target.
+#[cfg(test)]
+mod serve_timings_layout {
+    use super::{sipi_phase_count, SipiServeTimings, PHASE_COUNT, PHASE_SPAN_NAMES};
+    use std::mem::{align_of, offset_of, size_of};
+
+    #[test]
+    fn repr_c_matches_sipi_ffi_h() {
+        assert_eq!(size_of::<usize>(), 8, "layout assumes an LP64 target");
+        assert_eq!(PHASE_COUNT, 6);
+        // Cross-check against the engine's own count, not just our literal, so a
+        // C-side SIPI_PHASE_COUNT bump without a Rust bump fails here.
+        // SAFETY: a pure `return SIPI_PHASE_COUNT` accessor; no state, never fails.
+        assert_eq!(PHASE_COUNT, unsafe { sipi_phase_count() } as usize);
+        assert_eq!(align_of::<SipiServeTimings>(), 8);
+        assert_eq!(size_of::<SipiServeTimings>(), 112);
+        assert_eq!(offset_of!(SipiServeTimings, start_ns), 0);
+        assert_eq!(offset_of!(SipiServeTimings, dur_ns), PHASE_COUNT * 8);
+        assert_eq!(offset_of!(SipiServeTimings, present), 2 * PHASE_COUNT * 8);
+        assert_eq!(
+            offset_of!(SipiServeTimings, failed),
+            2 * PHASE_COUNT * 8 + PHASE_COUNT
+        );
+    }
+
+    #[test]
+    fn span_names_match_phase_order() {
+        // Bind the span-name array to the SipiPhase order so a future enum reorder
+        // (which the offset/count asserts cannot see) can't silently mislabel spans.
+        use super::SipiPhase::*;
+        assert_eq!(PHASE_SPAN_NAMES.len(), PHASE_COUNT);
+        assert_eq!(PHASE_SPAN_NAMES[Shape as usize], "sipi.engine.shape");
+        assert_eq!(PHASE_SPAN_NAMES[Decode as usize], "sipi.engine.decode");
+        assert_eq!(PHASE_SPAN_NAMES[Rotate as usize], "sipi.engine.rotate");
+        assert_eq!(PHASE_SPAN_NAMES[Quality as usize], "sipi.engine.quality");
+        assert_eq!(
+            PHASE_SPAN_NAMES[Watermark as usize],
+            "sipi.engine.watermark"
+        );
+        assert_eq!(PHASE_SPAN_NAMES[Encode as usize], "sipi.engine.encode");
+    }
+
+    #[test]
+    fn take_without_a_serve_is_all_absent() {
+        // On a thread that has not run `sipi_serve_image`, the accumulator reads
+        // as all-zero / absent — validates the FFI symbol links and the struct
+        // marshals across the seam.
+        let t = super::serve_timings_take();
+        assert!(t.present.iter().all(|&p| p == 0));
+        assert!(t.dur_ns.iter().all(|&d| d == 0));
+        assert!(t.failed.iter().all(|&f| f == 0));
+    }
+}
+
 #[cfg(test)]
 mod image_error_layout {
     use super::SipiImageErrorReport;

--- a/src/server-rs/src/routes.rs
+++ b/src/server-rs/src/routes.rs
@@ -13,7 +13,7 @@ use std::ffi::CString;
 use std::io::Write;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use axum::body::{to_bytes, Body};
 use axum::extract::{DefaultBodyLimit, FromRequest, Multipart, OriginalUri, Request, State};
@@ -705,12 +705,58 @@ fn serve_image(
         report_ctx: c_uri.as_ptr() as *mut std::ffi::c_void,
     };
 
+    // Wall-clock anchor for the engine child spans: the per-phase offsets the
+    // engine records (monotonic) are added onto this. Captured just before the
+    // call, a hair earlier than the engine's own monotonic origin — an accepted,
+    // sub-microsecond skew (one struct build, no I/O, in between).
+    let engine_start = SystemTime::now();
     // SAFETY: every pointer in `req` outlives this synchronous call; the seam
     // guards C++ exceptions (→ status code, never an unwind into Rust). The
     // streamed head's CORS header is added by the caller (`iiif`).
     sink::serve_streaming(outcome_tx, body_tx, |resp: &SipiResponse| unsafe {
         ffi::sipi_serve_image(&req, resp)
     });
+    // Break the opaque engine span open: one child span per phase (decode,
+    // encode, …) under `sipi.serve`, from the timings the engine just recorded.
+    emit_engine_phase_spans(engine_start);
+}
+
+/// Mint an OTel child span under the current `sipi.serve` span for each engine
+/// phase the just-returned `sipi_serve_image` recorded, placing it on the trace
+/// timeline from the FFI-returned per-phase offsets (relative to `engine_start`).
+/// Runs on the same blocking thread as the FFI call, so `serve_timings_take`
+/// reads that call's accumulator and `Span::current()` is `sipi.serve`. Returns
+/// immediately when trace export is off (no throwaway spans on the hot path) or
+/// when the engine recorded nothing (cache hit / HEAD / passthrough). A phase
+/// that exited via an exception (`failed`) is marked `Status=Error`.
+fn emit_engine_phase_spans(engine_start: SystemTime) {
+    use opentelemetry::trace::{Span as _, Status, Tracer as _};
+    use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+    if !crate::telemetry::tracing_active() {
+        return;
+    }
+    let timings = ffi::serve_timings_take();
+    if !timings.present.iter().any(|&p| p != 0) {
+        return;
+    }
+    let parent_cx = tracing::Span::current().context();
+    let tracer = opentelemetry::global::tracer("sipi");
+    for i in 0..ffi::PHASE_COUNT {
+        if timings.present[i] == 0 {
+            continue;
+        }
+        let start = engine_start + Duration::from_nanos(timings.start_ns[i]);
+        let end = start + Duration::from_nanos(timings.dur_ns[i]);
+        let mut span = tracer
+            .span_builder(ffi::PHASE_SPAN_NAMES[i])
+            .with_start_time(start)
+            .start_with_context(&tracer, &parent_cx);
+        if timings.failed[i] != 0 {
+            span.set_status(Status::error("engine phase failed"));
+        }
+        span.end_with_timestamp(end);
+    }
 }
 
 /// Raw `/file` passthrough via `sipi_serve_file` (Range/206). The CORS echo and,

--- a/src/server-rs/src/telemetry.rs
+++ b/src/server-rs/src/telemetry.rs
@@ -18,7 +18,7 @@ use std::fmt::{self, Write as _};
 
 use opentelemetry::trace::{TraceContextExt, TracerProvider as _};
 use opentelemetry::KeyValue;
-use opentelemetry_sdk::trace::SdkTracerProvider;
+use opentelemetry_sdk::trace::{Sampler, SdkTracerProvider};
 use tracing::field::{Field, Visit};
 use tracing::{Event, Subscriber};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
@@ -28,6 +28,18 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
+
+/// Set once in [`init`] when a tracer provider was built (an OTLP endpoint is
+/// configured). Lets the hot serve path skip span minting entirely when tracing
+/// is off, rather than building throwaway no-op spans per request.
+static TRACING_ACTIVE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Whether trace export is active (an OTLP endpoint was configured at startup).
+/// The serve path checks this before minting engine-phase child spans.
+#[must_use]
+pub fn tracing_active() -> bool {
+    TRACING_ACTIVE.load(std::sync::atomic::Ordering::Relaxed)
+}
 
 /// Owns the trace, metric, and (in local dev) log providers so their exporters
 /// flush on shutdown. Each is `None` when not configured (fail-open).
@@ -74,6 +86,15 @@ pub fn init() -> Telemetry {
     let otel_layer = provider
         .as_ref()
         .map(|p| tracing_opentelemetry::layer().with_tracer(p.tracer("sipi")));
+    // Register the tracer provider globally too, so the engine-phase child spans
+    // that `routes.rs` mints directly via the OTel API (from the FFI-returned
+    // per-phase timings) go through this same batch exporter. When no endpoint is
+    // configured we leave the global default and flag tracing inactive, so the
+    // serve path skips span minting rather than building throwaway no-op spans.
+    if let Some(p) = provider.as_ref() {
+        global::set_tracer_provider(p.clone());
+        TRACING_ACTIVE.store(true, std::sync::atomic::Ordering::Relaxed);
+    }
 
     // The metric meter provider (same fail-open endpoint gate). Set it as the
     // global provider so `crate::metrics::register` (called later, once the
@@ -176,10 +197,25 @@ fn build_tracer_provider() -> Option<SdkTracerProvider> {
     let resource = otel_resource();
     Some(
         SdkTracerProvider::builder()
+            .with_sampler(build_sampler())
             .with_batch_exporter(exporter)
             .with_resource(resource)
             .build(),
     )
+}
+
+/// `ParentBased(TraceIdRatioBased(ratio))` head sampler. `ratio` comes from the
+/// standard `OTEL_TRACES_SAMPLER_ARG` (clamped to `0.0..=1.0`), defaulting to
+/// `1.0` — sample everything, the prior behaviour. Parent-based so a sampled
+/// caller's trace is always continued; the ratio only governs root spans SIPI
+/// starts itself. Since one serve emits up to `PHASE_COUNT + 1` spans, dropping
+/// the ratio below 1.0 bounds trace-backend ingestion under load.
+fn build_sampler() -> Sampler {
+    let ratio = std::env::var("OTEL_TRACES_SAMPLER_ARG")
+        .ok()
+        .and_then(|s| s.trim().parse::<f64>().ok())
+        .map_or(1.0, |r| r.clamp(0.0, 1.0));
+    Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(ratio)))
 }
 
 /// Build the OTLP (gRPC-tonic) meter provider, or `None` when no endpoint is

--- a/test/e2e/tests/tracing.rs
+++ b/test/e2e/tests/tracing.rs
@@ -159,3 +159,46 @@ routes = {{}}
         "outbound dsp-api call must be in SIPI's trace (outbound={outbound}, response={resp_tp})"
     );
 }
+
+/// The engine-phase child spans (`sipi.engine.decode`/`.encode`/…) are minted on
+/// the hot serve path from the FFI-returned timings when tracing is active. This
+/// guards that the minting path runs without breaking image serving: with the
+/// OTLP exporter enabled (so the global tracer is live and `emit_engine_phase_spans`
+/// builds real spans), a decoding request still returns a correct image. The
+/// spans themselves are verified by observation in Grafana (no in-repo OTLP
+/// collector); this is the regression guard on the request path.
+#[test]
+fn engine_phase_spans_do_not_break_serving() {
+    let test_data = test_data_dir();
+    // OTLP enabled (dead endpoint): the tracer provider is installed, so the
+    // per-phase spans are actually built (and their export is fail-open/dropped).
+    let srv = SipiServer::start_env(
+        "config/sipi.e2e-test-config.lua",
+        &test_data,
+        &[],
+        &[("OTEL_EXPORTER_OTLP_ENDPOINT", "http://127.0.0.1:1")],
+    );
+    let client = http_client();
+
+    // A resize forces the decode → encode path (not a passthrough), so the
+    // DECODE and ENCODE phase timers fire and their spans are minted.
+    let resp = client
+        .get(format!(
+            "{}/unit/lena512.jp2/full/256,/0/default.jpg",
+            srv.base_url
+        ))
+        .send()
+        .expect("request to sipi");
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "decode request must still succeed"
+    );
+    let body = resp.bytes().expect("read image body");
+    assert!(!body.is_empty(), "served image must be non-empty");
+    assert_eq!(
+        &body[..2],
+        &[0xFF, 0xD8],
+        "JPEG SOI marker (valid decode+encode)"
+    );
+}

--- a/tools/differential_coverage_check.sh
+++ b/tools/differential_coverage_check.sh
@@ -20,7 +20,7 @@ cd "$(dirname "$0")/.."
 # Baseline: #[test] + #[tokio::test] across test/e2e/tests/*.rs EXCLUDING the
 # differential corpus file itself. Bump this (with a corpus update) whenever an
 # e2e test is added or removed.
-EXPECTED_E2E_TESTS=274
+EXPECTED_E2E_TESTS=275
 
 # Count via awk on a concatenated stream with literal `[ \t]` + exact string
 # compare — deterministic across awk/grep implementations. (Earlier a


### PR DESCRIPTION
## Motivation
The C++ engine served as one opaque `sipi.serve` span, so the source read, decode, and encode of a slow image request were an untraced black box — the time could not be attributed from the trace. This fell out of a performance investigation where cold JP2 decodes showed up as an untraced ~250ms+ region inside `sipi.serve`.

## Summary
- The engine times each serve phase (shape, decode, rotate, quality, watermark, encode); the Rust shell mints one real OTel child span per phase under `sipi.serve`, visible in the Tempo waterfall.
- No new dependency, no engine-side OTel SDK.

## Key Changes
### Engine timing (`src/ffi/serve_timings.{h,cpp}` new; `serve_image.cpp`)
- Thread-local accumulator + RAII `PhaseSpanTimer` at each phase boundary in `build_image_response` and the streamed encode — all within the single `sipi_serve_image` call.
### Seam (`sipi_ffi.h/.cpp`)
- `sipi_serve_timings_take` copies the per-phase timings out on the same thread after the serve call; the C `SipiServeTimings` ABI is pinned to the Rust mirror by paired `static_assert` / `offset_of` tests.
### Shell (`server-rs`: `ffi.rs`, `telemetry.rs`, `routes.rs`)
- The tracer provider is registered globally; `emit_engine_phase_spans` builds child spans with explicit start/end timestamps under the current `sipi.serve` context, through the exporter the shell already runs.

## Challenges and Decisions
### opentelemetry-cpp is unusable via BCR here
**Problem:** the obvious approach — add the C++ OTel SDK — cannot be consumed from BCR in this module graph.
**Tried:** `opentelemetry-cpp` 1.27.0 as-is; then pinning `googleapis` + configuring its `switched_rules` extension; then forcing `grpc` to 1.63.1. Each hit a different transitive break — `grpc 1.80.0 → envoy_api` imports a legacy `com_google_googleapis_imports` that only resolves via a patch grpc applies through a `single_version_override` Bazel ignores from a non-root module; forcing grpc older surfaces `grpc-java` referencing `@com_google_protobuf_javalite`, absent in our `protobuf 34.1`.
**Solution:** the engine emits no spans — it only *times* phases and returns them over the FFI, and the Rust shell (which already runs a tracer + OTLP exporter) mints the spans. No grpc, no vendoring.

## Gotchas
- Child spans are minted only when tracing is enabled (the global tracer is a noop otherwise); with no OTLP endpoint the timers cost a couple of monotonic clock reads per phase.
- Encode runs after `build_image_response` returns but still inside `sipi_serve_image` (in the streamed producer), so its timer is recorded before the shell reads the accumulator.

## Test Plan
- [x] unit (ABI layout + FFI-take plumbing); `//test/e2e:tracing` (minting path doesn't break a real decode)
- [x] differential parity vs the C++ oracle, `just bazel-coverage`
- [ ] On dev with OTLP enabled: a cold JP2 `/full/` request shows `sipi.engine.{shape,decode,rotate,quality,watermark,encode}` nested under `sipi.serve`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
