### PR TITLE
fix(formats): RAII for codec handles and buffers in all four format handlers

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -374,7 +374,7 @@
   "moduleExtensions": {
     "//bazel:benchmark_fixtures_extension.bzl%benchmark_fixtures_extension": {
       "general": {
-        "bzlTransitiveDigest": "LTpreO52kIPpVsBKekTBnXnonOEfi/B0L7PcGwN1Xd8=",
+        "bzlTransitiveDigest": "H14/96cHfmxp6CjcA8kwwdPaaC5gP23piJmoXkGUMVw=",
         "usagesDigest": "/OVd0sRob8VDNWU93dMHAiBNsg7C2sxDHY58Rp2wOJw=",
         "recordedInputs": [],
         "generatedRepoSpecs": {

--- a/src/SipiImage.cpp
+++ b/src/SipiImage.cpp
@@ -1485,8 +1485,9 @@ bool SipiImage::toBitonal()
 void SipiImage::add_watermark(const std::string &wmfilename)
 {
   int wm_nx, wm_ny, wm_nc;
-  byte *wmbuf = read_watermark(wmfilename, wm_nx, wm_ny, wm_nc);
-  if (wmbuf == nullptr) { throw SipiImageError("Cannot read watermark file " + wmfilename); }
+  std::vector<unsigned char> wm = read_watermark(wmfilename, wm_nx, wm_ny, wm_nc);
+  if (wm.empty()) { throw SipiImageError("Cannot read watermark file " + wmfilename); }
+  byte *wmbuf = wm.data();
 
   // scaling is calculated with the middle point as point of origin
   double wm_scale = ((double)wm_nx / wm_ny > (double)nx / ny) ? (double)wm_nx / nx : (double)wm_ny / ny;
@@ -1522,8 +1523,6 @@ void SipiImage::add_watermark(const std::string &wmfilename)
   } else if (bps == 16) {
     // 16bps support was never really finished, left unimplemented
   }
-
-  delete[] wmbuf;
 }
 
 #undef POSITION

--- a/src/formats/SipiIOJ2k.cpp
+++ b/src/formats/SipiIOJ2k.cpp
@@ -10,6 +10,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
+#include <memory>
 #include <span>
 #include <string>
 #include <vector>
@@ -197,9 +198,9 @@ static KduSipiError kdu_sipi_error("Kakadu-library: ");
 
 static bool is_jpx(const char *fname)
 {
-  int inf;
   int retval = 0;
-  if ((inf = ::open(fname, O_RDONLY)) != -1) {
+  int inf = ::open(fname, O_RDONLY);
+  if (inf != -1) {
     char testbuf[48];
     char sig0[] = { '\xff', '\x52' };
     char sig1[] = { '\xff', '\x4f', '\xff', '\x51' };
@@ -211,8 +212,8 @@ static bool is_jpx(const char *fname)
       retval = 1;
     } else if ((n >= 12) && (memcmp(sig2, testbuf, 12) == 0))
       retval = 1;
+    close(inf);
   }
-  close(inf);
   return retval == 1;
 }
 //=============================================================================
@@ -247,6 +248,30 @@ bool SipiIOJ2k::read(SipiImage *img,
   kdu_supp::jp2_palette palette;
   kdu_supp::jp2_resolution resolution;
   kdu_supp::jp2_colour colour;
+
+  kdu_core::kdu_codestream codestream;
+
+  // Tears down the Kakadu decode machinery exactly once on every exit path
+  // (normal, throw, and error-return), in the required order: codestream
+  // first, then the compressed source, then the JPX container.
+  struct KduReadTeardown
+  {
+    kdu_core::kdu_codestream &codestream;
+    kdu_core::kdu_compressed_source *&input;
+    kdu_supp::jpx_source &jpx_in;
+    bool done = false;
+
+    void teardown()
+    {
+      if (done) { return; }
+      done = true;
+      if (codestream.exists()) { codestream.destroy(); }
+      if (input != nullptr) { input->close(); }
+      jpx_in.close();
+    }
+
+    ~KduReadTeardown() { teardown(); }
+  } kdu_teardown{ codestream, input, jpx_in };
 
   jp2_ultimate_src.open(filepath.c_str());
 
@@ -334,23 +359,20 @@ bool SipiIOJ2k::read(SipiImage *img,
       input = jpx_stream.open_stream();
       palette = jpx_stream.access_palette();
     } catch (kdu_exception&) {
-      // input is live only if open_stream() returned before the throw; the
-      // codestream is not created yet. jp2_ultimate_src is released by its
-      // destructor on unwind, as on the normal path (which closes only
-      // input + jpx_in).
-      if (input != nullptr) input->close();
-      jpx_in.close();
+      // KduReadTeardown closes whatever is live (input is set only if
+      // open_stream() returned before the throw; the codestream is not
+      // created yet). jp2_ultimate_src is released by its destructor on
+      // unwind, as on the normal path.
       throw SipiImageError(
         "Cannot read JPEG2000 file \"" + filepath + "\": no usable codestream in JP2/JPX container");
     }
   }
 
-  kdu_core::kdu_codestream codestream;
   // Corrupt or truncated input makes create()/header parsing raise a Kakadu
   // error, which KduSipiError::flush throws as a kdu_exception. Convert it to a
-  // SipiImageError (as the JPEG/PNG handlers do) after tearing down the
-  // codestream + source, so the engine reports an enriched error rather than a
-  // bare catch-all, and no source is leaked on the failure path.
+  // SipiImageError (as the JPEG/PNG handlers do); KduReadTeardown tears down
+  // the codestream + source, so the engine reports an enriched error rather
+  // than a bare catch-all, and no source is leaked on the failure path.
   int maximal_reduce;
   try {
     codestream.create(input);
@@ -358,11 +380,6 @@ bool SipiIOJ2k::read(SipiImage *img,
     codestream.set_fast();// No errors expected in input
     maximal_reduce = codestream.get_min_dwt_levels();
   } catch (kdu_exception&) {
-    // create() can throw before the codestream exists; input is already set by
-    // the branch above. Otherwise the same teardown as the ROI/normal paths.
-    if (codestream.exists()) codestream.destroy();
-    input->close();
-    jpx_in.close();
     throw SipiImageError(
       "Cannot read JPEG2000 file \"" + filepath + "\": corrupt or truncated codestream");
   }
@@ -407,18 +424,11 @@ bool SipiIOJ2k::read(SipiImage *img,
   kdu_core::kdu_dims roi;
   bool do_roi = false;
   if ((region != nullptr) && (region->getType()) != SipiRegion::FULL) {
-    try {
-      size_t sx, sy;
-      region->crop_coords(__nx, __ny, roi.pos.x, roi.pos.y, sx, sy);
-      roi.size.x = sx;
-      roi.size.y = sy;
-      do_roi = true;
-    } catch (Sipi::SipiError &err) {
-      codestream.destroy();
-      input->close();
-      jpx_in.close();// Not really necessary here.
-      throw err;
-    }
+    size_t sx, sy;
+    region->crop_coords(__nx, __ny, roi.pos.x, roi.pos.y, sx, sy);
+    roi.size.x = sx;
+    roi.size.y = sy;
+    do_roi = true;
   }
 
   //
@@ -457,9 +467,9 @@ bool SipiIOJ2k::read(SipiImage *img,
   //
   // The following definitions we need in case we get a palette color image!
   //
-  byte *rlut = NULL;
-  byte *glut = NULL;
-  byte *blut = NULL;
+  std::vector<byte> rlut;
+  std::vector<byte> glut;
+  std::vector<byte> blut;
   //
   // get ICC-Profile if available
   //
@@ -474,20 +484,19 @@ bool SipiIOJ2k::read(SipiImage *img,
     int nluts = palette.get_num_luts();
     if (nluts == 3) {
       int nentries = palette.get_num_entries();
-      rlut = new byte[nentries];
-      glut = new byte[nentries];
-      blut = new byte[nentries];
-      float *tmplut = new float[nentries];
+      rlut.resize(nentries);
+      glut.resize(nentries);
+      blut.resize(nentries);
+      std::vector<float> tmplut(nentries);
 
-      palette.get_lut(0, tmplut);
+      palette.get_lut(0, tmplut.data());
       for (int i = 0; i < nentries; i++) { rlut[i] = roundf((tmplut[i] + 0.5) * 255.0); }
 
-      palette.get_lut(1, tmplut);
+      palette.get_lut(1, tmplut.data());
       for (int i = 0; i < nentries; i++) { glut[i] = roundf((tmplut[i] + 0.5) * 255.0); }
 
-      palette.get_lut(2, tmplut);
+      palette.get_lut(2, tmplut.data());
       for (int i = 0; i < nentries; i++) { blut[i] = roundf((tmplut[i] + 0.5) * 255.0); }
-      delete[] tmplut;
     }
     img->orientation = TOPLEFT;
     if (img->nc > numcol) {// we have more components than colors -> alpha channel!
@@ -604,11 +613,6 @@ bool SipiIOJ2k::read(SipiImage *img,
   try {
     decompressor.start(codestream);
   } catch (kdu_exception&) {
-    // codestream + input are both live here (create() already succeeded);
-    // unconditional teardown, matching the ROI-error and normal-exit paths.
-    codestream.destroy();
-    input->close();
-    jpx_in.close();
     throw SipiImageError(
       "Cannot read JPEG2000 file \"" + filepath + "\": corrupt codestream (decompressor start failed)");
   }
@@ -620,57 +624,55 @@ bool SipiIOJ2k::read(SipiImage *img,
   if (force_bps_8) img->bps = 8;// forces kakadu to convert to 8 bit!
   switch (img->bps) {
   case 8: {
-    auto *buffer8 = new kdu_core::kdu_byte[static_cast<int>(dims.area()) * img->nc];
+    auto buffer8 = std::make_unique<kdu_core::kdu_byte[]>(static_cast<int>(dims.area()) * img->nc);
     try {
-      decompressor.pull_stripe(buffer8, stripe_heights);
+      decompressor.pull_stripe(buffer8.get(), stripe_heights);
     } catch (kdu_exception &exc) {
-      codestream.destroy();
-      input->close();
-      jpx_in.close();// Not really necessary here.
       log_err("Error while decompressing image: %s.", filepath.c_str());
       return false;
     }
-    img->pixels = buffer8;
+    img->pixels = buffer8.release();
     break;
   }
   case 12: {
     std::vector<char> get_signed(img->nc, 0);// vector<bool> does not work -> special treatment in C++
-    auto *buffer16 = new kdu_core::kdu_int16[(int)dims.area() * img->nc];
+    auto buffer16 = std::make_unique<kdu_core::kdu_int16[]>((int)dims.area() * img->nc);
     try {
-      decompressor.pull_stripe(
-        buffer16, stripe_heights, nullptr, nullptr, nullptr, nullptr, reinterpret_cast<bool *>(get_signed.data()));
+      decompressor.pull_stripe(buffer16.get(),
+        stripe_heights,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        reinterpret_cast<bool *>(get_signed.data()));
     } catch (kdu_exception &exc) {
-      codestream.destroy();
-      input->close();
-      jpx_in.close();// Not really necessary here.
       log_err("Error while decompressing image: %s.", filepath.c_str());
       return false;
     }
-    img->pixels = reinterpret_cast<byte *>(buffer16);
+    img->pixels = reinterpret_cast<byte *>(buffer16.release());
     img->bps = 16;
     break;
   }
   case 16: {
     std::vector<char> get_signed(img->nc, 0);// vector<bool> does not work -> special treatment in C++
-    auto *buffer16 = new kdu_core::kdu_int16[(int)dims.area() * img->nc];
+    auto buffer16 = std::make_unique<kdu_core::kdu_int16[]>((int)dims.area() * img->nc);
     try {
-      decompressor.pull_stripe(
-        buffer16, stripe_heights, nullptr, nullptr, nullptr, nullptr, reinterpret_cast<bool *>(get_signed.data()));
+      decompressor.pull_stripe(buffer16.get(),
+        stripe_heights,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        reinterpret_cast<bool *>(get_signed.data()));
     } catch (kdu_exception &exc) {
-      codestream.destroy();
-      input->close();
-      jpx_in.close();// Not really necessary here.
       log_err("Error while decompressing image: %s.", filepath.c_str());
       return false;
     }
-    img->pixels = reinterpret_cast<byte *>(buffer16);
+    img->pixels = reinterpret_cast<byte *>(buffer16.release());
     break;
   }
   default: {
     decompressor.finish();
-    codestream.destroy();
-    input->close();
-    jpx_in.close();// Not really necessary here.
     log_err("Unsupported number of bits/sample: %ld in file %s", img->bps, filepath.c_str());
     throw SipiImageError("Cannot read JPEG2000: unsupported bits/sample (" + std::to_string(img->bps)
       + ") in file \"" + filepath + "\" (dimensions: " + std::to_string(img->nx) + "x"
@@ -678,15 +680,13 @@ bool SipiIOJ2k::read(SipiImage *img,
   }
   }
   decompressor.finish();
-  codestream.destroy();
-  input->close();
-  jpx_in.close();// Not really necessary here.
+  kdu_teardown.teardown();
 
-  if (rlut != NULL) {
+  if (!rlut.empty()) {
     //
     // we have a palette color image...
     //
-    byte *tmpbuf = new byte[img->nx * img->ny * numcol];
+    auto tmpbuf = std::make_unique<byte[]>(img->nx * img->ny * numcol);
     for (int y = 0; y < img->ny; ++y) {
       for (int x = 0; x < img->nx; ++x) {
         tmpbuf[3 * (y * img->nx + x) + 0] = rlut[img->pixels[y * img->nx + x]];
@@ -695,11 +695,8 @@ bool SipiIOJ2k::read(SipiImage *img,
       }
     }
     delete[] img->pixels;
-    img->pixels = tmpbuf;
+    img->pixels = tmpbuf.release();
     img->nc = numcol;
-    delete[] rlut;
-    delete[] glut;
-    delete[] blut;
   }
   if (img->photo == PhotometricInterpretation::YCBCR) {
     img->convertYCC2RGB();
@@ -744,6 +741,30 @@ SipiImgInfo SipiIOJ2k::read_shape(const std::string &filepath)
   kdu_supp::jpx_codestream_source jpx_stream;
   kdu_core::kdu_compressed_source *input = nullptr;
   kdu_supp::kdu_simple_file_source file_in;
+
+  kdu_core::kdu_codestream codestream;
+
+  // Same exactly-once teardown as in read(): a corrupt file makes
+  // codestream.create() (or set_fussy header parsing) throw a kdu_exception,
+  // and the sources must not leak on that path.
+  struct KduReadTeardown
+  {
+    kdu_core::kdu_codestream &codestream;
+    kdu_core::kdu_compressed_source *&input;
+    kdu_supp::jpx_source &jpx_in;
+    bool done = false;
+
+    void teardown()
+    {
+      if (done) { return; }
+      done = true;
+      if (codestream.exists()) { codestream.destroy(); }
+      if (input != nullptr) { input->close(); }
+      jpx_in.close();
+    }
+
+    ~KduReadTeardown() { teardown(); }
+  } kdu_teardown{ codestream, input, jpx_in };
 
   jp2_ultimate_src.open(filepath.c_str());
 
@@ -809,7 +830,6 @@ SipiImgInfo SipiIOJ2k::read_shape(const std::string &filepath)
         Sipi::observability::EssentialsFormat::Jp2,
         Sipi::observability::ReadShapeFastPathOutcome::Hit)
         .Increment();
-      jpx_in.close();
       return info;
     }
     // Pre-record fast-path outcome for the slow path; the actual
@@ -819,7 +839,6 @@ SipiImgInfo SipiIOJ2k::read_shape(const std::string &filepath)
     input = jpx_stream.open_stream();
   }
 
-  kdu_core::kdu_codestream codestream;
   codestream.create(input);
   codestream.set_fussy();// Set the parsing error tolerance.
 
@@ -876,10 +895,6 @@ SipiImgInfo SipiIOJ2k::read_shape(const std::string &filepath)
   }
   Sipi::observability::read_shape_fast_path_counter(
     Sipi::observability::EssentialsFormat::Jp2, outcome).Increment();
-
-  codestream.destroy();
-  input->close();
-  jpx_in.close();// Not really necessary here.
 
   return info;
 }
@@ -972,6 +987,12 @@ void SipiIOJ2k::write(SipiImage *img, const OutputSink &sink, const SipiCompress
   std::unique_ptr<SinkStream> sink_stream;
   std::unique_ptr<J2kHttpStream> http;
 
+  // Declared outside the try so the catch below can destroy it; the JPX
+  // target and its boxes are deliberately NOT closed on the error path —
+  // closing a jpx_target with incompletely written codestreams raises
+  // another Kakadu error.
+  kdu_codestream codestream;
+
   try {
     // Construct code-stream object
     siz_params siz;
@@ -1054,7 +1075,6 @@ void SipiIOJ2k::write(SipiImage *img, const OutputSink &sink, const SipiCompress
       env_ref = nullptr;
     }
 
-    kdu_codestream codestream;
     codestream.create(&siz, output, nullptr, 0, 0, env_ref, &membroker);
 
     // Set up any specific coding parameters and finalize them.
@@ -1378,18 +1398,13 @@ void SipiIOJ2k::write(SipiImage *img, const OutputSink &sink, const SipiCompress
 
     // int *stripe_heights = new int[img->nc];
     int stripe_heights[5];
-    int *precisions;
-    bool *is_signed;
     if (img->bps == 16) {
       kdu_int16 *buf = (kdu_int16 *)img->pixels;
-      precisions = new int[img->nc];
-      is_signed = new bool[img->nc];
-      for (size_t i = 0; i < img->nc; i++) {
-        precisions[i] = img->bps;
-        is_signed[i] = false;
-      }
+      std::vector<int> precisions(img->nc, static_cast<int>(img->bps));
+      std::vector<char> is_signed(img->nc, 0);// vector<bool> does not work -> special treatment in C++
       for (size_t i = 0; i < img->nc; i++) { stripe_heights[i] = img->ny; }
-      compressor.push_stripe(buf, stripe_heights, nullptr, nullptr, nullptr, precisions, is_signed);
+      compressor.push_stripe(
+        buf, stripe_heights, nullptr, nullptr, nullptr, precisions.data(), reinterpret_cast<bool *>(is_signed.data()));
     } else if (img->bps == 8) {
       if (th == 0) th = img->ny;
       size_t stripe_start = 0;
@@ -1418,12 +1433,8 @@ void SipiIOJ2k::write(SipiImage *img, const OutputSink &sink, const SipiCompress
     output->close();// Not really necessary here.
     jpx_out.close();
     if (jp2_ultimate_tgt.exists()) { jp2_ultimate_tgt.close(); }
-    // delete[] stripe_heights;
-    if (img->bps == 16) {
-      delete[] precisions;
-      delete[] is_signed;
-    }
   } catch (kdu_exception e) {
+    if (codestream.exists()) { codestream.destroy(); }
     if (http && http->client_aborted) {
       throw SipiImageClientAbortError("Client aborted HTTP response during JPEG2000 write");
     }

--- a/src/formats/SipiIOJpeg.cpp
+++ b/src/formats/SipiIOJpeg.cpp
@@ -9,6 +9,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <memory>
 #include <string>
 #include <unistd.h>
 
@@ -94,12 +95,22 @@ static void jpegErrorExit(j_common_ptr cinfo)
 //------------------------------------------------------------------
 
 
-typedef struct FileBuffer
+/*!
+ * Buffer for libjpeg's file source/destination managers. Owned by the caller
+ * of jpeg_file_src/jpeg_file_dest and declared *before* the setjmp() so its
+ * destructor runs on the C++ unwind path; the term_* callbacks only flush and
+ * unhook — they do not free (longjmp would otherwise leak what they skip).
+ */
+struct FileBuffer
 {
-  JOCTET *buffer;
+  explicit FileBuffer(int file_id_p, size_t buflen_p = 65536)
+    : buffer(std::make_unique<JOCTET[]>(buflen_p)), buflen(buflen_p), file_id(file_id_p)
+  {}
+
+  std::unique_ptr<JOCTET[]> buffer;
   size_t buflen;
   int file_id;
-} FileBuffer;
+};
 
 /*!
  * Function which initializes the structures for managing the IO
@@ -108,7 +119,7 @@ static void init_file_destination(j_compress_ptr cinfo)
 {
   auto *file_buffer = (FileBuffer *)cinfo->client_data;
   cinfo->dest->free_in_buffer = file_buffer->buflen;
-  cinfo->dest->next_output_byte = file_buffer->buffer;
+  cinfo->dest->next_output_byte = file_buffer->buffer.get();
 }
 
 //=============================================================================
@@ -122,7 +133,7 @@ static boolean empty_file_buffer(j_compress_ptr cinfo)
   size_t n = file_buffer->buflen;
   size_t nn = 0;
   do {
-    ssize_t tmp_n = write(file_buffer->file_id, file_buffer->buffer + nn, n);
+    ssize_t tmp_n = write(file_buffer->file_id, file_buffer->buffer.get() + nn, n);
     if (tmp_n < 0) {
       ERREXIT(cinfo, JERR_FILE_WRITE);  // triggers jpegErrorExit → longjmp
       return FALSE;  // unreachable, but satisfies return type
@@ -133,7 +144,7 @@ static boolean empty_file_buffer(j_compress_ptr cinfo)
   } while (n > 0);
 
   cinfo->dest->free_in_buffer = file_buffer->buflen;
-  cinfo->dest->next_output_byte = file_buffer->buffer;
+  cinfo->dest->next_output_byte = file_buffer->buffer.get();
 
   return static_cast<boolean>(1);
 }
@@ -146,10 +157,10 @@ static boolean empty_file_buffer(j_compress_ptr cinfo)
 static void term_file_destination(j_compress_ptr cinfo)
 {
   FileBuffer *file_buffer = (FileBuffer *)cinfo->client_data;
-  size_t n = cinfo->dest->next_output_byte - file_buffer->buffer;
+  size_t n = cinfo->dest->next_output_byte - file_buffer->buffer.get();
   size_t nn = 0;
   do {
-    auto tmp_n = write(file_buffer->file_id, file_buffer->buffer + nn, n);
+    auto tmp_n = write(file_buffer->file_id, file_buffer->buffer.get() + nn, n);
     if (tmp_n < 0) {
       ERREXIT(cinfo, JERR_FILE_WRITE);  // triggers jpegErrorExit → longjmp
       return;  // unreachable
@@ -159,32 +170,23 @@ static void term_file_destination(j_compress_ptr cinfo)
     }
   } while (n > 0);
 
-  delete[] file_buffer->buffer;
-  delete file_buffer;
+  // The FileBuffer and the destination manager are owned by the caller of
+  // jpeg_file_dest; only unhook them here.
   cinfo->client_data = nullptr;
-
-  free(cinfo->dest);
   cinfo->dest = nullptr;
 }
 
 //=============================================================================
 
 /*!
- * This function is used to setup the I/O destination to the HTTP socket
+ * This function is used to setup the I/O destination to a file descriptor.
+ * Both the FileBuffer and the destination manager are owned by the caller and
+ * must outlive the compress struct (declare them before the setjmp).
  */
-static void jpeg_file_dest(struct jpeg_compress_struct *cinfo, int file_id)
+static void
+  jpeg_file_dest(struct jpeg_compress_struct *cinfo, FileBuffer *file_buffer, struct jpeg_destination_mgr *destmgr)
 {
-  struct jpeg_destination_mgr *destmgr;
-  FileBuffer *file_buffer;
-  cinfo->client_data = new FileBuffer;
-  file_buffer = (FileBuffer *)cinfo->client_data;
-
-  file_buffer->buffer = new JOCTET[65536];
-  //(JOCTET *) malloc(buflen*sizeof(JOCTET));
-  file_buffer->buflen = 65536;
-  file_buffer->file_id = file_id;
-
-  destmgr = (struct jpeg_destination_mgr *)malloc(sizeof(struct jpeg_destination_mgr));
+  cinfo->client_data = file_buffer;
 
   destmgr->init_destination = init_file_destination;
   destmgr->empty_output_buffer = empty_file_buffer;
@@ -199,7 +201,7 @@ static void jpeg_file_dest(struct jpeg_compress_struct *cinfo, int file_id)
 static void init_file_source(struct jpeg_decompress_struct *cinfo)
 {
   auto *file_buffer = (FileBuffer *)cinfo->client_data;
-  cinfo->src->next_input_byte = file_buffer->buffer;
+  cinfo->src->next_input_byte = file_buffer->buffer.get();
   cinfo->src->bytes_in_buffer = 0;
 }
 
@@ -210,7 +212,7 @@ static boolean file_source_fill_input_buffer(struct jpeg_decompress_struct *cinf
   auto *file_buffer = (FileBuffer *)cinfo->client_data;
   size_t nbytes = 0;
   do {
-    auto n = read(file_buffer->file_id, file_buffer->buffer + nbytes, file_buffer->buflen - nbytes);
+    auto n = read(file_buffer->file_id, file_buffer->buffer.get() + nbytes, file_buffer->buflen - nbytes);
     if (n < 0) {
       break;// error
     }
@@ -226,7 +228,7 @@ static boolean file_source_fill_input_buffer(struct jpeg_decompress_struct *cinf
     nbytes = 2;
     */
   }
-  cinfo->src->next_input_byte = file_buffer->buffer;
+  cinfo->src->next_input_byte = file_buffer->buffer.get();
   cinfo->src->bytes_in_buffer = nbytes;
   return static_cast<boolean>(true);
 }
@@ -249,32 +251,23 @@ static void file_source_skip_input_data(struct jpeg_decompress_struct *cinfo, lo
 
 static void term_file_source(struct jpeg_decompress_struct *cinfo)
 {
-  auto *file_buffer = (FileBuffer *)cinfo->client_data;
-
-  delete[] file_buffer->buffer;
-  delete file_buffer;
+  // The FileBuffer and the source manager are owned by the caller of
+  // jpeg_file_src; only unhook them here.
   cinfo->client_data = nullptr;
-  free(cinfo->src);
   cinfo->src = nullptr;
 }
 
 //=============================================================================
 
 /*!
- * Load the JPEG file
+ * Load the JPEG file. Both the FileBuffer and the source manager are owned by
+ * the caller and must outlive the decompress struct (declare them before the
+ * setjmp).
  */
-static void jpeg_file_src(struct jpeg_decompress_struct *cinfo, int file_id)
+static void jpeg_file_src(struct jpeg_decompress_struct *cinfo, FileBuffer *file_buffer, struct jpeg_source_mgr *srcmgr)
 {
-  struct jpeg_source_mgr *srcmgr;
-  FileBuffer *file_buffer;
-  cinfo->client_data = new FileBuffer;
-  file_buffer = (FileBuffer *)cinfo->client_data;
+  cinfo->client_data = file_buffer;
 
-  file_buffer->buffer = new JOCTET[65536];
-  file_buffer->buflen = 65536;
-  file_buffer->file_id = file_id;
-
-  srcmgr = (struct jpeg_source_mgr *)malloc(sizeof(struct jpeg_source_mgr));
   srcmgr->init_source = init_file_source;
   srcmgr->fill_input_buffer = file_source_fill_input_buffer;
   srcmgr->skip_input_data = file_source_skip_input_data;
@@ -472,12 +465,12 @@ bool SipiIOJpeg::read(SipiImage *img,
   // open the input file
   //
   if ((infile = ::open(filepath.c_str(), O_RDONLY)) == -1) { return false; }
+  FdGuard infile_guard(infile);
   // workaround for bug #0011: jpeglib crashes the app when the file is not a jpeg file
   // we check the magic number before calling any jpeglib routines
   unsigned char magic[2];
-  if (::read(infile, magic, 2) != 2) { ::close(infile); return false; }
+  if (::read(infile, magic, 2) != 2) { return false; }
   if ((magic[0] != 0xff) || (magic[1] != 0xd8)) {
-    close(infile);
     return false;// it's not a JPEG file!
   }
   // move infile position back to the beginning of the file
@@ -494,6 +487,11 @@ bool SipiIOJpeg::read(SipiImage *img,
   JSAMPARRAY linbuf = nullptr;
   jpeg_saved_marker_ptr marker = nullptr;
   unsigned char *icc_buffer_guard = nullptr;  // for cleanup on longjmp
+
+  // Source manager + buffer, owned here and declared before the setjmp so
+  // their destructors run on the C++ unwind path.
+  FileBuffer file_buffer(infile);
+  struct jpeg_source_mgr srcmgr{};
 
   //
   // let's create the decompressor
@@ -517,19 +515,15 @@ bool SipiIOJpeg::read(SipiImage *img,
   // eliminating C++ throw-through-C undefined behavior.
   //
   if (setjmp(jerr.error_jmp)) {
-    // longjmp landed here — clean up and throw in C++ context
+    // longjmp landed here — clean up and throw in C++ context.
+    // file_buffer / srcmgr / infile_guard are declared before the setjmp, so
+    // their destructors run during the throw's stack unwinding.
     free(icc_buffer_guard);  // may have been allocated during marker parsing
-    // Call term_source to free the source manager allocated by jpeg_file_src.
-    // jpeg_destroy_decompress does NOT call term_source on error paths.
-    if (cinfo.src && cinfo.src->term_source) {
-      cinfo.src->term_source(&cinfo);
-    }
     jpeg_destroy_decompress(&cinfo);
-    ::close(infile);
     throw SipiImageError("JPEG read failed for \"" + filepath + "\": " + std::string(jerr.error_message));
   }
 
-  jpeg_file_src(&cinfo, infile);
+  jpeg_file_src(&cinfo, &file_buffer, &srcmgr);
   jpeg_save_markers(&cinfo, JPEG_COM, 0xffff);
   for (int i = 0; i < 16; i++) { jpeg_save_markers(&cinfo, JPEG_APP0 + i, 0xffff); }
 
@@ -539,7 +533,6 @@ bool SipiIOJpeg::read(SipiImage *img,
   int res = jpeg_read_header(&cinfo, static_cast<boolean>(true));
   if (res != JPEG_HEADER_OK) {
     jpeg_destroy_decompress(&cinfo);
-    close(infile);
     throw SipiImageError("Error reading JPEG file: \"" + filepath + "\"");
   }
 
@@ -749,7 +742,6 @@ bool SipiIOJpeg::read(SipiImage *img,
 
   jpeg_finish_decompress(&cinfo);
   jpeg_destroy_decompress(&cinfo);
-  ::close(infile);
 
   //
   // CMYK / YCCK polarity handling.
@@ -861,28 +853,25 @@ SipiImgInfo SipiIOJpeg::read_shape(const std::string &filepath)
 
   jpeg_saved_marker_ptr marker;
 
+  // Source manager + buffer, owned here and declared before the setjmp so
+  // their destructors run on the C++ unwind path.
+  FileBuffer file_buffer(raw_fd);
+  struct jpeg_source_mgr srcmgr{};
+
   cinfo.err = jpeg_std_error(&jerr.pub);
   jerr.pub.error_exit = jpegErrorExit;
 
   jpeg_create_decompress(&cinfo);
   cinfo.dct_method = JDCT_ISLOW;// integer IDCT — cross-arch bit-exact (see the main read path)
 
-  // Helper to clean up jpeg resources (source manager + decompress struct).
-  auto cleanup_jpeg = [&cinfo]() {
-    if (cinfo.src && cinfo.src->term_source) {
-      cinfo.src->term_source(&cinfo);
-    }
-    jpeg_destroy_decompress(&cinfo);
-  };
-
   // setjmp error handler for read_shape — libjpeg errors longjmp here
   if (setjmp(jerr.error_jmp)) {
-    cleanup_jpeg();
+    jpeg_destroy_decompress(&cinfo);
     info.success = SipiImgInfo::FAILURE;
     return info;
   }
 
-  jpeg_file_src(&cinfo, raw_fd);
+  jpeg_file_src(&cinfo, &file_buffer, &srcmgr);
   jpeg_save_markers(&cinfo, JPEG_COM, 0xffff);
   for (int i = 0; i < 16; i++) { jpeg_save_markers(&cinfo, JPEG_APP0 + i, 0xffff); }
 
@@ -891,7 +880,7 @@ SipiImgInfo SipiIOJpeg::read_shape(const std::string &filepath)
   //
   int res = jpeg_read_header(&cinfo, static_cast<boolean>(true));
   if (res != JPEG_HEADER_OK) {
-    cleanup_jpeg();
+    jpeg_destroy_decompress(&cinfo);
     info.success = SipiImgInfo::FAILURE;
     return info;
   }
@@ -984,15 +973,22 @@ SipiImgInfo SipiIOJpeg::read_shape(const std::string &filepath)
 
           img.xmp = std::make_shared<Xmp>(xmpstr);
         } catch (SipiImageError &err) {
-          cleanup_jpeg();
+          jpeg_destroy_decompress(&cinfo);
           info.success = SipiImgInfo::FAILURE;
           return info;
         }
       }
     } else if (marker->marker == JPEG_APP0 + 13) {
       // PHOTOSHOP MARKER....
+      // Wrapped like the main read path: a malformed IPTC / EXIF / XMP inside
+      // the Photoshop resource block must not abort the shape probe (and must
+      // not unwind past the live decompress struct).
       if (strncmp("Photoshop 3.0", (char *)marker->data, 14) == 0) {
-        parse_photoshop(&img, (char *)marker->data + 14, (int)marker->data_length - 14);
+        try {
+          parse_photoshop(&img, (char *)marker->data + 14, (int)marker->data_length - 14);
+        } catch (const std::exception &err) {
+          log_warn("Failed to parse Photoshop APP13 resource block: %s", err.what());
+        }
       }
     }
     marker = marker->next;
@@ -1011,7 +1007,7 @@ SipiImgInfo SipiIOJpeg::read_shape(const std::string &filepath)
     if (img.exif->getValByKey("Exif.Image.Orientation", ori)) { info.orientation = Orientation(ori); }
   }
   info.success = SipiImgInfo::DIMS;
-  cleanup_jpeg();
+  jpeg_destroy_decompress(&cinfo);
   // fd_guard closes the file descriptor automatically
   return info;// portions derived from IJG code */
 }
@@ -1069,12 +1065,13 @@ void SipiIOJpeg::write(SipiImage *img, const OutputSink &sink, const SipiCompres
   // FdGuard for outfile — constructed before setjmp. Its destructor runs
   // during the C++ stack unwinding from the throw SipiImageError after longjmp.
   FdGuard outfile_guard(-1);
-  // HTTP destination owned by the caller via unique_ptr. Declared before
-  // setjmp so destructors are on the normal C++ unwind path when we throw
-  // from the setjmp handler (longjmp would skip destructors of objects
+  // HTTP / file destination owned by the caller via unique_ptr. Declared
+  // before setjmp so destructors are on the normal C++ unwind path when we
+  // throw from the setjmp handler (longjmp would skip destructors of objects
   // constructed *between* setjmp and longjmp — these live outside that window).
   std::unique_ptr<SinkStream> sink_stream;
   std::unique_ptr<HtmlBuffer> html_buffer;
+  std::unique_ptr<FileBuffer> file_buffer;
   std::unique_ptr<jpeg_destination_mgr> destmgr;
   JSAMPROW row_pointer[1];
   int row_stride;
@@ -1117,7 +1114,9 @@ void SipiIOJpeg::write(SipiImage *img, const OutputSink &sink, const SipiCompres
         throw SipiImageError("Cannot open file \"" + filepath + "\"!");
       }
       outfile_guard.fd = outfile;
-      jpeg_file_dest(&cinfo, outfile);
+      file_buffer = std::make_unique<FileBuffer>(outfile);
+      destmgr = std::make_unique<jpeg_destination_mgr>();
+      jpeg_file_dest(&cinfo, file_buffer.get(), destmgr.get());
     }
   }
 

--- a/src/formats/SipiIOPng.cpp
+++ b/src/formats/SipiIOPng.cpp
@@ -47,25 +47,19 @@ static char xmp_tag[] = "XML:com.adobe.xmp";
 static char sipi_tag[] = "SIPI:io.sipi.essentials";
 
 //============== HELPER CLASS ==================
+// NOTE: pointers returned by next() are invalidated by the following next()
+// call; write the entry through them immediately (as add_zTXt/add_iTXt do).
 class PngTextPtr
 {
 private:
-  png_text *text_ptr;
-  unsigned int num_text;
-  unsigned int num_text_len;
+  std::vector<png_text> text;
 
 public:
-  inline PngTextPtr(unsigned int len = 16) : num_text_len(len)
-  {
-    num_text = 0;
-    text_ptr = new png_text[num_text_len];
-  };
+  inline PngTextPtr(unsigned int len = 16) { text.reserve(len); };
 
-  inline ~PngTextPtr() { delete[] text_ptr; };
+  inline unsigned int num() const { return static_cast<unsigned int>(text.size()); };
 
-  inline unsigned int num() const { return num_text; };
-
-  inline png_text *ptr() { return text_ptr; };
+  inline png_text *ptr() { return text.data(); };
 
   png_text *next();
 
@@ -74,18 +68,7 @@ public:
   void add_iTXt(char *key, char *data, unsigned int len);
 };
 
-png_text *PngTextPtr::next()
-{
-  if (num_text < num_text_len) {
-    return &(text_ptr[num_text++]);
-  } else {
-    auto *tmpptr = new png_text[num_text_len + 16];
-    for (unsigned int i = 0; i < num_text_len; i++) tmpptr[i] = text_ptr[i];
-    delete[] text_ptr;
-    text_ptr = tmpptr;
-    return &(text_ptr[num_text++]);
-  }
-}
+png_text *PngTextPtr::next() { return &text.emplace_back(); }
 //=============================================
 
 void PngTextPtr::add_zTXt(char *key, char *data, unsigned int len)
@@ -135,33 +118,31 @@ bool SipiIOPng::read(SipiImage *img,
   ScalingQuality scaling_quality)
 {
   SIPI_ZONE_N("SipiIOPng::read");
-  FILE *infile;
   unsigned char header[PNG_BYTES_TO_CHECK];
   png_structp png_ptr;
   png_infop info_ptr;
 
   //
-  // open the input file
+  // open the input file. The unique_ptr is declared before the setjmp, so its
+  // destructor runs on the C++ unwind path when the handler below throws.
   //
-  if ((infile = fopen(filepath.c_str(), "rb")) == nullptr) { return FALSE; }
+  auto infile = std::unique_ptr<FILE, decltype(&fclose)>(fopen(filepath.c_str(), "rb"), fclose);
+  if (infile == nullptr) { return FALSE; }
 
   //
   // check header if we really have a PNG file...
   //
-  fread(header, 1, PNG_BYTES_TO_CHECK, infile);
+  fread(header, 1, PNG_BYTES_TO_CHECK, infile.get());
   if (png_sig_cmp(header, 0, PNG_BYTES_TO_CHECK) != 0) {
-    fclose(infile);
     return FALSE;// it's not a PNG file
   }
 
   if ((png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, (png_voidp) nullptr, sipi_error_fn, sipi_warning_fn))
       == nullptr) {
-    fclose(infile);
     throw SipiImageError("Error reading PNG file \"" + filepath + "\": Could not allocate memory for png_structp !");
   }
   if ((info_ptr = png_create_info_struct(png_ptr)) == nullptr) {
     png_destroy_read_struct(&png_ptr, nullptr, nullptr);
-    fclose(infile);
     throw SipiImageError("Error reading PNG file \"" + filepath + "\": Could not allocate memory for png_infop !");
   }
 
@@ -175,11 +156,10 @@ bool SipiIOPng::read(SipiImage *img,
     delete[] pixel_buffer_guard;
     delete[] row_pointers_guard;
     png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
-    fclose(infile);
     throw SipiImageError("PNG read failed for \"" + filepath + "\"");
   }
 
-  png_init_io(png_ptr, infile);
+  png_init_io(png_ptr, infile.get());
   png_set_sig_bytes(png_ptr, PNG_BYTES_TO_CHECK);
   png_read_info(png_ptr, info_ptr);
 
@@ -308,7 +288,7 @@ bool SipiIOPng::read(SipiImage *img,
   img->pixels = buffer;
 
   delete[] row_pointers;
-  fclose(infile);
+  infile.reset();
 
   if (region != nullptr) {// we just use the image.crop method
     (void)img->crop(region);
@@ -464,6 +444,10 @@ void SipiIOPng::write(SipiImage *img, const OutputSink &sink, const SipiCompress
   FILE *outfile = nullptr;
   png_structp png_ptr;
 
+  // Owns the output FILE for the file branch (stdout is never owned).
+  // Declared before the setjmp so the handler's throw unwinds it.
+  auto outfile_guard = std::unique_ptr<FILE, decltype(&fclose)>(nullptr, fclose);
+
   if (!(png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, nullptr, sipi_error_fn, sipi_warning_fn))) {
     throw SipiImageError("Error writing PNG file \"" + filepath + "\": png_create_write_struct failed !");
   }
@@ -485,19 +469,18 @@ void SipiIOPng::write(SipiImage *img, const OutputSink &sink, const SipiCompress
       png_free_data(png_ptr, nullptr, PNG_FREE_ALL, -1);
       throw SipiImageError("Error writing PNG file \"" + filepath + "\": Could not open output file!");
     }
+    outfile_guard.reset(outfile);
   }
 
   png_infop info_ptr;
   if (!(info_ptr = png_create_info_struct(png_ptr))) {
     png_free_data(png_ptr, nullptr, PNG_FREE_ALL, -1);
-    if (outfile != nullptr && outfile != stdout) fclose(outfile);
     throw SipiImageError("Error writing PNG file \"" + filepath + "\": png_create_info_struct !");
   }
 
   // setjmp error recovery for write — sipi_error_fn calls longjmp
   if (setjmp(png_jmpbuf(png_ptr))) {
     png_destroy_write_struct(&png_ptr, &info_ptr);
-    if (outfile != nullptr && outfile != stdout) fclose(outfile);
     if (http_ctx.client_aborted) {
       throw SipiImageClientAbortError("Client aborted HTTP response during PNG write");
     }
@@ -622,8 +605,6 @@ void SipiIOPng::write(SipiImage *img, const OutputSink &sink, const SipiCompress
 
   png_ptr = nullptr;
   info_ptr = nullptr;
-
-  if (outfile != nullptr && outfile != stdout) fclose(outfile);
 }
 
 }

--- a/src/formats/SipiIOTiff.cpp
+++ b/src/formats/SipiIOTiff.cpp
@@ -15,6 +15,7 @@
 #include <memory>
 #include <span>
 #include <string>
+#include <vector>
 
 #include <cerrno>
 
@@ -194,10 +195,9 @@ static void memTiffUnmapProc(thandle_t handle, tdata_t base, toff_t size) {}
 
 static void memTiffFree(MEMTIFF *memtif)
 {
-  if (memtif->data != nullptr) free(memtif->data);
-  memtif->data = nullptr;
-  if (memtif != nullptr) free(memtif);
-  memtif = nullptr;
+  if (memtif == nullptr) { return; }
+  free(memtif->data);
+  free(memtif);
 }
 /*===========================================================================*/
 }
@@ -327,16 +327,15 @@ static int exiftag_list_len = sizeof(exiftag_list) / sizeof(ExifTag_type);
 
 namespace Sipi {
 
-unsigned char *read_watermark(const std::string &wmfile, int &nx, int &ny, int &nc)
+std::vector<unsigned char> read_watermark(const std::string &wmfile, int &nx, int &ny, int &nc)
 {
-  TIFF *tif;
   int sll;
   unsigned short spp, bps, pmi, pc;
-  byte *wmbuf;
   nx = 0;
   ny = 0;
 
-  if (nullptr == (tif = TIFFOpen(wmfile.c_str(), "r"))) { return nullptr; }
+  std::unique_ptr<TIFF, decltype(&TIFFClose)> tif(TIFFOpen(wmfile.c_str(), "r"), TIFFClose);
+  if (tif == nullptr) { return {}; }
 
   // add EXIF tags to the set of tags that libtiff knows about
   // necessary if we want to set EXIFTAG_DATETIMEORIGINAL, for example
@@ -344,51 +343,44 @@ unsigned char *read_watermark(const std::string &wmfile, int &nx, int &ny, int &
   //_TIFFMergeFields(tif, exif_fields->fields, exif_fields->count);
 
 
-  if (TIFFGetField(tif, TIFFTAG_IMAGEWIDTH, &nx) == 0) {
-    TIFFClose(tif);
+  if (TIFFGetField(tif.get(), TIFFTAG_IMAGEWIDTH, &nx) == 0) {
     throw Sipi::SipiImageError("ERROR in read_watermark: TIFFGetField of TIFFTAG_IMAGEWIDTH failed: " + wmfile);
   }
 
-  if (TIFFGetField(tif, TIFFTAG_IMAGELENGTH, &ny) == 0) {
-    TIFFClose(tif);
+  if (TIFFGetField(tif.get(), TIFFTAG_IMAGELENGTH, &ny) == 0) {
     throw Sipi::SipiImageError("ERROR in read_watermark: TIFFGetField of TIFFTAG_IMAGELENGTH failed: " + wmfile);
   }
 
-  TIFF_GET_FIELD(tif, TIFFTAG_SAMPLESPERPIXEL, &spp, 1);
+  TIFF_GET_FIELD(tif.get(), TIFFTAG_SAMPLESPERPIXEL, &spp, 1);
 
-  TIFF_GET_FIELD(tif, TIFFTAG_BITSPERSAMPLE, &bps, 1);
+  TIFF_GET_FIELD(tif.get(), TIFFTAG_BITSPERSAMPLE, &bps, 1);
 
-  if (bps != 8) {
-    TIFFClose(tif);
-    throw Sipi::SipiImageError("ERROR in read_watermark: bps ≠ 8: " + wmfile);
-  }
+  if (bps != 8) { throw Sipi::SipiImageError("ERROR in read_watermark: bps ≠ 8: " + wmfile); }
 
-  TIFF_GET_FIELD(tif, TIFFTAG_PHOTOMETRIC, &pmi, PHOTOMETRIC_MINISBLACK);
-  TIFF_GET_FIELD(tif, TIFFTAG_PLANARCONFIG, &pc, PLANARCONFIG_CONTIG);
+  TIFF_GET_FIELD(tif.get(), TIFFTAG_PHOTOMETRIC, &pmi, PHOTOMETRIC_MINISBLACK);
+  TIFF_GET_FIELD(tif.get(), TIFFTAG_PLANARCONFIG, &pc, PLANARCONFIG_CONTIG);
 
   if (pc != PLANARCONFIG_CONTIG) {
-    TIFFClose(tif);
     throw Sipi::SipiImageError(
       "ERROR in read_watermark: Tag TIFFTAG_PLANARCONFIG is not PLANARCONFIG_CONTIG: " + wmfile);
   }
 
   sll = nx * spp * bps / 8;
 
+  std::vector<unsigned char> wmbuf;
   try {
-    wmbuf = new byte[ny * sll];
+    wmbuf.resize(static_cast<size_t>(ny) * sll);
   } catch (std::bad_alloc &ba) {
     throw Sipi::SipiImageError("ERROR in read_watermark: Could not allocate memory: ");// + ba.what());
   }
 
   for (int i = 0; i < ny; i++) {
-    if (TIFFReadScanline(tif, wmbuf + i * sll, i) == -1) {
-      delete[] wmbuf;
+    if (TIFFReadScanline(tif.get(), wmbuf.data() + i * sll, i) == -1) {
       throw Sipi::SipiImageError(
         "ERROR in read_watermark: TIFFReadScanline failed on scanline " + std::to_string(i) + " in file " + wmfile);
     }
   }
 
-  TIFFClose(tif);
   nc = spp;
 
   return wmbuf;
@@ -581,7 +573,6 @@ static std::vector<T> read_standard_data(TIFF *tif, int32_t roi_x, int32_t roi_y
       line = std::make_unique<T[]>(nx * nc);
       for (uint32_t i = roi_y; i < roi_y + roi_h; ++i) {
         if (TIFFReadScanline(tif, scanline.get(), i, 0) != 1) {
-          TIFFClose(tif);
           throw Sipi::SipiImageError("TIFFReadScanline failed on scanline " + std::to_string(i)
             + ", dimensions=" + std::to_string(nx) + "x" + std::to_string(ny)
             + ", channels=" + std::to_string(nc) + ", bps=" + std::to_string(bps));
@@ -616,7 +607,6 @@ static std::vector<T> read_standard_data(TIFF *tif, int32_t roi_x, int32_t roi_y
       for (uint32_t c = 0; c < nc; ++c) {
         for (uint32_t i = roi_y; i < roi_h; ++i) {
           if (TIFFReadScanline(tif, scanline.get(), i, c) == -1) {
-            TIFFClose(tif);
             throw Sipi::SipiImageError("TIFFReadScanline failed on scanline " + std::to_string(i)
               + ", dimensions=" + std::to_string(nx) + "x" + std::to_string(ny)
               + ", channels=" + std::to_string(nc) + ", bps=" + std::to_string(bps));
@@ -651,7 +641,6 @@ static std::vector<T> read_standard_data(TIFF *tif, int32_t roi_x, int32_t roi_y
       line = std::make_unique<T[]>(nx * nc);
       for (uint32_t i = 0; i < ny; ++i) {
         if (TIFFReadScanline(tif, scanline.get(), i, 0) != 1) {
-          TIFFClose(tif);
           throw Sipi::SipiImageError("TIFFReadScanline failed on scanline " + std::to_string(i)
             + ", dimensions=" + std::to_string(nx) + "x" + std::to_string(ny)
             + ", channels=" + std::to_string(nc) + ", bps=" + std::to_string(bps));
@@ -690,7 +679,6 @@ static std::vector<T> read_standard_data(TIFF *tif, int32_t roi_x, int32_t roi_y
       for (uint32_t c = 0; c < nc; ++c) {
         for (uint32_t i = 0; i < ny; ++i) {
           if (TIFFReadScanline(tif, scanline.get(), i, c) == -1) {
-            TIFFClose(tif);
             throw Sipi::SipiImageError("TIFFReadScanline failed on scanline " + std::to_string(i)
               + ", dimensions=" + std::to_string(nx) + "x" + std::to_string(ny)
               + ", channels=" + std::to_string(nc) + ", bps=" + std::to_string(bps));
@@ -811,7 +799,6 @@ static std::vector<T> read_tiled_data(TIFF *tif, int32_t roi_x, int32_t roi_y, u
   for (uint32_t ty = starttile_y; ty < endtile_y; ++ty) {
     for (uint32_t tx = starttile_x; tx < endtile_x; ++tx) {
       if (TIFFReadTile(tif, tilebuf.get(), tx * tile_width, ty * tile_length, 0, 0) < 0) {
-        TIFFClose(tif);
         throw Sipi::SipiImageError("TIFFReadTile failed on tile (" + std::to_string(tx) + ", " + std::to_string(ty) + ")"
           + ", dimensions=" + std::to_string(nx) + "x" + std::to_string(ny)
           + ", channels=" + std::to_string(nc) + ", bps=" + std::to_string(bps));
@@ -886,9 +873,10 @@ bool SipiIOTiff::read(SipiImage *img,
   ScalingQuality scaling_quality)
 {
   SIPI_ZONE_N("SipiIOTiff::read");
-  TIFF *tif;
+  std::unique_ptr<TIFF, decltype(&TIFFClose)> tif_guard(TIFFOpen(filepath.c_str(), "r"), TIFFClose);
 
-  if (nullptr != (tif = TIFFOpen(filepath.c_str(), "r"))) {
+  if (tif_guard != nullptr) {
+    TIFF *tif = tif_guard.get();
     TIFFSetErrorHandler(tiffError);
     TIFFSetWarningHandler(tiffWarning);
     TIFFSetField(tif, TIFFTAG_JPEGCOLORMODE, JPEGCOLORMODE_RGB);
@@ -901,13 +889,11 @@ bool SipiIOTiff::read(SipiImage *img,
     (void)TIFFSetWarningHandler(nullptr);
 
     if (TIFFGetField(tif, TIFFTAG_IMAGEWIDTH, &(img->nx)) == 0) {
-      TIFFClose(tif);
       std::string msg = "TIFFGetField of TIFFTAG_IMAGEWIDTH failed: " + filepath;
       throw Sipi::SipiImageError(msg);
     }
 
     if (TIFFGetField(tif, TIFFTAG_IMAGELENGTH, &(img->ny)) == 0) {
-      TIFFClose(tif);
       std::string msg = "TIFFGetField of TIFFTAG_IMAGELENGTH failed: " + filepath;
       throw Sipi::SipiImageError(msg);
     }
@@ -942,7 +928,6 @@ bool SipiIOTiff::read(SipiImage *img,
     if (img->photo == PhotometricInterpretation::PALETTE) {
       uint16_t *_rcm = nullptr, *_gcm = nullptr, *_bcm = nullptr;
       if (TIFFGetField(tif, TIFFTAG_COLORMAP, &_rcm, &_gcm, &_bcm) == 0) {
-        TIFFClose(tif);
         std::string msg = "TIFFGetField of TIFFTAG_COLORMAP failed: " + filepath;
         throw Sipi::SipiImageError(msg);
       }
@@ -1262,8 +1247,7 @@ bool SipiIOTiff::read(SipiImage *img,
         "Unsupported bits/sample (" + std::to_string(img->bps) + ") in file " + filepath);
     }
 
-    delete[] img->pixels;// free previous buffer if re-reading into same SipiImage
-    auto *inbuf = new uint8_t[ps * roi_w * roi_h * img->nc];
+    auto inbuf = std::make_unique<uint8_t[]>(ps * roi_w * roi_h * img->nc);
 
     if (img->bps <= 8) {
       std::vector<uint8_t> pixdata;
@@ -1274,7 +1258,7 @@ bool SipiIOTiff::read(SipiImage *img,
 
       img->bps = 8;
 
-      memcpy(inbuf, pixdata.data(), pixdata.size() * img->bps / 8);
+      memcpy(inbuf.get(), pixdata.data(), pixdata.size() * img->bps / 8);
     } else if (img->bps <= 16) {
       std::vector<uint16_t> pixdata;
       if (is_tiled)
@@ -1282,13 +1266,14 @@ bool SipiIOTiff::read(SipiImage *img,
       else
         pixdata = read_standard_data<uint16_t>(tif, roi_x, roi_y, roi_w, roi_h);
       img->bps = 16;
-      memcpy(inbuf, pixdata.data(), pixdata.size() * img->bps / 8);
+      memcpy(inbuf.get(), pixdata.data(), pixdata.size() * img->bps / 8);
     }
 
-    img->pixels = inbuf;
+    delete[] img->pixels;// free previous buffer if re-reading into same SipiImage
+    img->pixels = inbuf.release();
     img->nx = roi_w;
     img->ny = roi_h;
-    TIFFClose(tif);
+    tif_guard.reset();
 
     if (img->photo == PhotometricInterpretation::PALETTE) {
       //
@@ -1300,7 +1285,7 @@ bool SipiIOTiff::read(SipiImage *img,
         if (gcm[i] > cm_max) cm_max = gcm[i];
         if (bcm[i] > cm_max) cm_max = bcm[i];
       }
-      auto *dataptr = new uint8_t[3 * img->nx * img->ny];
+      auto dataptr = std::make_unique<uint8_t[]>(3 * img->nx * img->ny);
       if (cm_max <= 256) {// we have a colomap with entries form 0 - 255
         for (size_t i = 0; i < img->nx * img->ny; i++) {
           dataptr[3 * i] = (uint8_t)rcm[img->pixels[i]];
@@ -1315,8 +1300,7 @@ bool SipiIOTiff::read(SipiImage *img,
         }
       }
       delete[] img->pixels;
-      img->pixels = dataptr;
-      dataptr = nullptr;
+      img->pixels = dataptr.release();
       img->photo = PhotometricInterpretation::RGB;
       img->nc = 3;
     }
@@ -1625,28 +1609,33 @@ void SipiIOTiff::write(SipiImage *img, const OutputSink &sink, const SipiCompres
   const bool streaming = is_streaming_sink(sink);
   const std::string filepath = streaming ? std::string("<http response>") : std::get<FilePath>(sink).path;
 
-  TIFF *tif;
-  MEMTIFF *memtif = nullptr;
+  // Declared before tif_guard: TIFFClose flushes through the memTiff*Proc
+  // callbacks, so the MEMTIFF must outlive the TIFF handle.
+  std::unique_ptr<MEMTIFF, decltype(&memTiffFree)> memtif_guard(nullptr, &memTiffFree);
+  std::unique_ptr<TIFF, decltype(&TIFFClose)> tif_guard(nullptr, &TIFFClose);
   auto rowsperstrip = (uint32_t)-1;
   if (streaming || (filepath == "stdout:")) {
-    memtif = memTiffOpen();
-    tif = TIFFClientOpen("MEMTIFF",
+    memtif_guard.reset(memTiffOpen());
+    tif_guard.reset(TIFFClientOpen("MEMTIFF",
       "w",
-      (thandle_t)memtif,
+      (thandle_t)memtif_guard.get(),
       memTiffReadProc,
       memTiffWriteProc,
       memTiffSeekProc,
       memTiffCloseProc,
       memTiffSizeProc,
       memTiffMapProc,
-      memTiffUnmapProc);
+      memTiffUnmapProc));
+    if (tif_guard == nullptr) { throw Sipi::SipiImageError("TIFFClientOpen for in-memory TIFF failed!"); }
   } else {
-    if ((tif = TIFFOpen(filepath.c_str(), "w")) == nullptr) {
-      if (memtif != nullptr) memTiffFree(memtif);
+    tif_guard.reset(TIFFOpen(filepath.c_str(), "w"));
+    if (tif_guard == nullptr) {
       std::string msg = "TIFFopen of \"" + filepath + "\" failed!";
       throw Sipi::SipiImageError(msg);
     }
   }
+  TIFF *tif = tif_guard.get();
+  MEMTIFF *memtif = memtif_guard.get();
   TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, static_cast<int>(img->nx));
   TIFFSetField(tif, TIFFTAG_IMAGELENGTH, static_cast<int>(img->ny));
   TIFFSetField(tif, TIFFTAG_ORIENTATION, ORIENTATION_TOPLEFT);
@@ -1827,11 +1816,9 @@ void SipiIOTiff::write(SipiImage *img, const OutputSink &sink, const SipiCompres
   // TIFFCheckpointDirectory(tif);
   if (its_1_bit) {
     unsigned int sll;
-    unsigned char *buf = cvrt8BitTo1bit(*img, sll);
+    std::vector<unsigned char> buf = cvrt8BitTo1bit(*img, sll);
 
-    for (size_t i = 0; i < img->ny; i++) { TIFFWriteScanline(tif, buf + i * sll, (int)i, 0); }
-
-    delete[] buf;
+    for (size_t i = 0; i < img->ny; i++) { TIFFWriteScanline(tif, buf.data() + i * sll, (int)i, 0); }
   } else {
     if (!pyramid) {
       for (size_t i = 0; i < img->ny; i++) {
@@ -1860,7 +1847,8 @@ void SipiIOTiff::write(SipiImage *img, const OutputSink &sink, const SipiCompres
     TIFFWriteDirectory(tif);
     writeExif(img, tif);
   }
-  TIFFClose(tif);
+  // Close (and thereby flush) the TIFF before consuming the MEMTIFF buffer.
+  tif_guard.reset();
 
   if (memtif != nullptr) {
     if (!streaming && filepath == "stdout:") {
@@ -1877,15 +1865,11 @@ void SipiIOTiff::write(SipiImage *img, const OutputSink &sink, const SipiCompres
       // equivalent of the old OUTPUT_WRITE_FAIL abort signal.
       SinkStream stream{ sink };
       if (stream.write(memtif->data, memtif->flen) != 0) {
-        memTiffFree(memtif);
         throw Sipi::SipiImageClientAbortError("Client aborted HTTP response during TIFF write");
       }
     } else {
-      memTiffFree(memtif);
       throw Sipi::SipiImageError("Unknown output method: " + filepath + " !");
     }
-
-    memTiffFree(memtif);
   }
 }
 //============================================================================
@@ -2357,7 +2341,7 @@ void SipiIOTiff::separateToContig(SipiImage *img, unsigned int sll)
 // code (img->bps was already 8 by the time those call sites executed).
 //============================================================================
 
-unsigned char *SipiIOTiff::cvrt8BitTo1bit(const SipiImage &img, unsigned int &sll)
+std::vector<unsigned char> SipiIOTiff::cvrt8BitTo1bit(const SipiImage &img, unsigned int &sll)
 {
   static unsigned char mask[8] = { 128, 64, 32, 16, 8, 4, 2, 1 };
 
@@ -2373,21 +2357,21 @@ unsigned char *SipiIOTiff::cvrt8BitTo1bit(const SipiImage &img, unsigned int &sl
   }
 
   sll = (img.nx + 7) / 8;
-  unsigned char *outbuf = new unsigned char[sll * img.ny];
 
   if (img.photo == PhotometricInterpretation::MINISBLACK) {
-    memset(outbuf, 0L, sll * img.ny);
+    std::vector<unsigned char> outbuf(sll * img.ny, 0x00);
     for (y = 0; y < img.ny; y++) {
       for (x = 0; x < img.nx; x++) {
         outbuf[y * sll + (x / 8)] |= (img.pixels[y * img.nx + x] > 128) ? mask[x % 8] : !mask[x % 8];
       }
     }
-  } else {// must be MINISWHITE
-    memset(outbuf, -1L, sll * img.ny);
-    for (y = 0; y < img.ny; y++) {
-      for (x = 0; x < img.nx; x++) {
-        outbuf[y * sll + (x / 8)] |= (img.pixels[y * img.nx + x] > 128) ? !mask[x % 8] : mask[x % 8];
-      }
+    return outbuf;
+  }
+  // must be MINISWHITE
+  std::vector<unsigned char> outbuf(sll * img.ny, 0xff);
+  for (y = 0; y < img.ny; y++) {
+    for (x = 0; x < img.nx; x++) {
+      outbuf[y * sll + (x / 8)] |= (img.pixels[y * img.nx + x] > 128) ? !mask[x % 8] : mask[x % 8];
     }
   }
   return outbuf;

--- a/src/formats/SipiIOTiff.h
+++ b/src/formats/SipiIOTiff.h
@@ -10,6 +10,7 @@
 #define __sipi_io_tiff_h
 
 #include <string>
+#include <vector>
 
 #include "tiff.h"
 #include "tiffio.h"
@@ -19,7 +20,7 @@
 
 namespace Sipi {
 
-unsigned char *read_watermark(const std::string &wmfile, int &nx, int &ny, int &nc);
+std::vector<unsigned char> read_watermark(const std::string &wmfile, int &nx, int &ny, int &nc);
 
 /*! Class which implements the TIFF-reader/writer */
 class SipiIOTiff : public SipiIO
@@ -66,9 +67,9 @@ private:
    *
    * \param[in] img Reference to SipiImage instance
    * \param[out] sll Scan line lengt
-   * \returns Buffer of 1-bit data (padded to bytes). NOTE: This buffer has to be deleted by the caller!
+   * \returns Buffer of 1-bit data (padded to bytes)
    */
-  unsigned char *cvrt8BitTo1bit(const SipiImage &img, unsigned int &sll);
+  std::vector<unsigned char> cvrt8BitTo1bit(const SipiImage &img, unsigned int &sll);
 
 public:
   virtual ~SipiIOTiff(){};


### PR DESCRIPTION
## Motivation
Phase 3 of the RAII refactoring plan. All four codec handlers leaked handles and buffers on their error paths: TIFF leaked the open handle and decode buffer on throw (and left `img->pixels` dangling), Kakadu teardown was hand-duplicated across seven paths and still missed the LUTs and stripe buffers, a JPEG `longjmp` during file writes leaked the custom destination manager, and PNG's `PngTextPtr` was a latent double-free. One commit per codec.

## Summary
- Corrupt/truncated images and client aborts no longer leak codec handles, decode buffers, or Kakadu machinery.
- A TIFF decode failure no longer leaves the image pointing at freed pixels (previous buffer was freed before the fallible decode ran).
- No IIIF-visible behavior change: approval goldens and the differential parity gate pass unchanged.

## Key Changes
### TIFF
`unique_ptr<TIFF,&TIFFClose>` for `read`/`write`/`read_watermark` (the `read_shape` pattern); decode buffer released into the image only after decode succeeds; helpers no longer close the caller's handle before throwing; `MEMTIFF` owned by a guard ordered to stay alive through the flush-on-close; `read_watermark`/`cvrt8BitTo1bit` return `std::vector`; `memTiffFree` null-check fixed; `TIFFClientOpen` failure now checked.

### JPEG 2000 (Kakadu)
A `KduReadTeardown` guard destroys codestream → input → JPX exactly once on every exit path of `read` and `read_shape` (which previously had *no* guard around `codestream.create`); LUTs and 16-bit write arrays are `std::vector`s; stripe buffers release into the image only after `pull_stripe` succeeds; the `write` catch destroys the codestream but deliberately does not close the half-written JPX target (that raises a second Kakadu error).

### JPEG
`FileBuffer` + source/destination managers are now caller-owned stack objects declared before the `setjmp` (mirroring the existing `HtmlBuffer` pattern), so the C++ unwind path frees them on every outcome and the `term_*` callbacks only flush; the read fd moved into `FdGuard`; `read_shape` wraps `parse_photoshop` like the main read path instead of throwing past the live decompress struct.

### PNG
`PngTextPtr` backed by `std::vector` (was: raw owning array + user dtor + default copies); `FILE*` in read/write held by `unique_ptr` declared before the `setjmp` (stdout never owned).

## Gotchas
- setjmp/longjmp discipline is preserved, not fought: RAII objects live *before* the `setjmp`; resources acquired inside the longjmp window stay raw-pointer-freed-in-handler (PNG pixel buffers, JPEG ICC realloc guard). Don't "fix" those into destructors — longjmp skips them.
- Kakadu error path: never close a `jpx_target` whose codestreams are incomplete.

## Benchmarks (hot-path gate)
`just bench decode` / `just bench encode` on the same `-c opt` build and machine, baseline from `origin/main`:
- decode: OVERALL_GEOMEAN +0.3 % (noise)
- encode: OVERALL_GEOMEAN +2.9 % wall / +0.6 % CPU; the one flagged series (`BM_EncodeTiff`, 25 ms) was re-run with 7 repetitions per side: U-test p=1.00 (wall) / p=0.10 (CPU), median shift inside the wall-time CV (8–12 % — it writes 117 MB through the page cache). Verdict per docs/src/development/benchmarking.md: noise, no regression.

## Test Plan
- [x] `just bazel-build`
- [x] `just bazel-test-unit` (25/25)
- [x] `just bazel-test-approval` (byte-identical output)
- [x] e2e suite 27/27
- [x] `just bazel-test-differential` (parity gate green)
- [x] `just bench` + `bench-compare` decode/encode (no significant delta)

🤖 Generated with [Claude Code](https://claude.com/claude-code)