### PR TITLE
ci: attach Bazel build-event JSON for cache-hit-rate analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@
 #      so short-circuiting it on a lint finding saves the most. Linux legs
 #      additionally build the Docker image, run the Bazel-built smoke test
 #      against it, and feed Docker Scout; amd64 alone runs the differential
-#      parity gate and uploads the SARIF CVE scan.
+#      parity gate and uploads the SARIF CVE scan. Every leg writes its
+#      `just bazel-test` invocation's Build Event Protocol JSON and uploads it
+#      as a `bep-<platform>` artifact for offline cache-hit-rate analysis.
 #   3. `sanitizer-unit` / `sanitizer-e2e` — two parallel path-gated
 #      ASan+UBSan jobs (see the scope-rationale comment above those jobs).
 #   4. `docs` — MkDocs build.
@@ -189,7 +191,22 @@ jobs:
       - name: Build + run all tests
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
-        run: just bazel-test ${{ steps.setup.outputs.flags }}
+        run: just bazel-test ${{ steps.setup.outputs.flags }} --build_event_json_file=bep-${{ matrix.platform }}.json
+
+      # Attach the Build Event Protocol JSON so the action/remote cache hit
+      # rate can be analyzed offline. Bazel emits one BuildMetrics event per
+      # invocation whose actionSummary.runnerCount[] breaks actions down by
+      # runner type (total / remote cache hit / remote / local / internal) —
+      # the cache-hit signal, present in the default BEP without
+      # --build_event_publish_all_actions. `always()` so a failed build's
+      # breakdown (often the most interesting) is still captured.
+      - name: Upload build event JSON (cache-hit-rate analysis)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: bep-${{ matrix.platform }}
+          path: bep-${{ matrix.platform }}.json
+          retention-days: 30
 
       # The differential parity gate (Rust shell vs the retained C++ oracle)
       # is `manual`-tagged, so the `just bazel-test` wildcard above and
@@ -338,11 +355,22 @@ jobs:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
         run: |
           export ASAN_SYMBOLIZER_PATH="$(just asan-symbolizer)"
-          just bazel-test-unit --config=asan --config=ubsan --build_tag_filters=-no-sanitizer --test_tag_filters=-no-sanitizer ${{ steps.setup.outputs.flags }}
+          just bazel-test-unit --config=asan --config=ubsan --build_tag_filters=-no-sanitizer --test_tag_filters=-no-sanitizer ${{ steps.setup.outputs.flags }} --build_event_json_file=bep-sanitizer-unit.json
 
       - name: Check for sanitizer findings
         if: always()
         run: bash tools/check_sanitizer_findings.sh
+
+      # BEP for cache-hit-rate analysis (see the `test` job's upload step).
+      # This leg's instrumented sanitizer build has its own cache behavior
+      # worth tracking separately.
+      - name: Upload build event JSON (cache-hit-rate analysis)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: bep-sanitizer-unit
+          retention-days: 30
+          path: bep-sanitizer-unit.json
 
       - name: Upload sanitizer reports
         if: failure()
@@ -384,11 +412,22 @@ jobs:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
         run: |
           export ASAN_SYMBOLIZER_PATH="$(just asan-symbolizer)"
-          just bazel-test-e2e --config=asan --config=ubsan --test_tag_filters=-no-sanitizer ${{ steps.setup.outputs.flags }}
+          just bazel-test-e2e --config=asan --config=ubsan --test_tag_filters=-no-sanitizer ${{ steps.setup.outputs.flags }} --build_event_json_file=bep-sanitizer-e2e.json
 
       - name: Check for sanitizer findings
         if: always()
         run: bash tools/check_sanitizer_findings.sh
+
+      # BEP for cache-hit-rate analysis (see the `test` job's upload step).
+      # This leg's instrumented sanitizer build has its own cache behavior
+      # worth tracking separately.
+      - name: Upload build event JSON (cache-hit-rate analysis)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: bep-sanitizer-e2e
+          retention-days: 30
+          path: bep-sanitizer-e2e.json
 
       - name: Upload sanitizer reports
         if: failure()


### PR DESCRIPTION
## Motivation

The branch exists to measure how well the self-hosted NativeLink RBE backend serves CI. Nothing durable was captured before: Bazel's per-invocation cache breakdown printed to the INFO line and was lost when the runner was torn down. We want every build/test leg to persist the action/remote cache hit rate so it can be analyzed offline.

## Summary

- Every build/test leg writes its Bazel invocation's Build Event Protocol (BEP) JSON.
- Each leg uploads it as an artifact (30-day retention): the three `test` matrix legs (`bep-<platform>`) and both sanitizer legs (`bep-sanitizer-unit`, `bep-sanitizer-e2e`).

## Key Changes

### ci.yml `test` job
- Append `--build_event_json_file=bep-<platform>.json` to the "Build + run all tests" step.
- New `actions/upload-artifact@v7` step (`if: always()`) publishing `bep-<platform>`.
- Header comment updated to document the new artifact.

### ci.yml sanitizer jobs
- Append `--build_event_json_file=bep-sanitizer-{unit,e2e}.json` to each ASan+UBSan run step.
- New `if: always()` upload steps publishing `bep-sanitizer-unit` / `bep-sanitizer-e2e`. The instrumented sanitizer build has distinct cache behavior worth tracking separately.

## Challenges and Decisions

### Flag name changed upstream
**Problem:** The flag was historically `--experimental_build_event_json_file`; that spelling no longer works.
**Solution:** The prefix was dropped when the flag stabilized. `--build_event_json_file` is the current name, confirmed accepted by the pinned Bazel 9.1.0 (`bazel help build`).

### What to capture, and how much
**Tried/considered:** `--build_event_publish_all_actions` — rejected; it appends a per-action record and bloats the file.
**Solution:** Bazel's default BEP already carries one `BuildMetrics` event whose `actionSummary.runnerCount[]` breaks actions down by runner type (`total` / `remote cache hit` / `remote` / `local` / `internal`) — exactly the hit-rate signal. Each leg captures its single primary Bazel invocation.

### Where the flag lives
**Solution:** Appended in each CI step, not `.bazelrc` (a static path there would be overwritten by a leg's several bazel invocations, and can't vary per leg) and not the justfile recipe (would pollute local dev with stray BEP files). Matches the repo's \"recipes take positional flags, CI appends\" contract.

## Gotchas

- BEP JSON is **line-delimited** (one event per line), not a single JSON document. Parse with `jq -c 'select(.buildMetrics)'`, not a whole-file parse.
- On the `test` legs only the `just bazel-test` invocation is captured (not rustfmt/clippy/differential/smoke); each sanitizer leg captures its one run step.
- `if: always()` is intentional: a failed build's cache breakdown is often the most interesting.

## Test Plan

- [x] `bazel help build` lists `--build_event_json_file` (experimental spelling gone).
- [x] Local `bazel build --build_event_json_file=… //platforms:linux_x86_64` wrote the file; `jq '.buildMetrics.actionSummary.runnerCount'` returned the runner-type array.
- [ ] On this PR run, each `test / <platform>` leg produces a `bep-<platform>` artifact and each sanitizer leg produces `bep-sanitizer-{unit,e2e}`, all containing the `buildMetrics` event.

To analyze a downloaded artifact:
\`\`\`
jq -c 'select(.buildMetrics) | .buildMetrics.actionSummary.runnerCount' bep-linux-amd64.json
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)