### PR TITLE
test: add concurrent-load decode harness

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,6 +24,7 @@
     "eng@dasch-claude-plugins": true,
     "linear@claude-plugins-official": true,
     "sentry@claude-plugins-official": true,
-    "my-eng@subotic-claude-plugins": true
+    "my-eng@subotic-claude-plugins": true,
+    "misc@dasch-claude-plugins": true
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ cmake-build-relwithdebinfo-inside-docker/
 cmake-build-relwithdebinfo-nix-develop/
 # ignore runtime cache directory
 /cache/
+/loadtest_cache/
 # test-generated cache directories and configs
 test/_test_data/cache/
 test/_test_data/cache_test_*/

--- a/config/sipi.loadtest-config.lua
+++ b/config/sipi.loadtest-config.lua
@@ -1,0 +1,38 @@
+-- Config for the concurrent-load decode harness (`just loadtest-decode`).
+--
+-- Deliberately differs from the localdev config in two ways that matter for a
+-- decode-throughput measurement:
+--   * `nthreads = 0` sizes the Rust FFI pool from the host core count — the
+--     production default, i.e. the pool's real saturation point.
+--   * a tiny cache (4 files) so that, combined with the harness requesting a
+--     distinct tile region per request, every request misses the cache and
+--     exercises a real JPEG2000 decode rather than a cache hit.
+sipi = {
+    hostname = 'localhost',
+    port = 2048,
+    nthreads = 0,                  -- 0 = auto (host core count) = pool saturation point
+    max_waiting_connections = 200, -- generous queue so excess clients wait rather than 503 immediately
+    queue_timeout = 60,
+    keep_alive = 5,
+    imgroot = './test/_test_data/images',
+    prefix_as_path = true,
+    subdir_levels = 0,
+    cache_dir = './loadtest_cache',
+    cache_size = '1M',
+    cache_nfiles = 4,              -- tiny; distinct tile regions guarantee decode-every-request anyway
+    jpeg_quality = 80,
+    scaling_quality = { jpeg = 'medium', tiff = 'high', png = 'high', j2k = 'high' },
+    thumb_size = '!128,128',
+    max_post_size = '50M',
+    tmpdir = '/tmp',
+    initscript = './config/sipi.init.lua',
+    scriptdir = './scripts',
+    ssl_port = 2049,
+    ssl_certificate = './certificate/certificate.pem',
+    ssl_key = './certificate/key.pem',
+    jwt_secret = 'UP 4888, nice 4-8-4 steam engine',
+    loglevel = 'WARN'
+}
+admin = { user = 'admin', password = 'Sipi-Admin' }
+fileserver = { docroot = './server', wwwroute = '/server' }
+routes = {}

--- a/docs/src/development/benchmarking.md
+++ b/docs/src/development/benchmarking.md
@@ -121,3 +121,29 @@ on the author's machine.
    defeat the optimizer with `benchmark::DoNotOptimize` /
    `benchmark::ClobberMemory`.
 4. `just bench <name>` — there is nothing to register anywhere else.
+
+## Concurrent-load measurement
+
+`just bench` measures a single decode/encode in isolation. It cannot see how
+a change behaves when many requests run at once — the regime that matters for
+decisions about worker-thread counts, pool sizing, or anything whose cost is
+paid in contention rather than per-call work. A single-request speedup can
+coincide with no aggregate gain (or a regression) once the request pool is
+saturated.
+
+`just loadtest-decode "10,20,40"` covers that gap. It builds the production
+Rust shell (`//src/cli-rs:sipi`, `-c opt`), serves `load_test.jpx` via
+`config/sipi.loadtest-config.lua`, and drives it with
+`tools/loadtest/loadgen.py`: N concurrent clients each requesting a distinct
+native-resolution tile (distinct region → cache miss → real decode), reporting
+throughput and p50/p90/p99 per concurrency level after a warm-up window. The
+pool is sized from the host core count (`nthreads = 0`), so the listed
+concurrencies straddle its saturation point.
+
+Same rules as the microbench: never CI-gated, run on a quiesced machine, and
+compare a "before" branch against an "after" **on the same host** (build and
+run each branch in turn — do not run a build during a measurement, it steals
+cores). Interpretation caveats: the effect of thread-count changes scales with
+core count, so a result on a 10-core laptop does not settle behavior on a
+high-core production host; and the Rust FFI pool already bounds concurrent
+decodes to its permit count, which caps the worst-case thread total.

