### PR TITLE
perf(formats): cap JP2 decode worker threads at 4

### DIFF
--- a/src/formats/SipiIOJ2k.cpp
+++ b/src/formats/SipiIOJ2k.cpp
@@ -230,6 +230,14 @@ bool SipiIOJ2k::read(SipiImage *img,
 
   int num_threads;
   if ((num_threads = kdu_get_num_processors()) < 2) num_threads = 0;
+  // Cap decode workers well below the core count. The server admits up to
+  // available_parallelism() concurrent decodes (the Rust FFI pool in
+  // routes.rs); one worker per core each would oversubscribe to ~N² threads on
+  // N cores under normal load. 4 retains most of the single-request speedup
+  // (decode parallelism has steep diminishing returns past ~4 workers) while
+  // bounding that contention. Encode (write()) is ingest-time and rare, so it
+  // keeps the full core count.
+  else if (num_threads > 4) num_threads = 4;
 #if defined(__SANITIZE_ADDRESS__) || (defined(__has_feature) && __has_feature(address_sanitizer))
   // Same ASan "Joining already joined thread" false positive as the encode path
   // (see the guard in write() for the full rationale): Kakadu's worker-thread


### PR DESCRIPTION
> Stacked on #743 (`perf/jp2-multithread-decode`). Review/merge #743 first; this PR's diff is only the cap.

## Motivation

#743 makes JP2 decode multi-threaded with one Kakadu worker per core. In isolation that is a 4–8× win, but the Rust FFI pool independently admits up to `available_parallelism()` concurrent decodes (`routes.rs:278`, `default_pool_size`). At the pool's normal saturation point, N concurrent decodes each spawning ~N workers produce **~N² threads contending for N cores** (≈240 on a 16-core host) — a throughput cliff / tail-latency blowup under the server's ordinary concurrent-request load. The single-request microbench cannot see this.

## Summary

- Cap JP2 decode workers at `min(cores, 4)` (was: full core count).
- Bounds worst-case contention from ~N² to ~4N threads.
- Encode (`write()`) is unchanged — ingest-time and rare, not the per-request hot path.

## Key Changes

### `src/formats/SipiIOJ2k.cpp` — `SipiIOJ2k::read`
- `else if (num_threads > 4) num_threads = 4;` after the core-count computation (single-core `num_threads == 0` fallback preserved).

## Challenges and Decisions

### Why 4, and why accept a single-request regression
**Problem:** capping threads slows a single isolated decode.
**Tried:** budget-relative sizing (`cores / permits_in_flight`) — optimal utilization, but needs live pool-occupancy across the FFI seam and is easy to get subtly wrong. A process-wide shared env — removes per-request teardown but needs per-decode job coordination across independent codestreams Kakadu doesn't obviously offer without serialization.
**Solution:** a fixed cap is the lowest-risk first step. Decode parallelism has steep diminishing returns past ~4 workers, so 4 keeps most of the speedup over the pre-MT baseline while bounding contention. The single-request cost is real (measured below) but the capped path is still 3–4× faster than the original single-threaded decode.

## Gotchas
- **The real acceptance gate is a concurrent-load measurement, not this microbench.** The single-request `just bench decode` numbers below quantify only the per-request cost of the cap; they cannot show the oversubscription this prevents. Before relying on it under real traffic, measure aggregate throughput + p99 with N simultaneous decode requests at N = `default_pool_size` across a couple of core counts. **This PR should not merge on the microbench alone.**
- If that measurement shows cores sitting idle at low concurrency, escalate to budget-relative sizing or a shared env.

## Test Plan
- [x] `just bench decode` before (uncapped, base of stack) / after (capped), 10-core Apple Silicon, `-c opt`, 20 reps; U-test p=0.0000, median shift ≫ baseline CV (~2%):

  | Benchmark | Uncapped (10T) | Capped (4T) | Δ | vs pre-MT (1T) |
  |---|---|---|---|---|
  | `decode_tile/jp2/256` | 6.75 ms | 11.6 ms | +72% | 42.8 ms → still 3.7× faster |
  | `decode_tile/jp2/1024` | 19.4 ms | 37.4 ms | +93% | 143 ms → still 3.8× faster |
  | `decode_thumb/jp2` | 9.62 ms | 14.7 ms | +53% | 44.9 ms → still 3.1× faster |

- [ ] **Concurrent-load throughput + p99 measurement (acceptance gate — not yet run)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
