### PR TITLE
fix(metadata): give Exif and Icc correct ownership semantics

### DIFF
--- a/src/SipiImage.cpp
+++ b/src/SipiImage.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include <cassert>
@@ -512,12 +513,13 @@ void SipiImage::convertToIcc(const Icc &target_icc_p, int new_bps)
     throw SipiImageError("Unsupported bits/sample (" + std::to_string(bps) + ")");
   }
 
-  cmsHTRANSFORM hTransform;
   in_formatter = icc->iccFormatter(bps, nc, photo);
   out_formatter = target_icc_p.iccFormatter(new_bps);
 
-  hTransform = cmsCreateTransform(
-    icc->getIccProfile(), in_formatter, target_icc_p.getIccProfile(), out_formatter, INTENT_PERCEPTUAL, 0);
+  std::unique_ptr<std::remove_pointer_t<cmsHTRANSFORM>, decltype(&cmsDeleteTransform)> hTransform(
+    cmsCreateTransform(
+      icc->getIccProfile(), in_formatter, target_icc_p.getIccProfile(), out_formatter, INTENT_PERCEPTUAL, 0),
+    &cmsDeleteTransform);
 
   if (hTransform == nullptr) {
     throw SipiImageError("Failed to create color transform"
@@ -529,13 +531,11 @@ void SipiImage::convertToIcc(const Icc &target_icc_p, int new_bps)
       + ", target_profile_type=" + std::to_string(static_cast<int>(target_icc_p.getProfileType())));
   }
 
-  byte *inbuf = pixels;
-  byte *outbuf = new byte[nx * ny * nnc * new_bps / 8];
-  cmsDoTransform(hTransform, inbuf, outbuf, nx * ny);
-  cmsDeleteTransform(hTransform);
+  auto outbuf = std::make_unique<byte[]>(nx * ny * nnc * new_bps / 8);
+  cmsDoTransform(hTransform.get(), pixels, outbuf.get(), nx * ny);
   icc = std::make_shared<Icc>(target_icc_p);
-  pixels = outbuf;
-  delete[] inbuf;
+  delete[] pixels;
+  pixels = outbuf.release();
   nc = nnc;
   bps = new_bps;
 