--- a/justfile
+++ b/justfile
@@ -385,6 +385,31 @@ bench-compare before after *FLAGS='':
     for f in "${@:3}"; do [ -n "$f" ] && flags+=("$f"); done
     bazel run //tools/benchmark:compare -- ${flags[@]+"${flags[@]}"} benchmarks "$BEFORE" "$AFTER"
 
+# Concurrent-load decode measurement (local dev loop, never CI-gated). Unlike
+# `just bench` (single-request microbench), this drives the production Rust
+# shell under N concurrent clients requesting distinct native-resolution JP2
+# tiles — every request decodes — and reports throughput + latency percentiles
+# per concurrency level. Answers "how does a decode-path change behave at the
+# request pool's saturation point", which the isolated microbench cannot.
+# Compare two runs by eye (run on each branch); see benchmarking.md.
+# Usage: just loadtest-decode "10,20,40"
+loadtest-decode concs='10,20,40' dur='20' warm='5' id='knora/load_test.jpx':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    bazel build -c opt //src/cli-rs:sipi
+    port=2048
+    rm -rf ./loadtest_cache && mkdir -p ./loadtest_cache
+    ./bazel-bin/src/cli-rs/sipi server --config config/sipi.loadtest-config.lua \
+        --serverport "$port" --drain-timeout 2 >/tmp/sipi-loadtest.log 2>&1 &
+    srv=$!
+    trap 'kill $srv 2>/dev/null || true; wait $srv 2>/dev/null || true' EXIT
+    for _ in $(seq 1 60); do
+        curl -fsS "http://localhost:$port/health" >/dev/null 2>&1 && break
+        kill -0 $srv 2>/dev/null || { echo "server died; see /tmp/sipi-loadtest.log"; exit 1; }
+        sleep 0.5
+    done
+    python3 tools/loadtest/loadgen.py "http://localhost:$port" "{{id}}" 512 max "{{concs}}" "{{dur}}" "{{warm}}"
+
 #####################################
 # Bazel Docker (rules_oci)
 #

