### PR TITLE
fix(image): compare 16 bps pixels against rhs in operator==

### DIFF
--- a/src/SipiImage.cpp
+++ b/src/SipiImage.cpp
@@ -1760,7 +1760,7 @@ bool SipiImage::operator==(const SipiImage &rhs) const
   }
   case 16: {
     word *ltmp1 = (word *)pixels.data();
-    word *ltmp2 = (word *)pixels.data();
+    word *ltmp2 = (word *)rhs.pixels.data();
     for (size_t j = 0; j < ny; j++) {
       for (size_t i = 0; i < nx; i++) {
         for (size_t k = 0; k < nc; k++) {

--- a/test/unit/sipiimage/equality_regression_test.cpp
+++ b/test/unit/sipiimage/equality_regression_test.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2016 - 2026 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform
+ * contributors. SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Regression test — `SipiImage::operator==` compares the pixel buffers of
+ * both operands in every bits-per-sample arm.
+ *
+ * Before the fix the 16 bps arm aliased both comparison pointers to the
+ * left-hand buffer, so two 16 bps images with equal dimensions always
+ * compared equal regardless of pixel content. The 8 bps arm was correct,
+ * which is why the fixture-based equality tests (all 8 bps) never caught it.
+ */
+
+#include <gtest/gtest.h>
+
+#include "../../../src/SipiImage.h"
+
+namespace {
+
+using Sipi::PhotometricInterpretation;
+using Sipi::SipiImage;
+
+TEST(Equality, SixteenBpsDetectsDifferingPixels)
+{
+  SipiImage img1(3, 2, 3, 16, PhotometricInterpretation::RGB);
+  SipiImage img2(3, 2, 3, 16, PhotometricInterpretation::RGB);
+  EXPECT_TRUE(img1 == img2);
+
+  img2.setPixel(2, 1, 1, 0x1234);
+  EXPECT_FALSE(img1 == img2);
+}
+
+TEST(Equality, EightBpsDetectsDifferingPixels)
+{
+  SipiImage img1(3, 2, 3, 8, PhotometricInterpretation::RGB);
+  SipiImage img2(3, 2, 3, 8, PhotometricInterpretation::RGB);
+  EXPECT_TRUE(img1 == img2);
+
+  img2.setPixel(2, 1, 1, 0x42);
+  EXPECT_FALSE(img1 == img2);
+}
+
+}// namespace


### PR DESCRIPTION
> **Stacked PR — top of the RAII stack (#741 → #742 → #744 → #745 → #746 → this).** Base is `raii/phase-5-cleanup`. Merge last; retarget to `main` and rebase after #746 lands. Stacked (rather than based on `main`) because #745 rewrites the same lines in `operator==`, so landing this on `main` first would force a conflict into the stack's final rebase.

## Motivation
Review of the RAII stack surfaced a pre-existing `main` bug: the 16 bps arm of `SipiImage::operator==` aliased both comparison pointers to the left-hand pixel buffer, so two 16 bps images with equal dimensions always compared equal regardless of pixel content. Per commit conventions, a genuine pre-existing bug gets its own `fix:` commit instead of being buried in the refactor.

## Summary
- 16 bps image equality now actually compares the two operands (`rhs.pixels` instead of `pixels` on the right side).
- Regression test covers both the 8 bps and 16 bps arms with in-memory images.

## Key Changes
### src/SipiImage.cpp
- `operator==`, 16 bps arm: `ltmp2` now points at `rhs.pixels.data()`.

### test/unit/sipiimage/equality_regression_test.cpp
- New: two identical sized-constructor images compare equal; after `setPixel` on one, they compare unequal — for both 8 and 16 bps. Red-checked: the 16 bps assertion fails on the pre-fix code.

## Gotchas
- The fixture-based equality tests are all 8 bps, which is why this survived so long; if you add equality-sensitive tests for a new depth, cover it in `equality_regression_test.cpp` too.

## Test Plan
- [x] `bazel test //test/unit/sipiimage:sipi_image_tests` (full suite green; new tests red on pre-fix code, green with fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