--- a/src/metadata/exif.cpp
+++ b/src/metadata/exif.cpp
@@ -15,8 +15,6 @@ namespace Sipi {
 
 Exif::Exif()
 {
-  binaryExif = nullptr;
-  binary_size = 0;
   byteorder = Exiv2::littleEndian;// that's today's default....
 };
 //============================================================================
@@ -24,29 +22,17 @@ Exif::Exif()
 
 Exif::Exif(const unsigned char *exif, unsigned int len)
 {
-  //
-  // first we save the binary exif... we use it later for constructing a binary exif again!
-  //
-  // Hold the buffer in a unique_ptr until decode succeeds. If
-  // Exiv2::ExifParser::decode throws (e.g. on malformed EXIF embedded
-  // in PNG text comments), the unique_ptr cleans up on stack unwind.
-  // Releasing into the raw member only after decode succeeds keeps
-  // the destructor's `delete[]` honest.
-  auto buf = std::make_unique<unsigned char[]>(len);
-  std::memcpy(buf.get(), exif, len);
-
   try {
     byteorder = Exiv2::ExifParser::decode(exifData, exif, (uint32_t)len);
   } catch (Exiv2::Error &exiverr) {
     throw SipiError(exiverr.what());
   }
 
-  binaryExif = buf.release();
-  binary_size = len;
+  //
+  // we save the binary exif... we use it later for constructing a binary exif again!
+  //
+  binaryExif.assign(exif, exif + len);
 }
-//============================================================================
-
-Exif::~Exif() { delete[] binaryExif; }
 //============================================================================
 
 // Type-dispatched assignment helpers backing the inline `getValByKey<T>`
@@ -176,16 +162,13 @@ bool Exif::assign_val(Exiv2::Value::UniquePtr &v, std::vector<Exiv2::Rational> &
 std::vector<unsigned char> Exif::exifBytes()
 {
   Exiv2::Blob blob;
-  Exiv2::WriteMethod wm = Exiv2::ExifParser::encode(blob, binaryExif, binary_size, byteorder, exifData);
+  Exiv2::WriteMethod wm =
+    Exiv2::ExifParser::encode(blob, binaryExif.data(), static_cast<uint32_t>(binaryExif.size()), byteorder, exifData);
   if (wm == Exiv2::wmIntrusive) {
     // Refresh the cached binary blob so subsequent reads see the encoded form.
-    binary_size = blob.size();
-    unsigned char *tmpbuf = new unsigned char[binary_size];
-    if (binary_size > 0) memcpy(tmpbuf, blob.data(), binary_size);
-    delete[] binaryExif;
-    binaryExif = tmpbuf;
+    binaryExif.assign(blob.begin(), blob.end());
   }
-  return std::vector<unsigned char>(binaryExif, binaryExif + binary_size);
+  return binaryExif;
 }
 //============================================================================
 

--- a/src/metadata/exif.h
+++ b/src/metadata/exif.h
@@ -38,8 +38,7 @@ namespace Sipi {
 class Exif
 {
 private:
-  unsigned char *binaryExif;
-  unsigned int binary_size;
+  std::vector<unsigned char> binaryExif;//!< Cached binary EXIF blob (kept for re-encoding)
   Exiv2::ExifData exifData;//!< Private member variable holding the exiv2 EXIF data
   Exiv2::ByteOrder byteorder;//!< Private member holding the byteorder of the EXIF data
 
@@ -81,9 +80,6 @@ public:
    * \Param[in] len Length of the EXIF buffer
    */
   Exif(const unsigned char *exif, unsigned int len);
-
-
-  ~Exif();
 
   /*!
    * Returns the bytes of the EXIF data as a vector.

--- a/src/metadata/icc.cpp
+++ b/src/metadata/icc.cpp
@@ -61,12 +61,12 @@ void icc_error_logger(cmsContext ContextID, cmsUInt32Number ErrorCode, const cha
 Icc::Icc(const unsigned char *icc_buf, int icc_len)
 {
   cmsSetLogErrorHandler(icc_error_logger);
-  if ((icc_profile = cmsOpenProfileFromMem(icc_buf, icc_len)) == nullptr) {
-    throw SipiError("cmsOpenProfileFromMem failed");
-  }
-  unsigned int len = cmsGetProfileInfoASCII(icc_profile, cmsInfoDescription, cmsNoLanguage, cmsNoCountry, nullptr, 0);
+  icc_profile.reset(cmsOpenProfileFromMem(icc_buf, icc_len));
+  if (icc_profile == nullptr) { throw SipiError("cmsOpenProfileFromMem failed"); }
+  unsigned int len =
+    cmsGetProfileInfoASCII(icc_profile.get(), cmsInfoDescription, cmsNoLanguage, cmsNoCountry, nullptr, 0);
   auto buf = shttps::make_unique<char[]>(len);
-  cmsGetProfileInfoASCII(icc_profile, cmsInfoDescription, cmsNoLanguage, cmsNoCountry, buf.get(), len);
+  cmsGetProfileInfoASCII(icc_profile.get(), cmsInfoDescription, cmsNoLanguage, cmsNoCountry, buf.get(), len);
   if (strcmp(buf.get(), "sRGB IEC61966-2.1") == 0) {
     profile_type = icc_sRGB;
   } else if (strncmp(buf.get(), "AdobeRGB", 8) == 0) {
@@ -81,16 +81,15 @@ Icc::Icc(const Icc &icc_p)
   cmsSetLogErrorHandler(icc_error_logger);
   if (icc_p.icc_profile != nullptr) {
     cmsUInt32Number len = 0;
-    cmsSaveProfileToMem(icc_p.icc_profile, nullptr, &len);
+    cmsSaveProfileToMem(icc_p.icc_profile.get(), nullptr, &len);
     auto buf = shttps::make_unique<char[]>(len);
-    cmsSaveProfileToMem(icc_p.icc_profile, buf.get(), &len);
-    icc_profile = cmsOpenProfileFromMem(buf.get(), len);
+    cmsSaveProfileToMem(icc_p.icc_profile.get(), buf.get(), &len);
+    icc_profile.reset(cmsOpenProfileFromMem(buf.get(), len));
 
     if (icc_profile == nullptr) { throw SipiError("cmsOpenProfileFromMem failed"); }
 
     profile_type = icc_p.profile_type;
   } else {
-    icc_profile = nullptr;
     profile_type = icc_undefined;
   }
 }
@@ -103,9 +102,8 @@ Icc::Icc(cmsHPROFILE &icc_profile_p)
     cmsSaveProfileToMem(icc_profile_p, nullptr, &len);
     auto buf = shttps::make_unique<char[]>(len);
     cmsSaveProfileToMem(icc_profile_p, buf.get(), &len);
-    if ((icc_profile = cmsOpenProfileFromMem(buf.get(), len)) == nullptr) {
-      throw SipiError("cmsOpenProfileFromMem failed");
-    }
+    icc_profile.reset(cmsOpenProfileFromMem(buf.get(), len));
+    if (icc_profile == nullptr) { throw SipiError("cmsOpenProfileFromMem failed"); }
   }
   profile_type = icc_unknown;
 }
@@ -115,19 +113,19 @@ Icc::Icc(PredefinedProfiles predef)
   cmsSetLogErrorHandler(icc_error_logger);
   switch (predef) {
   case icc_undefined: {
-    icc_profile = nullptr;
     profile_type = icc_undefined;
+    break;
   }
   case icc_unknown: {
     throw SipiError("Profile type \"icc_inknown\" not allowed");
   }
   case icc_sRGB: {
-    icc_profile = cmsCreate_sRGBProfile();
+    icc_profile.reset(cmsCreate_sRGBProfile());
     profile_type = icc_sRGB;
     break;
   }
   case icc_AdobeRGB: {
-    icc_profile = cmsOpenProfileFromMem(AdobeRGB1998_icc, AdobeRGB1998_icc_len);
+    icc_profile.reset(cmsOpenProfileFromMem(AdobeRGB1998_icc, AdobeRGB1998_icc_len));
     profile_type = icc_AdobeRGB;
     break;
   }
@@ -135,14 +133,14 @@ Icc::Icc(PredefinedProfiles predef)
     throw SipiError("Profile type \"icc_RGB\" uses other constructor");
   }
   case icc_CMYK_standard: {
-    icc_profile = cmsOpenProfileFromMem(USWebCoatedSWOP_icc, USWebCoatedSWOP_icc_len);
+    icc_profile.reset(cmsOpenProfileFromMem(USWebCoatedSWOP_icc, USWebCoatedSWOP_icc_len));
     profile_type = icc_CMYK_standard;
     break;
   }
   case icc_GRAY_D50: {
     cmsContext context = cmsCreateContext(nullptr, nullptr);
     cmsToneCurve *gamma_2_2 = cmsBuildGamma(context, 2.2);
-    icc_profile = cmsCreateGrayProfileTHR(context, cmsD50_xyY(), gamma_2_2);
+    icc_profile.reset(cmsCreateGrayProfileTHR(context, cmsD50_xyY(), gamma_2_2));
     cmsFreeToneCurve(gamma_2_2);
     cmsDeleteContext(context);
     profile_type = icc_GRAY_D50;
@@ -151,7 +149,7 @@ Icc::Icc(PredefinedProfiles predef)
   case icc_LUM_D65: {
     cmsContext context = cmsCreateContext(nullptr, nullptr);
     cmsToneCurve *gamma_2_4 = cmsBuildGamma(context, 2.4);
-    icc_profile = cmsCreateGrayProfileTHR(context, cmsD50_xyY(), gamma_2_4);
+    icc_profile.reset(cmsCreateGrayProfileTHR(context, cmsD50_xyY(), gamma_2_4));
     cmsFreeToneCurve(gamma_2_4);
     cmsDeleteContext(context);
     profile_type = icc_LUM_D65;
@@ -160,16 +158,14 @@ Icc::Icc(PredefinedProfiles predef)
   case icc_ROMM_GRAY: {
     cmsContext context = cmsCreateContext(nullptr, nullptr);
     cmsToneCurve *gamma_1_8 = cmsBuildGamma(context, 1.8);
-    icc_profile = cmsCreateGrayProfileTHR(context, cmsD50_xyY(), gamma_1_8);
+    icc_profile.reset(cmsCreateGrayProfileTHR(context, cmsD50_xyY(), gamma_1_8));
     cmsFreeToneCurve(gamma_1_8);
     cmsDeleteContext(context);
     profile_type = icc_ROMM_GRAY;
     break;
   }
   case icc_LAB: {
-    cmsContext context = cmsCreateContext(nullptr, nullptr);
-    icc_profile = cmsCreateLab4Profile(NULL);
-    cmsDeleteContext(context);
+    icc_profile.reset(cmsCreateLab4Profile(NULL));
     profile_type = icc_LAB;
     break;
   }
@@ -207,29 +203,18 @@ Icc::Icc(float white_point_p[], float primaries_p[], const unsigned short tfunc[
     tonecurve[2] = cmsBuildTabulatedToneCurve16(context, tfunc_len, tfunc + 2 * tfunc_len);
   }
 
-  icc_profile = cmsCreateRGBProfileTHR(context, &white_point, &primaries, tonecurve);
+  icc_profile.reset(cmsCreateRGBProfileTHR(context, &white_point, &primaries, tonecurve));
   profile_type = icc_RGB;
   cmsFreeToneCurveTriple(tonecurve);
-}
-
-Icc::~Icc()
-{
-  if (icc_profile != nullptr) { cmsCloseProfile(icc_profile); }
+  cmsDeleteContext(context);
 }
 
 Icc &Icc::operator=(const Icc &rhs)
 {
   if (this != &rhs) {
-    if (rhs.icc_profile != nullptr) {
-      unsigned int len = 0;
-      cmsSaveProfileToMem(rhs.icc_profile, nullptr, &len);
-      auto buf = shttps::make_unique<char[]>(len);
-      cmsSaveProfileToMem(rhs.icc_profile, buf.get(), &len);
-      if ((icc_profile = cmsOpenProfileFromMem(buf.get(), len)) == nullptr) {
-        throw SipiError("cmsOpenProfileFromMem failed");
-      }
-    }
-    profile_type = rhs.profile_type;
+    Icc tmp(rhs);
+    std::swap(icc_profile, tmp.icc_profile);
+    std::swap(profile_type, tmp.profile_type);
   }
   return *this;
 }
@@ -239,11 +224,11 @@ std::vector<unsigned char> Icc::iccBytes()
   if (icc_profile == nullptr) return {};
 
   cmsUInt32Number len = 0;
-  if (!cmsSaveProfileToMem(icc_profile, nullptr, &len))
+  if (!cmsSaveProfileToMem(icc_profile.get(), nullptr, &len))
     throw SipiError("cmsSaveProfileToMem failed");
 
   std::vector<unsigned char> data(len);
-  if (!cmsSaveProfileToMem(icc_profile, data.data(), &len))
+  if (!cmsSaveProfileToMem(icc_profile.get(), data.data(), &len))
     throw SipiError("cmsSaveProfileToMem failed");
 
   // ICC normalization for reproducibility — no-op unless SOURCE_DATE_EPOCH
@@ -252,13 +237,13 @@ std::vector<unsigned char> Icc::iccBytes()
   return data;
 }
 
-cmsHPROFILE Icc::getIccProfile() const { return icc_profile; }
+cmsHPROFILE Icc::getIccProfile() const { return icc_profile.get(); }
 
 unsigned int Icc::iccFormatter(int bps) const
 {
   cmsSetLogErrorHandler(icc_error_logger);
   cmsUInt32Number format = (bps == 16) ? BYTES_SH(2) : BYTES_SH(1);
-  cmsColorSpaceSignature csig = cmsGetColorSpace(icc_profile);
+  cmsColorSpaceSignature csig = cmsGetColorSpace(icc_profile.get());
 
   switch (csig) {
   case cmsSigLabData: {
@@ -373,34 +358,34 @@ unsigned int Icc::iccFormatter(int bps, int nc, PhotometricInterpretation photo)
 std::ostream &operator<<(std::ostream &outstr, Icc &rhs)
 {
   unsigned int len =
-    cmsGetProfileInfoASCII(rhs.icc_profile, cmsInfoDescription, cmsNoLanguage, cmsNoCountry, nullptr, 0);
+    cmsGetProfileInfoASCII(rhs.icc_profile.get(), cmsInfoDescription, cmsNoLanguage, cmsNoCountry, nullptr, 0);
   auto buf = shttps::make_unique<char[]>(len);
-  cmsGetProfileInfoASCII(rhs.icc_profile, cmsInfoDescription, cmsNoLanguage, cmsNoCountry, buf.get(), len);
+  cmsGetProfileInfoASCII(rhs.icc_profile.get(), cmsInfoDescription, cmsNoLanguage, cmsNoCountry, buf.get(), len);
   outstr << "ICC-Description   : " << buf.get() << std::endl;
 
-  len = cmsGetProfileInfoASCII(rhs.icc_profile, cmsInfoManufacturer, cmsNoLanguage, cmsNoCountry, nullptr, 0);
+  len = cmsGetProfileInfoASCII(rhs.icc_profile.get(), cmsInfoManufacturer, cmsNoLanguage, cmsNoCountry, nullptr, 0);
   buf = shttps::make_unique<char[]>(len);
-  cmsGetProfileInfoASCII(rhs.icc_profile, cmsInfoManufacturer, cmsNoLanguage, cmsNoCountry, buf.get(), len);
+  cmsGetProfileInfoASCII(rhs.icc_profile.get(), cmsInfoManufacturer, cmsNoLanguage, cmsNoCountry, buf.get(), len);
   outstr << "ICC-Manufacturer  : " << buf.get() << std::endl;
 
-  len = cmsGetProfileInfoASCII(rhs.icc_profile, cmsInfoModel, cmsNoLanguage, cmsNoCountry, nullptr, 0);
+  len = cmsGetProfileInfoASCII(rhs.icc_profile.get(), cmsInfoModel, cmsNoLanguage, cmsNoCountry, nullptr, 0);
   buf = shttps::make_unique<char[]>(len);
-  cmsGetProfileInfoASCII(rhs.icc_profile, cmsInfoModel, cmsNoLanguage, cmsNoCountry, buf.get(), len);
+  cmsGetProfileInfoASCII(rhs.icc_profile.get(), cmsInfoModel, cmsNoLanguage, cmsNoCountry, buf.get(), len);
   outstr << "ICC-Model         : " << buf.get() << std::endl;
 
-  len = cmsGetProfileInfoASCII(rhs.icc_profile, cmsInfoCopyright, cmsNoLanguage, cmsNoCountry, nullptr, 0);
+  len = cmsGetProfileInfoASCII(rhs.icc_profile.get(), cmsInfoCopyright, cmsNoLanguage, cmsNoCountry, nullptr, 0);
   buf = shttps::make_unique<char[]>(len);
-  cmsGetProfileInfoASCII(rhs.icc_profile, cmsInfoCopyright, cmsNoLanguage, cmsNoCountry, buf.get(), len);
+  cmsGetProfileInfoASCII(rhs.icc_profile.get(), cmsInfoCopyright, cmsNoLanguage, cmsNoCountry, buf.get(), len);
   outstr << "ICC-Copyright     : " << buf.get() << std::endl;
 
   struct tm datetime
   {
   };
-  if (cmsGetHeaderCreationDateTime(rhs.icc_profile, &datetime)) {
+  if (cmsGetHeaderCreationDateTime(rhs.icc_profile.get(), &datetime)) {
     outstr << "ICC-Date          : " << asctime(&datetime);
   }
 
-  cmsProfileClassSignature sig = cmsGetDeviceClass(rhs.icc_profile);
+  cmsProfileClassSignature sig = cmsGetDeviceClass(rhs.icc_profile.get());
   outstr << "ICC profile class : ";
   switch (sig) {
   case 0x73636E72:
@@ -429,16 +414,16 @@ std::ostream &operator<<(std::ostream &outstr, Icc &rhs)
   }
   outstr << '\n';
 
-  cmsFloat64Number version = cmsGetProfileVersion(rhs.icc_profile);
+  cmsFloat64Number version = cmsGetProfileVersion(rhs.icc_profile.get());
   outstr << "ICC Version       : " << version << '\n';
 
   outstr << "ICC Matrix shaper : ";
-  if (cmsIsMatrixShaper(rhs.icc_profile)) {
+  if (cmsIsMatrixShaper(rhs.icc_profile.get())) {
     outstr << "yes" << '\n';
   } else {
     outstr << "no" << '\n';
   }
-  cmsColorSpaceSignature csig = cmsGetPCS(rhs.icc_profile);
+  cmsColorSpaceSignature csig = cmsGetPCS(rhs.icc_profile.get());
   outstr << "ICC color space sigature : ";
   switch (csig) {
   case 0x58595A20:
@@ -565,7 +550,7 @@ std::ostream &operator<<(std::ostream &outstr, Icc &rhs)
   }
   outstr << '\n';
 
-  cmsUInt32Number intent = cmsGetHeaderRenderingIntent(rhs.icc_profile);
+  cmsUInt32Number intent = cmsGetHeaderRenderingIntent(rhs.icc_profile.get());
   outstr << "ICC rendering intent : ";
   switch (intent) {
   case 0:

--- a/src/metadata/icc.h
+++ b/src/metadata/icc.h
@@ -10,7 +10,9 @@
 #ifndef SIPI_METADATA_ICC_H
 #define SIPI_METADATA_ICC_H
 
+#include <memory>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include <limits.h>
@@ -47,18 +49,20 @@ typedef enum {
 class Icc
 {
 private:
-  cmsHPROFILE icc_profile{};//!< Handle of the littleCMS profile data
-  PredefinedProfiles profile_type;//!< Profile type that is represented
+  struct ProfileCloser
+  {
+    void operator()(cmsHPROFILE p) const { cmsCloseProfile(p); }
+  };
+  using ProfilePtr = std::unique_ptr<std::remove_pointer_t<cmsHPROFILE>, ProfileCloser>;
+
+  ProfilePtr icc_profile{};//!< Owning handle of the littleCMS profile data
+  PredefinedProfiles profile_type{ icc_undefined };//!< Profile type that is represented
 
 public:
   /*!
    * Constructor (default) which results in empty, undefined profile
    */
-  inline Icc()
-  {
-    icc_profile = NULL;
-    profile_type = icc_undefined;
-  };
+  Icc() = default;
 
   /*!
    * Constructor which takes a blob that contains the ICC profile
@@ -95,10 +99,9 @@ public:
    */
   Icc(float white_point_p[], float primaries_p[], const unsigned short *tfunc = nullptr, int tfunc_len = 0);
 
-  /**
-   * Destructor
-   */
-  ~Icc();
+  Icc(Icc &&) = default;
+
+  Icc &operator=(Icc &&) = default;
 
   /*!
    * Assignment operator which makes deep copy


### PR DESCRIPTION
## Motivation
Phase 2 of the RAII refactoring plan (audit findings in engine-critical metadata classes). `Exif` had a real double-free reachable through the `SipiImage` copy constructor, and `Icc` leaked an lcms2 profile on every assignment. Both classes are on the image-serving path.

## Summary
- Copying a `SipiImage` with blob-backed EXIF no longer double-frees the blob.
- Assigning an `Icc` no longer leaks the previous lcms2 profile; the RGB constructor no longer leaks its `cmsContext`.
- `SipiImage::convertToIcc` no longer leaks the transformed pixel buffer when the target profile copy throws.

## Key Changes
### Exif → rule of zero
- `binaryExif` raw pointer + `binary_size` replaced with `std::vector<unsigned char>`; hand-written destructor removed. The compiler-generated copy previously shallow-copied the pointer (user dtor, no copy ctor — classic rule-of-three violation) and `SipiImage.cpp` copies `Exif` via `make_shared<Exif>(*img_p.exif)`.

### Icc → owning handle
- `icc_profile` is now `unique_ptr<remove_pointer_t<cmsHPROFILE>, ProfileCloser>`; destructor removed, moves defaulted (previously missing — moves silently deep-copied via lcms2 serialize+reopen).
- `operator=` rewritten as copy-and-swap: the old profile is now closed (previously leaked), and a null right-hand side now produces a consistent empty profile instead of a stale handle with a copied type tag.
- RGB constructor: added the missing `cmsDeleteContext` (all other color-space branches had it).
- `Icc(icc_undefined)`: added the missing `break` — it fell through into the `icc_unknown` throw, so constructing the documented "empty profile" value always threw.
- `icc_LAB`: dropped a create/delete of a context that was never used (`cmsCreateLab4Profile` isn't the THR variant).

### convertToIcc exception safety
- Transformed pixel buffer and the `cmsHTRANSFORM` held by unique_ptrs; the buffer is released into `pixels` only after `icc = make_shared<Icc>(target)` (which can throw on `cmsOpenProfileFromMem` failure) has succeeded.

## Gotchas
- `Icc::iccBytes()` (the ICC determinism chokepoint) is untouched apart from `.get()`; approval tests confirm byte-identical output.
- `getIccProfile()` still returns the raw `cmsHPROFILE` for lcms2 call sites — it's a non-owning observer now.

## Test Plan
- [x] `just bazel-build`
- [x] `just bazel-test-unit` (25/25, includes `icc_normalize_test`, `essentials_test`)
- [x] `just bazel-test-approval` (ICC determinism gate)
- [x] `just bazel-test-e2e` (27/27; a Bazel `generate-xml.sh` host flake required retries — test binaries themselves all passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)