### PR TITLE
refactor(image): own the pixel buffer as std::vector

### DIFF
--- a/src/SipiImage.cpp
+++ b/src/SipiImage.cpp
@@ -48,7 +48,6 @@ SipiImage::SipiImage()
   bps = 0;
   photo = PhotometricInterpretation::INVALID;
   orientation = TOPLEFT;
-  pixels = nullptr;
   xmp = nullptr;
   icc = nullptr;
   iptc = nullptr;
@@ -85,10 +84,7 @@ SipiImage::SipiImage(const SipiImage &img_p)
   }
   }
 
-  if (bufsiz > 0 && img_p.pixels != nullptr) {
-    pixels = new byte[bufsiz];
-    memcpy(pixels, img_p.pixels, bufsiz);
-  }
+  if (bufsiz > 0 && !img_p.pixels.empty()) { pixels = img_p.pixels; }
 
   // R11: Null-check metadata before deep copy
   if (img_p.xmp) xmp = std::make_shared<Xmp>(*img_p.xmp);
@@ -103,14 +99,12 @@ SipiImage::SipiImage(const SipiImage &img_p)
 //============================================================================
 
 SipiImage::SipiImage(SipiImage &&other) noexcept
-  : nx(other.nx), ny(other.ny), nc(other.nc), bps(other.bps),
-    es(std::move(other.es)), orientation(other.orientation), photo(other.photo),
-    pixels(other.pixels), xmp(std::move(other.xmp)), icc(std::move(other.icc)),
-    iptc(std::move(other.iptc)), exif(std::move(other.exif)),
-    emdata(std::move(other.emdata)),
+  : nx(other.nx), ny(other.ny), nc(other.nc), bps(other.bps), es(std::move(other.es)), orientation(other.orientation),
+    photo(other.photo), pixels(std::move(other.pixels)), xmp(std::move(other.xmp)), icc(std::move(other.icc)),
+    iptc(std::move(other.iptc)), exif(std::move(other.exif)), emdata(std::move(other.emdata)),
     skip_metadata(other.skip_metadata), app14_transform(other.app14_transform)
 {
-  other.pixels = nullptr;
+  other.pixels.clear();
   other.nx = 0;
   other.ny = 0;
   other.app14_transform = 255;
@@ -152,7 +146,7 @@ SipiImage::SipiImage(size_t nx_p, size_t ny_p, size_t nc_p, size_t bps_p, Photom
   }
 
   if (bufsiz > 0) {
-    pixels = new byte[bufsiz];
+    pixels.resize(bufsiz);
   } else {
     throw SipiImageError("Image has no pixel content (dimensions: " + std::to_string(nx) + "x" + std::to_string(ny) + ", bps: " + std::to_string(bps) + " — file may be corrupt or empty)");
   }
@@ -166,16 +160,10 @@ SipiImage::SipiImage(size_t nx_p, size_t ny_p, size_t nc_p, size_t bps_p, Photom
 
 //============================================================================
 
-SipiImage::~SipiImage() { delete[] pixels; }
-//============================================================================
-
-
 SipiImage &SipiImage::operator=(const SipiImage &img_p)
 {
   if (this != &img_p) {
-    // R12: Free old buffer before allocating new
-    delete[] pixels;
-    pixels = nullptr;
+    pixels.clear();
 
     nx = img_p.nx;
     ny = img_p.ny;
@@ -206,10 +194,7 @@ SipiImage &SipiImage::operator=(const SipiImage &img_p)
     }
     }
 
-    if (bufsiz > 0 && img_p.pixels != nullptr) {
-      pixels = new byte[bufsiz];
-      memcpy(pixels, img_p.pixels, bufsiz);
-    }
+    if (bufsiz > 0 && !img_p.pixels.empty()) { pixels = img_p.pixels; }
 
     // R11: Null-check metadata before deep copy, reset if source is null
     if (img_p.xmp)  xmp  = std::make_shared<Xmp>(*img_p.xmp);   else xmp.reset();
@@ -226,8 +211,6 @@ SipiImage &SipiImage::operator=(const SipiImage &img_p)
 SipiImage &SipiImage::operator=(SipiImage &&other) noexcept
 {
   if (this != &other) {
-    delete[] pixels;
-
     nx = other.nx;
     ny = other.ny;
     nc = other.nc;
@@ -235,7 +218,7 @@ SipiImage &SipiImage::operator=(SipiImage &&other) noexcept
     es = std::move(other.es);
     orientation = other.orientation;
     photo = other.photo;
-    pixels = other.pixels;
+    pixels = std::move(other.pixels);
     xmp = std::move(other.xmp);
     icc = std::move(other.icc);
     iptc = std::move(other.iptc);
@@ -244,7 +227,7 @@ SipiImage &SipiImage::operator=(SipiImage &&other) noexcept
     skip_metadata = other.skip_metadata;
     app14_transform = other.app14_transform;
 
-    other.pixels = nullptr;
+    other.pixels.clear();
     other.nx = 0;
     other.ny = 0;
     other.app14_transform = 255;
@@ -317,7 +300,7 @@ void SipiImage::readSource(const std::string &filepath,
   // abort. Active deliberate validation lives in `sipi verify service-file`.
   if (emdata.is_set()) {
     shttps::Hash internal_hash(emdata.fields().hash_type);
-    internal_hash.add_data(pixels, nx * ny * nc * bps / 8);
+    internal_hash.add_data(pixels.data(), nx * ny * nc * bps / 8);
     std::string checksum = internal_hash.hash();
     if (checksum != Essentials::to_hex(emdata.fields().data_chksum)) {
       log_err("Essentials data_chksum mismatch in %s; possible corruption", filepath.c_str());
@@ -344,7 +327,7 @@ void SipiImage::readSource(const std::string &filepath,
 std::vector<std::byte> SipiImage::compute_pixel_hash(shttps::HashType type) const
 {
   shttps::Hash digest(type);
-  if (pixels != nullptr) { digest.add_data(pixels, nx * ny * nc * bps / 8); }
+  if (!pixels.empty()) { digest.add_data(pixels.data(), nx * ny * nc * bps / 8); }
   return Essentials::from_hex(digest.hash());
 }
 
@@ -417,8 +400,8 @@ void SipiImage::write(const std::string &ftype, const std::string &filepath, con
 void SipiImage::convertYCC2RGB()
 {
   if (bps == 8) {
-    byte *inbuf = pixels;
-    byte *outbuf = new byte[(size_t)nc * (size_t)nx * (size_t)ny];
+    byte *inbuf = pixels.data();
+    std::vector<byte> outbuf((size_t)nc * (size_t)nx * (size_t)ny);
 
     for (size_t j = 0; j < ny; j++) {
       for (size_t i = 0; i < nx; i++) {
@@ -439,12 +422,12 @@ void SipiImage::convertYCC2RGB()
       }
     }
 
-    pixels = outbuf;
-    delete[] inbuf;
+    pixels = std::move(outbuf);
   } else if (bps == 16) {
-    word *inbuf = (word *)pixels;
+    word *inbuf = (word *)pixels.data();
     size_t nnc = nc - 1;
-    auto *outbuf = new unsigned short[nnc * nx * ny];
+    std::vector<byte> outbuf_v(2 * (nnc * nx * ny));
+    word *outbuf = (word *)outbuf_v.data();
 
     for (size_t j = 0; j < ny; j++) {
       for (size_t i = 0; i < nx; i++) {
@@ -465,8 +448,7 @@ void SipiImage::convertYCC2RGB()
       }
     }
 
-    pixels = (byte *)outbuf;
-    delete[] inbuf;
+    pixels = std::move(outbuf_v);
   } else {
     const std::string msg = "Bits per sample is not supported for operation: " + std::to_string(bps);
     throw SipiImageError(msg);
@@ -531,11 +513,10 @@ void SipiImage::convertToIcc(const Icc &target_icc_p, int new_bps)
       + ", target_profile_type=" + std::to_string(static_cast<int>(target_icc_p.getProfileType())));
   }
 
-  auto outbuf = std::make_unique<byte[]>(nx * ny * nnc * new_bps / 8);
-  cmsDoTransform(hTransform.get(), pixels, outbuf.get(), nx * ny);
+  std::vector<byte> outbuf(nx * ny * nnc * new_bps / 8);
+  cmsDoTransform(hTransform.get(), pixels.data(), outbuf.data(), nx * ny);
   icc = std::make_shared<Icc>(target_icc_p);
-  delete[] pixels;
-  pixels = outbuf.release();
+  pixels = std::move(outbuf);
   nc = nnc;
   bps = new_bps;
 
@@ -673,9 +654,10 @@ void SipiImage::removeChannel(const unsigned int channel, const bool force_gray_
    *   channel is 0.
    */
   if (bps == _8bps) {
-    byte *original_pixels = pixels;
+    const byte *original_pixels = pixels.data();
     const size_t new_nc = nc - 1;
-    auto *changed_pixels = new byte[new_nc * nx * ny];
+    std::vector<byte> changed_v(new_nc * nx * ny);
+    byte *changed_pixels = changed_v.data();
 
     // only force gray values if the image is RGB and the alpha channel is the channel to be removed
     const bool force_gray_values = force_gray_alpha && is_alpha_channel && is_rgb_image;
@@ -685,17 +667,16 @@ void SipiImage::removeChannel(const unsigned int channel, const bool force_gray_
       purge_channel_pixels(original_pixels, changed_pixels, nx, ny, nc, channel, new_nc);
     }
 
-    pixels = changed_pixels;
-    delete[] original_pixels;
+    pixels = std::move(changed_v);
   } else if (bps == _16bps) {
-    auto *original_pixels = reinterpret_cast<unsigned short *>(pixels);
+    const auto *original_pixels = reinterpret_cast<const unsigned short *>(pixels.data());
     size_t new_nc = nc - 1;
-    auto *changed_pixels = new unsigned short[new_nc * nx * ny];
+    std::vector<byte> changed_v(2 * new_nc * nx * ny);
+    auto *changed_pixels = reinterpret_cast<unsigned short *>(changed_v.data());
 
     purge_channel_pixels(original_pixels, changed_pixels, nx, ny, nc, channel, new_nc);
 
-    pixels = reinterpret_cast<unsigned char *>(changed_pixels);
-    delete[] original_pixels;
+    pixels = std::move(changed_v);
   } else {
     const std::string msg = "Bits per sample is not supported for operation: " + std::to_string(bps);
     throw SipiImageError(msg);
@@ -745,8 +726,8 @@ bool SipiImage::crop(int x, int y, size_t width, size_t height)
   }
 
   if (bps == 8) {
-    byte *inbuf = pixels;
-    byte *outbuf = new byte[width * height * nc];
+    byte *inbuf = pixels.data();
+    std::vector<byte> outbuf(width * height * nc);
 
     for (size_t j = 0; j < height; j++) {
       for (size_t i = 0; i < width; i++) {
@@ -754,11 +735,11 @@ bool SipiImage::crop(int x, int y, size_t width, size_t height)
       }
     }
 
-    pixels = outbuf;
-    delete[] inbuf;
+    pixels = std::move(outbuf);
   } else if (bps == 16) {
-    word *inbuf = (word *)pixels;
-    word *outbuf = new word[width * height * nc];
+    word *inbuf = (word *)pixels.data();
+    std::vector<byte> outbuf_v(2 * (width * height * nc));
+    word *outbuf = (word *)outbuf_v.data();
 
     for (size_t j = 0; j < height; j++) {
       for (size_t i = 0; i < width; i++) {
@@ -766,8 +747,7 @@ bool SipiImage::crop(int x, int y, size_t width, size_t height)
       }
     }
 
-    pixels = (byte *)outbuf;
-    delete[] inbuf;
+    pixels = std::move(outbuf_v);
   } else {
     // clean up and throw exception
   }
@@ -791,8 +771,8 @@ bool SipiImage::crop(const std::shared_ptr<SipiRegion> &region)
   region->crop_coords(nx, ny, x, y, width, height);
 
   if (bps == 8) {
-    byte *inbuf = pixels;
-    byte *outbuf = new byte[width * height * nc];
+    byte *inbuf = pixels.data();
+    std::vector<byte> outbuf(width * height * nc);
 
     for (size_t j = 0; j < height; j++) {
       for (size_t i = 0; i < width; i++) {
@@ -800,11 +780,11 @@ bool SipiImage::crop(const std::shared_ptr<SipiRegion> &region)
       }
     }
 
-    pixels = outbuf;
-    delete[] inbuf;
+    pixels = std::move(outbuf);
   } else if (bps == 16) {
-    word *inbuf = (word *)pixels;
-    word *outbuf = new word[width * height * nc];
+    word *inbuf = (word *)pixels.data();
+    std::vector<byte> outbuf_v(2 * (width * height * nc));
+    word *outbuf = (word *)outbuf_v.data();
 
     for (size_t j = 0; j < height; j++) {
       for (size_t i = 0; i < width; i++) {
@@ -812,8 +792,7 @@ bool SipiImage::crop(const std::shared_ptr<SipiRegion> &region)
       }
     }
 
-    pixels = (byte *)outbuf;
-    delete[] inbuf;
+    pixels = std::move(outbuf_v);
   } else {
     // clean up and throw exception
   }
@@ -924,25 +903,24 @@ bool SipiImage::scaleFast(size_t nnx, size_t nny)
   for (size_t i = 0; i < nny; i++) { ylut[i] = (size_t)lround(i * (ny - 1) / (nny - 1)); }
 
   if (bps == 8) {
-    byte *inbuf = pixels;
-    byte *outbuf = new byte[nnx * nny * nc];
+    byte *inbuf = pixels.data();
+    std::vector<byte> outbuf(nnx * nny * nc);
     for (size_t y = 0; y < nny; y++) {
       for (size_t x = 0; x < nnx; x++) {
         for (size_t k = 0; k < nc; k++) { outbuf[nc * (y * nnx + x) + k] = inbuf[nc * (ylut[y] * nx + xlut[x]) + k]; }
       }
     }
-    pixels = outbuf;
-    delete[] inbuf;
+    pixels = std::move(outbuf);
   } else if (bps == 16) {
-    word *inbuf = (word *)pixels;
-    word *outbuf = new word[nnx * nny * nc];
+    word *inbuf = (word *)pixels.data();
+    std::vector<byte> outbuf_v(2 * (nnx * nny * nc));
+    word *outbuf = (word *)outbuf_v.data();
     for (size_t y = 0; y < nny; y++) {
       for (size_t x = 0; x < nnx; x++) {
         for (size_t k = 0; k < nc; k++) { outbuf[nc * (y * nnx + x) + k] = inbuf[nc * (ylut[y] * nx + xlut[x]) + k]; }
       }
     }
-    pixels = (byte *)outbuf;
-    delete[] inbuf;
+    pixels = std::move(outbuf_v);
   } else {
     return false;
   }
@@ -970,8 +948,8 @@ bool SipiImage::scaleMedium(size_t nnx, size_t nny)
   for (size_t j = 0; j < nny; j++) { ylut[j] = (double)(j * (ny - 1)) / (double)(nny - 1); }
 
   if (bps == 8) {
-    byte *inbuf = pixels;
-    byte *outbuf = new byte[nnx * nny * nc];
+    byte *inbuf = pixels.data();
+    std::vector<byte> outbuf(nnx * nny * nc);
     double rx, ry;
 
     for (size_t j = 0; j < nny; j++) {
@@ -982,11 +960,11 @@ bool SipiImage::scaleMedium(size_t nnx, size_t nny)
       }
     }
 
-    pixels = outbuf;
-    delete[] inbuf;
+    pixels = std::move(outbuf);
   } else if (bps == 16) {
-    word *inbuf = (word *)pixels;
-    word *outbuf = new word[nnx * nny * nc];
+    word *inbuf = (word *)pixels.data();
+    std::vector<byte> outbuf_v(2 * (nnx * nny * nc));
+    word *outbuf = (word *)outbuf_v.data();
     double rx, ry;
 
     for (size_t j = 0; j < nny; j++) {
@@ -997,8 +975,7 @@ bool SipiImage::scaleMedium(size_t nnx, size_t nny)
       }
     }
 
-    pixels = (byte *)outbuf;
-    delete[] inbuf;
+    pixels = std::move(outbuf_v);
   } else {
     return false;
   }
@@ -1049,8 +1026,8 @@ bool SipiImage::scale(size_t nnx, size_t nny)
   for (size_t j = 0; j < nnny; j++) { ylut[j] = (double)(j * (ny - 1)) / (double)(nnny - 1); }
 
   if (bps == 8) {
-    byte *inbuf = pixels;
-    byte *outbuf = new byte[nnnx * nnny * nc];
+    byte *inbuf = pixels.data();
+    std::vector<byte> outbuf(nnnx * nnny * nc);
     double rx, ry;
 
     for (size_t j = 0; j < nnny; j++) {
@@ -1061,11 +1038,11 @@ bool SipiImage::scale(size_t nnx, size_t nny)
       }
     }
 
-    pixels = outbuf;
-    delete[] inbuf;
+    pixels = std::move(outbuf);
   } else if (bps == 16) {
-    word *inbuf = (word *)pixels;
-    word *outbuf = new word[nnnx * nnny * nc];
+    word *inbuf = (word *)pixels.data();
+    std::vector<byte> outbuf_v(2 * (nnnx * nnny * nc));
+    word *outbuf = (word *)outbuf_v.data();
     double rx, ry;
 
     for (size_t j = 0; j < nnny; j++) {
@@ -1076,8 +1053,7 @@ bool SipiImage::scale(size_t nnx, size_t nny)
       }
     }
 
-    pixels = (byte *)outbuf;
-    delete[] inbuf;
+    pixels = std::move(outbuf_v);
   } else {
     return false;
     // clean up and throw exception
@@ -1088,8 +1064,8 @@ bool SipiImage::scale(size_t nnx, size_t nny)
   //
   if ((iix > 1) || (iiy > 1)) {
     if (bps == 8) {
-      byte *inbuf = pixels;
-      byte *outbuf = new byte[nnx * nny * nc];
+      byte *inbuf = pixels.data();
+      std::vector<byte> outbuf(nnx * nny * nc);
       for (size_t j = 0; j < nny; j++) {
         for (size_t i = 0; i < nnx; i++) {
           for (size_t k = 0; k < nc; k++) {
@@ -1103,11 +1079,11 @@ bool SipiImage::scale(size_t nnx, size_t nny)
           }
         }
       }
-      pixels = outbuf;
-      delete[] inbuf;
+      pixels = std::move(outbuf);
     } else if (bps == 16) {
-      word *inbuf = (word *)pixels;
-      word *outbuf = new word[nnx * nny * nc];
+      word *inbuf = (word *)pixels.data();
+      std::vector<byte> outbuf_v(2 * (nnx * nny * nc));
+      word *outbuf = (word *)outbuf_v.data();
 
       for (size_t j = 0; j < nny; j++) {
         for (size_t i = 0; i < nnx; i++) {
@@ -1123,8 +1099,7 @@ bool SipiImage::scale(size_t nnx, size_t nny)
         }
       }
 
-      pixels = (byte *)outbuf;
-      delete[] inbuf;
+      pixels = std::move(outbuf_v);
     }
   }
 
@@ -1141,19 +1116,19 @@ bool SipiImage::rotate(float angle, bool mirror)
   SIPI_ZONE_N("SipiImage::rotate");
   if (mirror) {
     if (bps == 8) {
-      byte *inbuf = (byte *)pixels;
-      byte *outbuf = new byte[nx * ny * nc];
+      byte *inbuf = pixels.data();
+      std::vector<byte> outbuf(nx * ny * nc);
       for (size_t j = 0; j < ny; j++) {
         for (size_t i = 0; i < nx; i++) {
           for (size_t k = 0; k < nc; k++) { outbuf[nc * (j * nx + i) + k] = inbuf[nc * (j * nx + (nx - i - 1)) + k]; }
         }
       }
 
-      pixels = outbuf;
-      delete[] inbuf;
+      pixels = std::move(outbuf);
     } else if (bps == 16) {
-      word *inbuf = (word *)pixels;
-      word *outbuf = new word[nx * ny * nc];
+      word *inbuf = (word *)pixels.data();
+      std::vector<byte> outbuf_v(2 * (nx * ny * nc));
+      word *outbuf = (word *)outbuf_v.data();
 
       for (size_t j = 0; j < ny; j++) {
         for (size_t i = 0; i < nx; i++) {
@@ -1161,8 +1136,7 @@ bool SipiImage::rotate(float angle, bool mirror)
         }
       }
 
-      pixels = (byte *)outbuf;
-      delete[] inbuf;
+      pixels = std::move(outbuf_v);
     } else {
       return false;
       // clean up and throw exception
@@ -1187,8 +1161,8 @@ bool SipiImage::rotate(float angle, bool mirror)
     size_t nny = nx;
 
     if (bps == 8) {
-      byte *inbuf = (byte *)pixels;
-      byte *outbuf = new byte[nx * ny * nc];
+      byte *inbuf = pixels.data();
+      std::vector<byte> outbuf(nx * ny * nc);
 
       for (size_t j = 0; j < nny; j++) {
         for (size_t i = 0; i < nnx; i++) {
@@ -1196,11 +1170,11 @@ bool SipiImage::rotate(float angle, bool mirror)
         }
       }
 
-      pixels = outbuf;
-      delete[] inbuf;
+      pixels = std::move(outbuf);
     } else if (bps == 16) {
-      word *inbuf = (word *)pixels;
-      word *outbuf = new word[nx * ny * nc];
+      word *inbuf = (word *)pixels.data();
+      std::vector<byte> outbuf_v(2 * (nx * ny * nc));
+      word *outbuf = (word *)outbuf_v.data();
 
       for (size_t j = 0; j < nny; j++) {
         for (size_t i = 0; i < nnx; i++) {
@@ -1208,8 +1182,7 @@ bool SipiImage::rotate(float angle, bool mirror)
         }
       }
 
-      pixels = (byte *)outbuf;
-      delete[] inbuf;
+      pixels = std::move(outbuf_v);
     }
 
     nx = nnx;
@@ -1223,8 +1196,8 @@ bool SipiImage::rotate(float angle, bool mirror)
     size_t nnx = nx;
     size_t nny = ny;
     if (bps == 8) {
-      byte *inbuf = (byte *)pixels;
-      byte *outbuf = new byte[nx * ny * nc];
+      byte *inbuf = pixels.data();
+      std::vector<byte> outbuf(nx * ny * nc);
 
       for (size_t j = 0; j < nny; j++) {
         for (size_t i = 0; i < nnx; i++) {
@@ -1234,11 +1207,11 @@ bool SipiImage::rotate(float angle, bool mirror)
         }
       }
 
-      pixels = outbuf;
-      delete[] inbuf;
+      pixels = std::move(outbuf);
     } else if (bps == 16) {
-      word *inbuf = (word *)pixels;
-      word *outbuf = new word[nx * ny * nc];
+      word *inbuf = (word *)pixels.data();
+      std::vector<byte> outbuf_v(2 * (nx * ny * nc));
+      word *outbuf = (word *)outbuf_v.data();
 
       for (size_t j = 0; j < nny; j++) {
         for (size_t i = 0; i < nnx; i++) {
@@ -1248,8 +1221,7 @@ bool SipiImage::rotate(float angle, bool mirror)
         }
       }
 
-      pixels = (byte *)outbuf;
-      delete[] inbuf;
+      pixels = std::move(outbuf_v);
     }
     nx = nnx;
     ny = nny;
@@ -1266,26 +1238,25 @@ bool SipiImage::rotate(float angle, bool mirror)
     size_t nny = nx;
 
     if (bps == 8) {
-      byte *inbuf = (byte *)pixels;
-      byte *outbuf = new byte[nx * ny * nc];
+      byte *inbuf = pixels.data();
+      std::vector<byte> outbuf(nx * ny * nc);
       for (size_t j = 0; j < nny; j++) {
         for (size_t i = 0; i < nnx; i++) {
           for (size_t k = 0; k < nc; k++) { outbuf[nc * (j * nnx + i) + k] = inbuf[nc * (i * nx + (nx - j - 1)) + k]; }
         }
       }
 
-      pixels = outbuf;
-      delete[] inbuf;
+      pixels = std::move(outbuf);
     } else if (bps == 16) {
-      word *inbuf = (word *)pixels;
-      word *outbuf = new word[nx * ny * nc];
+      word *inbuf = (word *)pixels.data();
+      std::vector<byte> outbuf_v(2 * (nx * ny * nc));
+      word *outbuf = (word *)outbuf_v.data();
       for (size_t j = 0; j < nny; j++) {
         for (size_t i = 0; i < nnx; i++) {
           for (size_t k = 0; k < nc; k++) { outbuf[nc * (j * nnx + i) + k] = inbuf[nc * (i * nx + (nx - j - 1)) + k]; }
         }
       }
-      pixels = (byte *)outbuf;
-      delete[] inbuf;
+      pixels = std::move(outbuf_v);
     }
 
     nx = nnx;
@@ -1320,8 +1291,8 @@ bool SipiImage::rotate(float angle, bool mirror)
     double ppty = pty * (double)nny / (double)ny;
 
     if (bps == 8) {
-      byte *inbuf = pixels;
-      byte *outbuf = new byte[nnx * nny * nc];
+      byte *inbuf = pixels.data();
+      std::vector<byte> outbuf(nnx * nny * nc);
       byte bg = 0;
 
       for (size_t j = 0; j < nny; j++) {
@@ -1337,11 +1308,11 @@ bool SipiImage::rotate(float angle, bool mirror)
         }
       }
 
-      pixels = outbuf;
-      delete[] inbuf;
+      pixels = std::move(outbuf);
     } else if (bps == 16) {
-      word *inbuf = (word *)pixels;
-      word *outbuf = new word[nnx * nny * nc];
+      word *inbuf = (word *)pixels.data();
+      std::vector<byte> outbuf_v(2 * (nnx * nny * nc));
+      word *outbuf = (word *)outbuf_v.data();
       word bg = 0;
 
       for (size_t j = 0; j < nny; j++) {
@@ -1357,8 +1328,7 @@ bool SipiImage::rotate(float angle, bool mirror)
         }
       }
 
-      pixels = (byte *)outbuf;
-      delete[] inbuf;
+      pixels = std::move(outbuf_v);
     }
     nx = nnx;
     ny = nny;
@@ -1404,7 +1374,7 @@ bool SipiImage::set_topleft()
 
 //============================================================================
 
-bool SipiImage::to8bps()
+void SipiImage::to8bps()
 {
   // little-endian architecture assumed
   //
@@ -1414,10 +1384,8 @@ bool SipiImage::to8bps()
   if (bps == 16) {
     // icc = NULL;
 
-    word *inbuf = (word *)pixels;
-    // byte *outbuf = new(std::nothrow) Sipi::byte[nc*nx*ny];
-    byte *outbuf = new (std::nothrow) byte[nc * nx * ny];
-    if (outbuf == nullptr) return false;
+    word *inbuf = (word *)pixels.data();
+    std::vector<byte> outbuf(nc * nx * ny);
     for (size_t j = 0; j < ny; j++) {
       for (size_t i = 0; i < nx; i++) {
         for (size_t k = 0; k < nc; k++) {
@@ -1427,17 +1395,15 @@ bool SipiImage::to8bps()
       }
     }
 
-    delete[] pixels;
-    pixels = outbuf;
+    pixels = std::move(outbuf);
     bps = 8;
   }
-  return true;
 }
 
 //============================================================================
 
 
-bool SipiImage::toBitonal()
+void SipiImage::toBitonal()
 {
   SIPI_ZONE_N("SipiImage::toBitonal");
   if ((photo != PhotometricInterpretation::MINISBLACK) && (photo != PhotometricInterpretation::MINISWHITE)) {
@@ -1450,12 +1416,10 @@ bool SipiImage::toBitonal()
     if (!doit && (pixels[i] != 0) && (pixels[i] != 255)) doit = true;
   }
 
-  if (!doit) return true;// we have to do nothing, it's already bitonal
+  if (!doit) return;// we have to do nothing, it's already bitonal
 
   // must be signed!! Error propagation my result in values < 0 or > 255
-  auto *outbuf = new (std::nothrow) short[nx * ny];
-
-  if (outbuf == nullptr) return false;// TODO: throw an error with a reasonable error message
+  std::vector<short> outbuf(nx * ny);
 
   for (size_t i = 0; i < nx * ny; i++) {
     outbuf[i] = pixels[i];// copy buffer
@@ -1474,8 +1438,6 @@ bool SipiImage::toBitonal()
   }
 
   for (size_t i = 0; i < nx * ny; i++) pixels[i] = outbuf[i];
-  delete[] outbuf;
-  return true;
 }
 
 //============================================================================
@@ -1496,7 +1458,7 @@ void SipiImage::add_watermark(const std::string &wmfilename)
   double wm_strength = 0.8;
 
   if (bps == 8) {
-    auto *buf = pixels;
+    auto *buf = pixels.data();
 
     for (size_t j = 0; j < ny; j++) {
       for (size_t i = 0; i < nx; i++) {
@@ -1555,8 +1517,8 @@ SipiImage &SipiImage::operator-=(const SipiImage &rhs)
 
   switch (bps) {
   case 8: {
-    byte *ltmp = pixels;
-    byte *rtmp = rhs_ptr->pixels;
+    byte *ltmp = pixels.data();
+    const byte *rtmp = rhs_ptr->pixels.data();
 
     for (size_t j = 0; j < ny; j++) {
       for (size_t i = 0; i < nx; i++) {
@@ -1572,8 +1534,8 @@ SipiImage &SipiImage::operator-=(const SipiImage &rhs)
   }
 
   case 16: {
-    word *ltmp = (word *)pixels;
-    word *rtmp = (word *)rhs_ptr->pixels;
+    word *ltmp = (word *)pixels.data();
+    const word *rtmp = (const word *)rhs_ptr->pixels.data();
 
     for (size_t j = 0; j < ny; j++) {
       for (size_t i = 0; i < nx; i++) {
@@ -1608,7 +1570,7 @@ SipiImage &SipiImage::operator-=(const SipiImage &rhs)
 
   switch (bps) {
   case 8: {
-    byte *ltmp = pixels;
+    byte *ltmp = pixels.data();
 
     for (size_t j = 0; j < ny; j++) {
       for (size_t i = 0; i < nx; i++) {
@@ -1622,7 +1584,7 @@ SipiImage &SipiImage::operator-=(const SipiImage &rhs)
   }
 
   case 16: {
-    word *ltmp = (word *)pixels;
+    word *ltmp = (word *)pixels.data();
 
     for (size_t j = 0; j < ny; j++) {
       for (size_t i = 0; i < nx; i++) {
@@ -1680,8 +1642,8 @@ SipiImage &SipiImage::operator+=(const SipiImage &rhs)
 
   switch (bps) {
   case 8: {
-    byte *ltmp = pixels;
-    byte *rtmp = rhs_ptr->pixels;
+    byte *ltmp = pixels.data();
+    const byte *rtmp = rhs_ptr->pixels.data();
 
     for (size_t j = 0; j < ny; j++) {
       for (size_t i = 0; i < nx; i++) {
@@ -1696,8 +1658,8 @@ SipiImage &SipiImage::operator+=(const SipiImage &rhs)
   }
 
   case 16: {
-    word *ltmp = (word *)pixels;
-    word *rtmp = (word *)rhs_ptr->pixels;
+    word *ltmp = (word *)pixels.data();
+    const word *rtmp = (const word *)rhs_ptr->pixels.data();
 
     for (size_t j = 0; j < ny; j++) {
       for (size_t i = 0; i < nx; i++) {
@@ -1730,7 +1692,7 @@ SipiImage &SipiImage::operator+=(const SipiImage &rhs)
 
   switch (bps) {
   case 8: {
-    byte *ltmp = pixels;
+    byte *ltmp = pixels.data();
 
     for (size_t j = 0; j < ny; j++) {
       for (size_t i = 0; i < nx; i++) {
@@ -1744,7 +1706,7 @@ SipiImage &SipiImage::operator+=(const SipiImage &rhs)
   }
 
   case 16: {
-    word *ltmp = (word *)pixels;
+    word *ltmp = (word *)pixels.data();
 
     for (size_t j = 0; j < ny; j++) {
       for (size_t i = 0; i < nx; i++) {
@@ -1786,8 +1748,8 @@ bool SipiImage::operator==(const SipiImage &rhs) const
 
   switch (bps) {
   case 8: {
-    byte *ltmp1 = pixels;
-    byte *ltmp2 = rhs.pixels;
+    const byte *ltmp1 = pixels.data();
+    const byte *ltmp2 = rhs.pixels.data();
     for (size_t j = 0; j < ny; j++) {
       for (size_t i = 0; i < nx; i++) {
         for (size_t k = 0; k < nc; k++) {
@@ -1798,8 +1760,8 @@ bool SipiImage::operator==(const SipiImage &rhs) const
     break;
   }
   case 16: {
-    word *ltmp1 = (word *)pixels;
-    word *ltmp2 = (word *)pixels;
+    word *ltmp1 = (word *)pixels.data();
+    word *ltmp2 = (word *)pixels.data();
     for (size_t j = 0; j < ny; j++) {
       for (size_t i = 0; i < nx; i++) {
         for (size_t k = 0; k < nc; k++) {
@@ -1825,8 +1787,8 @@ std::optional<double> SipiImage::compare(const SipiImage &rhs) const
 
   switch (bps) {
   case 8: {
-    byte *ltmp1 = pixels;
-    byte *ltmp2 = rhs.pixels;
+    const byte *ltmp1 = pixels.data();
+    const byte *ltmp2 = rhs.pixels.data();
     for (size_t j = 0; j < ny; j++) {
       for (size_t i = 0; i < nx; i++) {
         for (size_t k = 0; k < nc; k++) {
@@ -1873,8 +1835,8 @@ std::optional<PixelDelta> SipiImage::maxPixelDelta(const SipiImage &rhs) const
 
   switch (bps) {
   case 8: {
-    const byte *ltmp = pixels;
-    const byte *rtmp = rhs.pixels;
+    const byte *ltmp = pixels.data();
+    const byte *rtmp = rhs.pixels.data();
     for (size_t y = 0; y < ny; y++) {
       for (size_t x = 0; x < nx; x++) {
         for (size_t c = 0; c < nc; c++) {
@@ -1886,8 +1848,8 @@ std::optional<PixelDelta> SipiImage::maxPixelDelta(const SipiImage &rhs) const
     break;
   }
   case 16: {
-    const word *ltmp = reinterpret_cast<const word *>(pixels);
-    const word *rtmp = reinterpret_cast<const word *>(rhs.pixels);
+    const word *ltmp = reinterpret_cast<const word *>(pixels.data());
+    const word *rtmp = reinterpret_cast<const word *>(rhs.pixels.data());
     for (size_t y = 0; y < ny; y++) {
       for (size_t x = 0; x < nx; x++) {
         for (size_t c = 0; c < nc; c++) {

--- a/src/SipiImage.h
+++ b/src/SipiImage.h
@@ -99,8 +99,7 @@ protected:
   std::vector<ExtraSamples> es;//!< meaning of the extra samples (channels)
   Orientation orientation;//!< Orientation of the image
   PhotometricInterpretation photo;//!< Image type, that is the meaning of the channels
-  byte *pixels;//!< Pointer to block of memory holding the pixels (allways in big-endian format if interpreted as 16
-               //!< bit/sample)
+  std::vector<byte> pixels;//!< Pixel buffer (allways in big-endian format if interpreted as 16 bit/sample)
   std::shared_ptr<Xmp> xmp;//!< Pointer to instance Xmp class (\ref Xmp), or NULL
   std::shared_ptr<Icc> icc;//!< Pointer to instance of Icc class (\ref Icc), or NULL
   std::shared_ptr<Iptc> iptc;//!< Pointer to instance of Iptc class (\ref Iptc), or NULL
@@ -220,11 +219,7 @@ public:
   [[nodiscard]] PhotometricInterpretation getPhoto() const { return photo; };
 
 
-  /*! Destructor
-   *
-   * Destroys the image and frees all the resources associated with it
-   */
-  ~SipiImage();
+  ~SipiImage() = default;
 
   /*!
    * Gets the value of a pixel sample.
@@ -244,11 +239,11 @@ public:
     if (c >= nc) throw((int)3);
     switch (bps) {
     case 8: {
-      unsigned char *tmp = (unsigned char *)pixels;
+      const unsigned char *tmp = pixels.data();
       return static_cast<int>(tmp[nc * (y * nx + x) + c]);
     }
     case 16: {
-      unsigned short *tmp = (unsigned short *)pixels;
+      const unsigned short *tmp = (const unsigned short *)pixels.data();
       return static_cast<int>(tmp[nc * (y * nx + x) + c]);
     }
     default: {
@@ -274,13 +269,13 @@ public:
     switch (bps) {
     case 8: {
       if (val > 0xff) throw((int)4);
-      unsigned char *tmp = (unsigned char *)pixels;
+      unsigned char *tmp = pixels.data();
       tmp[nc * (y * nx + x) + c] = (unsigned char)val;
       break;
     }
     case 16: {
       if (val > 0xffff) throw((int)5);
-      unsigned short *tmp = (unsigned short *)pixels;
+      unsigned short *tmp = (unsigned short *)pixels.data();
       tmp[nc * (y * nx + x) + c] = (unsigned short)val;
       break;
     }
@@ -523,20 +518,16 @@ public:
   /*!
    * Convert an image from 16 to 8 bit. The algorithm just divides all pixel values
    * by 256 using the ">> 8" operator (fast & efficient)
-   *
-   * \returns Returns true on success, false on error
    */
-  bool to8bps();
+  void to8bps();
 
   /*!
    * Convert an image to a bitonal representation using Steinberg-Floyd dithering.
    *
    * The method does nothing if the image is already bitonal. Otherwise, the image is converted
    * into a gray value image if necessary and then a FLoyd-Steinberg dithering is applied.
-   *
-   * \returns Returns true on success, false on error
    */
-  bool toBitonal();
+  void toBitonal();
 
   /*!
    * Conclude similarity of two SipiImages, used in tests. Only tested with small differences.

--- a/src/ffi/serve_image.cpp
+++ b/src/ffi/serve_image.cpp
@@ -720,19 +720,31 @@ std::expected<ServeResponse, SipiStatus>
       Metrics::instance().client_disconnected_total.Increment();
       return std::unexpected(SipiStatus::ClientGone);
     }
-    PhaseTimer phase_timer(SIPI_PHASE_QUALITY);
-    switch (quality_format.quality()) {
-    case SipiQualityFormat::COLOR:
-      img.convertToIcc(Icc(icc_sRGB), 8);
-      break;
-    case SipiQualityFormat::GRAY:
-      img.convertToIcc(Icc(icc_GRAY_D50), 8);
-      break;
-    case SipiQualityFormat::BITONAL:
-      img.toBitonal();
-      break;
-    default:
-      return std::unexpected(SipiStatus::BadRequest);
+    try {
+      PhaseTimer phase_timer(SIPI_PHASE_QUALITY);
+      switch (quality_format.quality()) {
+      case SipiQualityFormat::COLOR:
+        img.convertToIcc(Icc(icc_sRGB), 8);
+        break;
+      case SipiQualityFormat::GRAY:
+        img.convertToIcc(Icc(icc_GRAY_D50), 8);
+        break;
+      case SipiQualityFormat::BITONAL:
+        img.toBitonal();
+        break;
+      default:
+        return std::unexpected(SipiStatus::BadRequest);
+      }
+    } catch (const std::bad_alloc &) {
+      Metrics::instance().memory_alloc_failures_total.Increment();
+      return std::unexpected(SipiStatus::InternalError);
+    } catch (Sipi::SipiError &err) {
+      ImageContext sentry_ctx;
+      sentry_ctx.input_file = infile;
+      sentry_ctx.file_size_bytes = get_file_size(infile);
+      populate_from_image(sentry_ctx, img);
+      report_image_error(req.report_error, req.report_ctx, err.to_string(), "convert", sentry_ctx);
+      return std::unexpected(SipiStatus::InternalError);
     }
   }
 

--- a/src/formats/SipiIOJ2k.cpp
+++ b/src/formats/SipiIOJ2k.cpp
@@ -624,21 +624,21 @@ bool SipiIOJ2k::read(SipiImage *img,
   if (force_bps_8) img->bps = 8;// forces kakadu to convert to 8 bit!
   switch (img->bps) {
   case 8: {
-    auto buffer8 = std::make_unique<kdu_core::kdu_byte[]>(static_cast<int>(dims.area()) * img->nc);
+    std::vector<byte> buffer8(static_cast<int>(dims.area()) * img->nc);
     try {
-      decompressor.pull_stripe(buffer8.get(), stripe_heights);
+      decompressor.pull_stripe(buffer8.data(), stripe_heights);
     } catch (kdu_exception &exc) {
       log_err("Error while decompressing image: %s.", filepath.c_str());
       return false;
     }
-    img->pixels = buffer8.release();
+    img->pixels = std::move(buffer8);
     break;
   }
   case 12: {
     std::vector<char> get_signed(img->nc, 0);// vector<bool> does not work -> special treatment in C++
-    auto buffer16 = std::make_unique<kdu_core::kdu_int16[]>((int)dims.area() * img->nc);
+    std::vector<byte> buffer16(2 * dims.area() * img->nc);
     try {
-      decompressor.pull_stripe(buffer16.get(),
+      decompressor.pull_stripe(reinterpret_cast<kdu_core::kdu_int16 *>(buffer16.data()),
         stripe_heights,
         nullptr,
         nullptr,
@@ -649,15 +649,15 @@ bool SipiIOJ2k::read(SipiImage *img,
       log_err("Error while decompressing image: %s.", filepath.c_str());
       return false;
     }
-    img->pixels = reinterpret_cast<byte *>(buffer16.release());
+    img->pixels = std::move(buffer16);
     img->bps = 16;
     break;
   }
   case 16: {
     std::vector<char> get_signed(img->nc, 0);// vector<bool> does not work -> special treatment in C++
-    auto buffer16 = std::make_unique<kdu_core::kdu_int16[]>((int)dims.area() * img->nc);
+    std::vector<byte> buffer16(2 * dims.area() * img->nc);
     try {
-      decompressor.pull_stripe(buffer16.get(),
+      decompressor.pull_stripe(reinterpret_cast<kdu_core::kdu_int16 *>(buffer16.data()),
         stripe_heights,
         nullptr,
         nullptr,
@@ -668,7 +668,7 @@ bool SipiIOJ2k::read(SipiImage *img,
       log_err("Error while decompressing image: %s.", filepath.c_str());
       return false;
     }
-    img->pixels = reinterpret_cast<byte *>(buffer16.release());
+    img->pixels = std::move(buffer16);
     break;
   }
   default: {
@@ -686,7 +686,7 @@ bool SipiIOJ2k::read(SipiImage *img,
     //
     // we have a palette color image...
     //
-    auto tmpbuf = std::make_unique<byte[]>(img->nx * img->ny * numcol);
+    std::vector<byte> tmpbuf(img->nx * img->ny * numcol);
     for (int y = 0; y < img->ny; ++y) {
       for (int x = 0; x < img->nx; ++x) {
         tmpbuf[3 * (y * img->nx + x) + 0] = rlut[img->pixels[y * img->nx + x]];
@@ -694,8 +694,7 @@ bool SipiIOJ2k::read(SipiImage *img,
         tmpbuf[3 * (y * img->nx + x) + 2] = blut[img->pixels[y * img->nx + x]];
       }
     }
-    delete[] img->pixels;
-    img->pixels = tmpbuf.release();
+    img->pixels = std::move(tmpbuf);
     img->nc = numcol;
   }
   if (img->photo == PhotometricInterpretation::YCBCR) {
@@ -1399,7 +1398,7 @@ void SipiIOJ2k::write(SipiImage *img, const OutputSink &sink, const SipiCompress
     // int *stripe_heights = new int[img->nc];
     int stripe_heights[5];
     if (img->bps == 16) {
-      kdu_int16 *buf = (kdu_int16 *)img->pixels;
+      kdu_int16 *buf = (kdu_int16 *)img->pixels.data();
       std::vector<int> precisions(img->nc, static_cast<int>(img->bps));
       std::vector<char> is_signed(img->nc, 0);// vector<bool> does not work -> special treatment in C++
       for (size_t i = 0; i < img->nc; i++) { stripe_heights[i] = img->ny; }
@@ -1409,13 +1408,13 @@ void SipiIOJ2k::write(SipiImage *img, const OutputSink &sink, const SipiCompress
       if (th == 0) th = img->ny;
       size_t stripe_start = 0;
       do {
-        kdu_byte *buf = (kdu_byte *)img->pixels + stripe_start * img->nc * img->nx;
+        kdu_byte *buf = img->pixels.data() + stripe_start * img->nc * img->nx;
         for (size_t i = 0; i < img->nc; i++) { stripe_heights[i] = th; }
         compressor.push_stripe(buf, stripe_heights);
         stripe_start += th;
       } while ((img->ny - stripe_start) >= th);
       if ((img->ny - stripe_start) > 0) {
-        kdu_byte *buf = (kdu_byte *)img->pixels + stripe_start * img->nc * img->nx;
+        kdu_byte *buf = img->pixels.data() + stripe_start * img->nc * img->nx;
         for (size_t i = 0; i < img->nc; i++) { stripe_heights[i] = img->ny - stripe_start; }
         compressor.push_stripe(buf, stripe_heights);
         stripe_start += img->ny - stripe_start;

--- a/src/formats/SipiIOJpeg.cpp
+++ b/src/formats/SipiIOJpeg.cpp
@@ -730,8 +730,7 @@ bool SipiIOJpeg::read(SipiImage *img,
   }
   int sll = cinfo.output_components * cinfo.output_width * sizeof(uint8_t);
 
-  delete[] img->pixels;// free previous buffer if re-reading into same SipiImage
-  img->pixels = new byte[img->ny * sll];
+  img->pixels.assign(static_cast<size_t>(img->ny) * sll, 0);
 
   // All libjpeg calls below — errors → longjmp → setjmp handler above
   linbuf = (*cinfo.mem->alloc_sarray)((j_common_ptr)&cinfo, JPOOL_IMAGE, sll, 1);

--- a/src/formats/SipiIOPng.cpp
+++ b/src/formats/SipiIOPng.cpp
@@ -146,15 +146,14 @@ bool SipiIOPng::read(SipiImage *img,
     throw SipiImageError("Error reading PNG file \"" + filepath + "\": Could not allocate memory for png_infop !");
   }
 
-  // Guards for allocations that happen after setjmp — longjmp skips destructors,
-  // so we track raw pointers here for cleanup in the error handler.
-  uint8_t *pixel_buffer_guard = nullptr;
-  png_bytep *row_pointers_guard = nullptr;
+  // Declared before the setjmp: on longjmp the handler throws, and the C++
+  // unwind path destroys these (they are resized inside the window, which is
+  // safe — the vector object's storage is stable memory, not a register).
+  std::vector<uint8_t> buffer;
+  std::vector<png_bytep> row_pointers;
 
   // setjmp error recovery — sipi_error_fn calls longjmp(png_jmpbuf(png_ptr), 1)
   if (setjmp(png_jmpbuf(png_ptr))) {
-    delete[] pixel_buffer_guard;
-    delete[] row_pointers_guard;
     png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
     throw SipiImageError("PNG read failed for \"" + filepath + "\"");
   }
@@ -265,14 +264,12 @@ bool SipiIOPng::read(SipiImage *img,
   }
 
   size_t sll = png_get_rowbytes(png_ptr, info_ptr);
-  auto *buffer = new uint8_t[height * sll];
-  pixel_buffer_guard = buffer;  // track for longjmp cleanup
+  buffer.resize(height * sll);
 
-  auto *row_pointers = new png_bytep[height];
-  row_pointers_guard = row_pointers;  // track for longjmp cleanup
-  for (size_t i = 0; i < img->ny; i++) { row_pointers[i] = (buffer + i * sll); }
+  row_pointers.resize(height);
+  for (size_t i = 0; i < img->ny; i++) { row_pointers[i] = (buffer.data() + i * sll); }
 
-  png_read_image(png_ptr, row_pointers);
+  png_read_image(png_ptr, row_pointers.data());
   png_read_end(png_ptr, info_ptr);
   img->bps = png_get_bit_depth(png_ptr, info_ptr);
   img->nc = png_get_channels(png_ptr, info_ptr);
@@ -281,13 +278,11 @@ bool SipiIOPng::read(SipiImage *img,
   png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
 
   if (img->bps == 16) {
-    auto *tmp = (unsigned short *)buffer;
+    auto *tmp = (unsigned short *)buffer.data();
     for (int i = 0; i < img->nx * img->ny * img->nc; i++) { tmp[i] = ntohs(tmp[i]); }
   }
-  delete[] img->pixels;// free previous buffer if re-reading into same SipiImage
-  img->pixels = buffer;
+  img->pixels = std::move(buffer);
 
-  delete[] row_pointers;
   infile.reset();
 
   if (region != nullptr) {// we just use the image.crop method
@@ -316,9 +311,7 @@ bool SipiIOPng::read(SipiImage *img,
     }
   }
 
-  if (force_bps_8) {
-    if (!img->to8bps()) { throw SipiImageError("Cannot convert to 8 bits/sample"); }
-  }
+  if (force_bps_8) { img->to8bps(); }
   return true;
 };
 
@@ -585,9 +578,9 @@ void SipiIOPng::write(SipiImage *img, const OutputSink &sink, const SipiCompress
   png_bytep *row_pointers = (png_bytep *)png_malloc(png_ptr, img->ny * sizeof(png_byte *));
 
   if (img->bps == 8) {
-    for (size_t i = 0; i < img->ny; i++) { row_pointers[i] = (img->pixels + i * img->nx * img->nc); }
+    for (size_t i = 0; i < img->ny; i++) { row_pointers[i] = (img->pixels.data() + i * img->nx * img->nc); }
   } else if (img->bps == 16) {
-    for (size_t i = 0; i < img->ny; i++) { row_pointers[i] = (img->pixels + 2 * i * img->nx * img->nc); }
+    for (size_t i = 0; i < img->ny; i++) { row_pointers[i] = (img->pixels.data() + 2 * i * img->nx * img->nc); }
   }
 
   png_set_rows(png_ptr, info_ptr, row_pointers);

--- a/src/formats/SipiIOTiff.cpp
+++ b/src/formats/SipiIOTiff.cpp
@@ -1247,7 +1247,7 @@ bool SipiIOTiff::read(SipiImage *img,
         "Unsupported bits/sample (" + std::to_string(img->bps) + ") in file " + filepath);
     }
 
-    auto inbuf = std::make_unique<uint8_t[]>(ps * roi_w * roi_h * img->nc);
+    std::vector<uint8_t> inbuf(ps * roi_w * roi_h * img->nc);
 
     if (img->bps <= 8) {
       std::vector<uint8_t> pixdata;
@@ -1258,7 +1258,7 @@ bool SipiIOTiff::read(SipiImage *img,
 
       img->bps = 8;
 
-      memcpy(inbuf.get(), pixdata.data(), pixdata.size() * img->bps / 8);
+      memcpy(inbuf.data(), pixdata.data(), pixdata.size() * img->bps / 8);
     } else if (img->bps <= 16) {
       std::vector<uint16_t> pixdata;
       if (is_tiled)
@@ -1266,11 +1266,10 @@ bool SipiIOTiff::read(SipiImage *img,
       else
         pixdata = read_standard_data<uint16_t>(tif, roi_x, roi_y, roi_w, roi_h);
       img->bps = 16;
-      memcpy(inbuf.get(), pixdata.data(), pixdata.size() * img->bps / 8);
+      memcpy(inbuf.data(), pixdata.data(), pixdata.size() * img->bps / 8);
     }
 
-    delete[] img->pixels;// free previous buffer if re-reading into same SipiImage
-    img->pixels = inbuf.release();
+    img->pixels = std::move(inbuf);
     img->nx = roi_w;
     img->ny = roi_h;
     tif_guard.reset();
@@ -1285,7 +1284,7 @@ bool SipiIOTiff::read(SipiImage *img,
         if (gcm[i] > cm_max) cm_max = gcm[i];
         if (bcm[i] > cm_max) cm_max = bcm[i];
       }
-      auto dataptr = std::make_unique<uint8_t[]>(3 * img->nx * img->ny);
+      std::vector<uint8_t> dataptr(3 * img->nx * img->ny);
       if (cm_max <= 256) {// we have a colomap with entries form 0 - 255
         for (size_t i = 0; i < img->nx * img->ny; i++) {
           dataptr[3 * i] = (uint8_t)rcm[img->pixels[i]];
@@ -1299,8 +1298,7 @@ bool SipiIOTiff::read(SipiImage *img,
           dataptr[3 * i + 2] = (uint8_t)(bcm[img->pixels[i]] >> 8);
         }
       }
-      delete[] img->pixels;
-      img->pixels = dataptr.release();
+      img->pixels = std::move(dataptr);
       img->photo = PhotometricInterpretation::RGB;
       img->nc = 3;
     }
@@ -1352,7 +1350,7 @@ bool SipiIOTiff::read(SipiImage *img,
           }
           img->icc = std::make_shared<Icc>(icc_LAB);
         } else if (img->bps == 16) {
-          auto *data = (unsigned short *)img->pixels;
+          auto *data = (unsigned short *)img->pixels.data();
           for (size_t y = 0; y < img->ny; y++) {
             for (size_t x = 0; x < img->nx; x++) {
               union {
@@ -1434,9 +1432,7 @@ bool SipiIOTiff::read(SipiImage *img,
         }
       }
     }
-    if (force_bps_8) {
-      if (!img->to8bps()) { throw Sipi::SipiImageError("Cannot convert to 8 bits/sample"); }
-    }
+    if (force_bps_8) { img->to8bps(); }
     return true;
   }
   return false;
@@ -1647,12 +1643,12 @@ void SipiIOTiff::write(SipiImage *img, const OutputSink &sink, const SipiCompres
     its_1_bit = true;
 
     if (img->bps == 8) {
-      byte *scan = img->pixels;
+      const byte *scan = img->pixels.data();
       for (size_t i = 0; i < img->nx * img->ny; i++) {
         if ((scan[i] != 0) && (scan[i] != 255)) { its_1_bit = false; }
       }
     } else if (img->bps == 16) {
-      word *scan = (word *)img->pixels;
+      const word *scan = (const word *)img->pixels.data();
       for (size_t i = 0; i < img->nx * img->ny; i++) {
         if ((scan[i] != 0) && (scan[i] != 65535)) { its_1_bit = false; }
       }
@@ -1684,7 +1680,7 @@ void SipiIOTiff::write(SipiImage *img, const OutputSink &sink, const SipiCompres
     } else if (img->bps == 16) {
       for (size_t y = 0; y < img->ny; y++) {
         for (size_t x = 0; x < img->nx; x++) {
-          auto *data = (unsigned short *)img->pixels;
+          auto *data = (unsigned short *)img->pixels.data();
           union {
             unsigned short u;
             signed short s;
@@ -1822,7 +1818,7 @@ void SipiIOTiff::write(SipiImage *img, const OutputSink &sink, const SipiCompres
   } else {
     if (!pyramid) {
       for (size_t i = 0; i < img->ny; i++) {
-        TIFFWriteScanline(tif, img->pixels + i * img->nc * img->nx * (img->bps / 8), (int)i, 0);
+        TIFFWriteScanline(tif, img->pixels.data() + i * img->nc * img->nx * (img->bps / 8), (int)i, 0);
       }
     } else {
       for (int reduce = 0; reduce <= 5; reduce += 1) {
@@ -1935,7 +1931,7 @@ void SipiIOTiff::write_subfile(const SipiImage &img,
   tsize_t tilesize = TIFFTileSize(tif);
 
   // reduce resolution of image: A reduce factor can be given, 0=no scaling, 1=0.5, 2=0.25, 3=0.125,...
-  std::vector<uint8_t> nbuf(img.pixels, img.pixels + img.nx * img.ny * img.nc * img.bps / 8);
+  std::vector<uint8_t> nbuf(img.pixels.data(), img.pixels.data() + img.nx * img.ny * img.nc * img.bps / 8);
 
   if (level > 0) { nbuf = doReduce<uint8_t>(std::move(nbuf), level, img.nx, img.ny, img.nc, nnx, nny); }
 
@@ -2301,8 +2297,9 @@ void SipiIOTiff::separateToContig(SipiImage *img, unsigned int sll)
   // rearrange RRRRRR...GGGGG...BBBBB data  to RGBRGBRGB…RGB
   //
   if (img->bps == 8) {
-    byte *dataptr = img->pixels;
-    auto *tmpptr = new unsigned char[img->nc * img->ny * img->nx];
+    const byte *dataptr = img->pixels.data();
+    std::vector<byte> tmp_v(img->nc * img->ny * img->nx);
+    byte *tmpptr = tmp_v.data();
 
     for (unsigned int k = 0; k < img->nc; k++) {
       for (unsigned int j = 0; j < img->ny; j++) {
@@ -2312,11 +2309,11 @@ void SipiIOTiff::separateToContig(SipiImage *img, unsigned int sll)
       }
     }
 
-    delete[] dataptr;
-    img->pixels = tmpptr;
+    img->pixels = std::move(tmp_v);
   } else if (img->bps == 16) {
-    word *dataptr = (word *)img->pixels;
-    word *tmpptr = new word[img->nc * img->ny * img->nx];
+    const word *dataptr = (const word *)img->pixels.data();
+    std::vector<byte> tmp_v(2 * img->nc * img->ny * img->nx);
+    word *tmpptr = (word *)tmp_v.data();
 
     for (unsigned int k = 0; k < img->nc; k++) {
       for (unsigned int j = 0; j < img->ny; j++) {
@@ -2326,8 +2323,7 @@ void SipiIOTiff::separateToContig(SipiImage *img, unsigned int sll)
       }
     }
 
-    delete[] dataptr;
-    img->pixels = (byte *)tmpptr;
+    img->pixels = std::move(tmp_v);
   } else {
     std::string msg = "Bits per sample not supported: " + std::to_string(-img->bps);
     throw Sipi::SipiImageError(msg);


### PR DESCRIPTION
> **Stacked PR — depends on #742 and #744.** Base branch is `raii/phase-3-formats`; the first commit duplicates #742's metadata commit (cherry-pick, same patch-id — it rebases away once #742 lands). Merge #741/#742/#744 first, then retarget this to `main` and rebase.

## Motivation
Final structural step of the RAII refactoring plan. `SipiImage` held its pixel buffer as a raw owning `byte *` with a hand-written rule-of-five, and every transform re-implemented the `new[]`/`delete[]`/reassign dance (~25 sites). Every codec had a leak-on-throw window between decoding into a raw buffer and handing it to `img->pixels`.

## Summary
- `pixels` is now `std::vector<byte>`: destructor gone, moves defaulted, copy is one line of the (still user-written, metadata-cloning) copy constructor.
- Transforms build a `std::vector` and move-assign it — no manual frees anywhere in `SipiImage.cpp`.
- All four handlers move their decode buffers into the image, permanently closing the leak-on-throw window class Phase 3 fixed site-by-site.
- PNG read drops its raw-pointer longjmp guards entirely: the buffer/row-pointer vectors are declared before the `setjmp`, so the handler's throw unwinds them.

## Key Changes
### SipiImage
16-bit transform arms allocate a byte vector and view it through a `word *` alias, so the arithmetic loops are unchanged. Blast radius is exactly `SipiImage.{h,cpp}` plus the four friend handlers — nothing else in the tree touches the member.

### Intentional edge-behavior changes
- The sized constructor now really zero-fills the buffer (its docstring always claimed it did; `new byte[]` never did).
- `to8bps`/`toBitonal` are `void` and propagate `bad_alloc` on OOM instead of returning `false` (`new (nothrow)` is gone); the now-unreachable failure checks at their PNG/TIFF call sites are removed, and the FFI quality phase catches `bad_alloc` (incrementing the OOM metric) like its sibling phases.

## Benchmarks (hot-path gate)
Cumulative `origin/main` → this branch, same `-c opt` build + machine:
- decode: OVERALL_GEOMEAN −0.7 %
- encode: +1.3 % wall / −2.6 % CPU
- process (scale/rotate/crop/convert): +0.3 %; every series within noise per the benchmarking decision rule.

## Test Plan
- [x] `just bazel-build`
- [x] `just bazel-test-unit` (25/25)
- [x] `just bazel-test-approval` (byte-identical goldens)
- [x] e2e 27/27
- [x] `just bazel-test-differential`
- [x] `just bench` decode/encode/process vs `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
