### PR TITLE
ci: surface every commit type in the release notes

### DIFF
--- a/.github/release-please/config.json
+++ b/.github/release-please/config.json
@@ -9,13 +9,13 @@
     { "type": "fix", "section": "Bug Fixes" },
     { "type": "perf", "section": "Performance Improvements" },
     { "type": "revert", "section": "Reverts" },
-    { "type": "docs", "section": "Documentation", "hidden": true },
-    { "type": "style", "section": "Styles", "hidden": true },
-    { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
-    { "type": "refactor", "section": "Code Refactoring", "hidden": true },
-    { "type": "test", "section": "Tests", "hidden": true },
-    { "type": "build", "section": "Build System", "hidden": true },
-    { "type": "ci", "section": "Continuous Integration", "hidden": true }
+    { "type": "docs", "section": "Documentation" },
+    { "type": "style", "section": "Styles" },
+    { "type": "chore", "section": "Miscellaneous Chores" },
+    { "type": "refactor", "section": "Code Refactoring" },
+    { "type": "test", "section": "Tests" },
+    { "type": "build", "section": "Build System" },
+    { "type": "ci", "section": "Continuous Integration" }
   ],
   "packages": {".": {}},
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"

--- a/README.md
+++ b/README.md
@@ -131,21 +131,25 @@ The most important prefixes you should have in mind are:
 * `feat!:`,  or `fix!:`, `refactor!:`, etc., which represent a breaking change
   (indicated by the `!`) and will result in a SemVer major.
 
-This is the complete list of what is defined and if it is visible in the
-changelog:
+Every prefix is visible in the release notes. This is the complete list, in the
+order the sections are rendered:
+
 - 'feat' -> section: 'Features'
 - 'feature' -> section: 'Features'
 - 'fix' -> section: 'Bug Fixes'
 - 'perf' -> section: 'Performance Improvements'
 - 'revert' -> section: 'Reverts'
-- 'docs' -> section: 'Documentation', hidden: true
-- 'style' -> section: 'Styles', hidden: true
-- 'chore' -> section: 'Miscellaneous Chores', hidden: true
-- 'refactor' -> section: 'Code Refactoring', hidden: true
-- 'test' -> section: 'Tests', hidden: true
-- 'build' -> section: 'Build System', hidden: true
-- 'ci' -> section: 'Continuous Integration', hidden: true
-```
+- 'docs' -> section: 'Documentation'
+- 'style' -> section: 'Styles'
+- 'chore' -> section: 'Miscellaneous Chores'
+- 'refactor' -> section: 'Code Refactoring'
+- 'test' -> section: 'Tests'
+- 'build' -> section: 'Build System'
+- 'ci' -> section: 'Continuous Integration'
+
+The canonical prefix-to-release mapping, including the SemVer effect of each
+prefix, lives in
+[docs/src/development/ci.md](docs/src/development/ci.md#release-automation-release-please).
 
 # Contact Information
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -49,8 +49,10 @@ When release-please goes wrong:
   the correct prefix (or a `Release-As: X.Y.Z` footer commit) so
   release-please catches up. Do not edit `version.txt` / `CHANGELOG.md`
   by hand.
-- **Need to skip a release** — merge only non-release-bumping commits
-  (`docs:`, `chore:`, `refactor:`, `test:`, `build:`, `ci:`, `style:`).
+- **Need to skip a release** — leave the release PR unmerged. Every commit
+  type is changelog-visible, so any merge to `main` keeps a release PR open;
+  landing only internal-work commits no longer suppresses it. A release made
+  up solely of internal-work commits is a patch bump.
 - **Emergency patch on an old version** — branch from the tag, cherry-pick
   the fix, push a tag manually. `publish.yml` runs the same way.
 - **`publish.yml` fails after a tag** — fix forward; do not delete the tag.

--- a/docs/src/development/ci.md
+++ b/docs/src/development/ci.md
@@ -25,7 +25,19 @@ to determine the SemVer bump and generate the changelog.
 | `feat!:` / `fix!:` | major bump | Breaking Changes |
 | `perf:` | patch bump | Performance Improvements |
 | `revert:` | patch bump | Reverts |
-| `docs:`, `style:`, `refactor:`, `test:`, `build:`, `ci:`, `chore:` | no bump | hidden |
+| `docs:` | patch bump | Documentation |
+| `style:` | patch bump | Styles |
+| `chore:` | patch bump | Miscellaneous Chores |
+| `refactor:` | patch bump | Code Refactoring |
+| `test:` | patch bump | Tests |
+| `build:` | patch bump | Build System |
+| `ci:` | patch bump | Continuous Integration |
+
+Every commit with a valid prefix appears in the release notes, in its own
+section. The internal-work sections render after Features / Bug Fixes /
+Performance Improvements / Reverts. A release containing only internal-work
+commits is therefore a patch release — release-please keeps a release PR open
+for it, and the maintainer decides when to merge it.
 
 !!! warning "Correct commit prefixes are critical"
     A commit without a valid Conventional Commit prefix will be invisible to

--- a/docs/src/development/commit-conventions.md
+++ b/docs/src/development/commit-conventions.md
@@ -40,13 +40,17 @@ to determine SemVer bumps and generate the changelog —
 | `fix` | Bug fix (see [What `fix:` means](#what-fix-means)) | Bug Fixes | patch |
 | `perf` | Performance improvement | Performance Improvements | patch |
 | `revert` | Revert of a previous commit | Reverts | patch |
-| `refactor` | Code restructuring, no behavior change | hidden | none |
-| `docs` | Documentation | hidden | none |
-| `test` | Adding or refactoring tests | hidden | none |
-| `build` | Build system or dependencies | hidden | none |
-| `ci` | Continuous integration | hidden | none |
-| `style` | Formatting, no code change | hidden | none |
-| `chore` | Miscellaneous maintenance | hidden | none |
+| `refactor` | Code restructuring, no behavior change | Code Refactoring | patch |
+| `docs` | Documentation | Documentation | patch |
+| `test` | Adding or refactoring tests | Tests | patch |
+| `build` | Build system or dependencies | Build System | patch |
+| `ci` | Continuous integration | Continuous Integration | patch |
+| `style` | Formatting, no code change | Styles | patch |
+| `chore` | Miscellaneous maintenance | Miscellaneous Chores | patch |
+
+Every prefix in this table is visible in the release notes, in its own section.
+The bottom seven render after Features / Bug Fixes / Performance Improvements /
+Reverts.
 
 Breaking changes take a `!` suffix (or a `BREAKING CHANGE:` footer) and
 bump the **major** version:
@@ -65,7 +69,9 @@ eviction`, not `feat(cache): Add ...`).
 
 A `fix:` corrects behavior that exists on `main` — a bug a deployer could
 hit today, or that a released version shipped. It earns a "Bug Fixes"