--- a/tools/loadtest/loadgen.py
+++ b/tools/loadtest/loadgen.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Concurrent-load generator for the JP2 decode path.
+
+Fires `concurrency` parallel clients at a running sipi, each requesting a
+distinct native-resolution tile of one image (distinct region => distinct cache
+key => a real decode per request, mirroring a IIIF viewer's tile burst). Reports
+throughput and latency percentiles per concurrency level, discarding a warm-up
+window. Stdlib only (no third-party deps in the dev shell).
+
+Usage:
+    loadgen.py BASE_URL IMAGE_ID TILE OUT CONCS DUR WARM
+
+    BASE_URL  e.g. http://localhost:2048
+    IMAGE_ID  IIIF id, e.g. knora/load_test.jpx
+    TILE      tile edge in px (region grid step), e.g. 512
+    OUT       IIIF size, e.g. `max` (native-res tile; never upscales)
+    CONCS     comma-separated concurrency levels, e.g. 10,20,40
+    DUR       measurement seconds per level
+    WARM      warm-up seconds discarded before measuring
+"""
+import sys, json, time, threading, urllib.request, urllib.error, collections
+
+
+def tiles(w, h, step):
+    out, y = [], 0
+    while y < h:
+        th, x = min(step, h - y), 0
+        while x < w:
+            out.append(f"{x},{y},{min(step, w - x)},{th}")
+            x += step
+        y += step
+    return out
+
+
+def run(base, idp, regions, out, conc, dur, warm):
+    url = lambda i: f"{base}/{idp}/{regions[i % len(regions)]}/{out}/0/default.jpg"
+    lock, samples, counter, stop = threading.Lock(), [], [0], threading.Event()
+    errkind = collections.Counter()
+
+    def worker():
+        while not stop.is_set():
+            with lock:
+                i = counter[0]; counter[0] += 1
+            t0, kind = time.perf_counter(), None
+            try:
+                r = urllib.request.urlopen(url(i), timeout=120)
+                ok = (r.status == 200 and len(r.read()) > 0)
+                if not ok:
+                    kind = f"http_{r.status}"
+            except urllib.error.HTTPError as e:
+                ok, kind = False, f"http_{e.code}"
+            except Exception as e:
+                ok, kind = False, type(e).__name__
+            fin = time.perf_counter()
+            with lock:
+                samples.append((fin, fin - t0, ok))
+                if kind:
+                    errkind[kind] += 1
+
+    threads = [threading.Thread(target=worker, daemon=True) for _ in range(conc)]
+    start = time.perf_counter()
+    for t in threads:
+        t.start()
+    time.sleep(warm + dur)
+    stop.set()
+    for t in threads:
+        t.join(timeout=125)
+
+    lo, hi = start + warm, start + warm + dur
+    win = [(dt, ok) for (fin, dt, ok) in samples if lo <= fin <= hi]
+    oks = sorted(dt for dt, ok in win if ok)
+    pct = lambda a, p: a[min(len(a) - 1, int(round(p / 100.0 * (len(a) - 1))))] if a else None
+    ms = lambda v: round(v * 1000, 1) if v is not None else None
+    return {
+        "concurrency": conc, "tiles": len(regions),
+        "requests_ok": len(oks), "errors": sum(1 for _, ok in win if not ok),
+        "err_kinds": dict(errkind), "throughput_rps": round(len(oks) / dur, 2),
+        "p50_ms": ms(pct(oks, 50)), "p90_ms": ms(pct(oks, 90)),
+        "p99_ms": ms(pct(oks, 99)), "max_ms": ms(oks[-1]) if oks else None,
+    }
+
+
+def main():
+    base, idp, tile, out, concs, dur, warm = sys.argv[1:8]
+    info = json.load(urllib.request.urlopen(f"{base}/{idp}/info.json", timeout=30))
+    regions = tiles(info["width"], info["height"], int(tile))
+    print(f"image {info['width']}x{info['height']}, {len(regions)} distinct tiles")
+    for c in (int(x) for x in concs.split(",")):
+        print(json.dumps(run(base, idp, regions, out, c, float(dur), float(warm))))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Motivation

`just bench` measures a single decode in isolation. It cannot answer "how does a decode-path change behave when the request pool is saturated" — the regime that decides worker-thread counts and pool sizing, where a single-request speedup can coincide with no aggregate gain or even a regression. That gap is exactly what left the JP2 MT-decode thread-cap question (#749) undecidable from the microbench alone.

## Summary

- Add `just loadtest-decode "10,20,40"` — a concurrent-load measurement for the production Rust shell.
- Drives N concurrent clients requesting distinct native-resolution JP2 tiles (every request decodes) and reports throughput + p50/p90/p99 per concurrency level.
- Local dev loop, never CI-gated (same policy as `just bench`).

## Key Changes

### `config/sipi.loadtest-config.lua`
- Pool sized from host core count (`nthreads = 0`); tiny cache so distinct-region tile requests always miss and decode.

### `tools/loadtest/loadgen.py`
- Stdlib-only generator: discovers image dims from `info.json`, sweeps a comma-separated concurrency list, discards a warm-up window, reports throughput + latency percentiles and an error breakdown.

### `justfile` — `loadtest-decode`
- Builds `-c opt //src/cli-rs:sipi`, starts it on `config/sipi.loadtest-config.lua`, runs the sweep against `load_test.jpx`, tears the server down.

### `docs/src/development/benchmarking.md`
- New "Concurrent-load measurement" section: when to use it vs the microbench, the same-host / quiesced-machine rules, and the core-count-scaling caveat.

## Challenges and Decisions

### Why not extend `just bench`
**Problem:** the microbench harness is a single-threaded Google Benchmark loop; it structurally can't model concurrent requests through the real pool.
**Solution:** a separate harness that drives the actual production server binary over HTTP, so it exercises the Rust FFI pool + FFI seam + C++ decode exactly as production does.

### Forcing a real decode per request
**Problem:** cache hits would measure the cache, not decode.
**Tried:** varying output size — but edge tiles smaller than the requested width return IIIF 400 (no upscaling in 3.0).
**Solution:** request distinct tile **regions** at `max` (native resolution) — distinct cache keys, uniform decode cost, never upscales, and it mirrors a viewer's tile burst.

## Gotchas
- Compare a "before" branch against "after" **on the same host**, building each branch in turn — never run a build during a measurement (it steals cores).
- The effect of thread-count changes scales with core count, so a 10-core-laptop result does not settle behavior on a high-core production host.
- The Rust FFI pool already bounds concurrent decodes to its permit count, which caps the worst-case thread total — worth remembering when reasoning about oversubscription.

## Test Plan
- [x] `just loadtest-decode "4" 4 2` — builds, starts, measures, tears down cleanly; 0 errors; dims auto-discovered.
- [x] Used in anger to settle #749 (the thread-cap PR): showed flat throughput and no p99 benefit from capping on 10 cores, which is why #749 was closed and #743 kept uncapped.
- [x] `just --list` parses the new recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