-changelog line and a patch bump precisely because deployers need to know.
+changelog line precisely because deployers need to know. The same change
+filed as `chore:` or `refactor:` still appears in the release notes, but
+under a section nobody scanning for a regression will read.
 
 A bug you introduced earlier in the **same branch** is not a `fix:`. Fold
 it into the commit that introduced it (`git commit --fixup=<sha>`, then
@@ -114,12 +120,13 @@ self-contained changes that each stand on their own.
 
 ### Rules
 
-1. Each `feat:` or `fix:` commit = one changelog entry visible to
-   developers deploying Sipi.
+1. Each `feat:` or `fix:` commit = one changelog entry in the sections
+   developers deploying Sipi read first.
 2. Internal work (`build:`, `ci:`, `refactor:`, `docs:`, `chore:`,
-   `test:`) is hidden from the changelog — squash aggressively.
+   `test:`) lands in its own changelog section further down — squash
+   aggressively so those sections stay readable.
 3. Ask: "would a developer deploying Sipi care about this change?"
-   If yes → `feat:` or `fix:`. If no → hidden type.
+   If yes → `feat:` or `fix:`. If no → an internal-work prefix.
 4. Debugging journeys (trial-and-error, reverts of in-branch mistakes,
    iterative fixes) belong in the PR description, not the commit history.
    See [What `fix:` means](#what-fix-means).
@@ -128,7 +135,7 @@ self-contained changes that each stand on their own.
 
 | Layer | Audience | Content |
 |-------|----------|---------|
-| Commit messages | Release notes readers | User-visible changes only |
+| Commit messages | Release notes readers | Every change; `feat:`/`fix:` carry the user-visible ones |
 | PR description | Reviewers + future developers | Full context including challenges |
 | Learnings docs | Future Claude + engineers | Structured, searchable knowledge |
 | Code comments | Code readers | "Why not the obvious approach" |
@@ -187,7 +194,7 @@ learnings automatically.
 |-------------|-------------|
 | New feature / breaking change | Commit message (`feat:` / `feat!:`) |
 | Bug fix | Commit message (`fix:`) |
-| Build/CI/refactor details | Commit message (hidden type) |
+| Build/CI/refactor details | Commit message (`build:` / `ci:` / `refactor:`) |
 | Why the work was needed | PR Motivation section |
 | What was tried and failed | PR Challenges section |
 | Architecture decisions + rationale | PR Challenges section |

--- a/docs/src/development/reviewer-guidelines.md
+++ b/docs/src/development/reviewer-guidelines.md
@@ -19,7 +19,7 @@ Checklist for human and AI reviewers. Not every item applies to every PR — use
 
 ## Commit & PR Hygiene
 
-- [ ] Commits follow [commit-conventions.md](commit-conventions.md) — `feat:` / `fix:` for changelog-visible changes, `build:` / `test:` / `refactor:` for internal
+- [ ] Commits follow [commit-conventions.md](commit-conventions.md) — `feat:` / `fix:` for changes a deployer cares about, `build:` / `test:` / `refactor:` for internal work
 - [ ] One topic per commit (rebase-merge = commits land as-is on `main`)
 - [ ] PR description follows the template (Motivation, Summary, Key Changes, Test Plan)
 


### PR DESCRIPTION
## Motivation

The release-please config hid seven of the twelve configured commit types, so a
release listed only `feat`/`fix`/`perf`/`revert` work. v6.2.0 shipped two
Features lines and nothing else, despite containing substantial refactor, test
and CI work. The changelog misrepresented what was actually released.

## Summary

- Every commit with a valid Conventional Commit prefix now appears in the
  release notes.
- The seven previously-hidden types keep their original section titles and
  render after Features / Bug Fixes / Performance Improvements / Reverts.
- Release *triggering* changes too: a push of only internal-work commits now
  proposes a patch release instead of nothing.

## Key Changes

### `.github/release-please/config.json`

Dropped `"hidden": true` from `docs`, `style`, `chore`, `refactor`, `test`,
`build` and `ci`. Section titles are unchanged (Documentation, Styles,
Miscellaneous Chores, Code Refactoring, Tests, Build System, Continuous
Integration). Their position in the `changelog-sections` array is what puts
them last, so the array order is load-bearing — see Gotchas.

### Documentation

- `docs/src/development/ci.md` — the canonical prefix table now has one row per
  prefix with its real section, and states the patch-release consequence.
- `docs/src/development/commit-conventions.md` — prefix table, the
  "What `fix:` means" rationale, the commit-organization rules, and two
  "what goes where" cells no longer describe a hidden/visible split.
- `README.md` — the duplicated config listing is accurate again and points at
  `ci.md` as canonical. Also removed an orphan closing code fence that had no
  opener (pre-existing defect in the block being rewritten).
- `RELEASING.md` — "skip a release" no longer says to land only non-bumping
  prefixes, which stops working with this change.
- `docs/src/development/reviewer-guidelines.md` — "changelog-visible" is no
  longer a discriminator between prefixes.

## Challenges and Decisions

### Un-hiding types changes when releases happen, not just what they show

**Problem:** the obvious reading is that `hidden` is cosmetic. It is not.

**Solution:** confirmed in release-please's source before committing. `Strategy.buildReleasePullRequest`
gates the entire release PR on `changelogEmpty(releaseNotesBody)` ("No user
facing commits found - skipping"), and `DefaultVersioningStrategy.determineReleaseType`
falls through to `PatchVersionUpdate()` when no `feat`/breaking commit is
present. So the same emptiness check that hid the notes was also suppressing
the release PR. Once the types are visible, any merge to `main` keeps a release
PR open, and a maintenance-only release is a patch bump. Merge timing is still
entirely the maintainer's, so this was accepted deliberately rather than worked
around; `RELEASING.md` is updated to match.

### One "Maintenance" section vs. the original per-type sections

**Tried:** collapsing all seven onto a single `Maintenance` section.

**Problem:** the preset renders entries as `* **scope:** subject` — the *type*
is never printed. Merged into one section, a `ci(bazel):` and a `docs(bazel):`
commit become indistinguishable.

**Solution:** kept the original per-type section titles. Each type gets its own
header, so no fidelity is lost.

## Gotchas

- **The order of `changelog-sections` is load-bearing.**
  `conventional-changelog-conventionalcommits` builds
  `commitGroupOrder = config.types.flatMap(t => t.section)` and sorts groups by
  `indexOf(title)`. Moving an entry up in that array moves its section up in
  every future changelog. Keep the internal-work entries last.
- **A `release-please --dry-run` reads the config from the target branch on
  GitHub, not your working tree.** Running it while the change was uncommitted
  reported the *old* behavior and looked like the change had no effect. Pass
  `--target-branch=<your branch>` after pushing.
- **`--dry-run` is mandatory** when exercising `release-pr` by hand; without it
  the command opens a real release PR.

## Test Plan

- [x] `jq` — config is valid JSON and no `hidden` flags remain.
- [x] Rendered a changelog locally through the exact preset release-please uses
      (`conventional-changelog-conventionalcommits@6` +
      `conventional-changelog-writer@6`), feeding one commit per configured type
      in deliberately scrambled order: all 11 sections rendered, in config order,
      internal-work sections after Reverts.
- [x] `release-please release-pr --target-branch=ci/surface-all-commit-types --dry-run`
      against this pushed branch: Documentation, Miscellaneous Chores, Code
      Refactoring, Tests, Build System and Continuous Integration all now appear
      after Bug Fixes and Performance Improvements, proposing 6.2.1.
- [ ] CI `docs` job (`just docs-build`, mkdocs strict) passes — could not be run
      locally, mkdocs is not in the dev shell and the system copy has a broken
      interpreter.
- [ ] Ground truth after merge: the release PR on `main` shows the new sections.

No code changed, so the Rust lint gates (`bazel-rustfmt-check`,
`bazel-clippy-check`) are not implicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
