### PR TITLE
ci: attach the Bazel build event JSON to the publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,21 @@ jobs:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - name: Build Docker image (Bazel rules_oci)
-        run: just bazel-docker-build-${{ matrix.arch }} ${{ steps.setup.outputs.flags }}
+        run: just bazel-docker-build-${{ matrix.arch }} ${{ steps.setup.outputs.flags }} --build_event_json_file=bep-validate-${{ matrix.arch }}.json
+      # Attach the Build Event Protocol JSON so the action/remote cache hit
+      # rate can be analyzed offline (cf. ci.yml). Bazel emits one
+      # BuildMetrics event per invocation whose actionSummary.runnerCount[]
+      # breaks actions down by runner type (total / remote cache hit /
+      # remote / local / internal) — the cache-hit signal, present in the
+      # default BEP. `always()` so a failed build's breakdown (often the
+      # most interesting) is still captured.
+      - name: Upload build event JSON (cache-hit-rate analysis)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: bep-validate-${{ matrix.arch }}
+          path: bep-validate-${{ matrix.arch }}.json
+          retention-days: 30
       # Exercise the release-only debug-symbol extraction in the validation
       # stage so it can't silently break at publish time (as it did for
       # v6.0.0). The artifact is discarded here — publish-docker rebuilds it
@@ -121,7 +135,17 @@ jobs:
         # Binary version + OCI image tag come from version.txt, which
         # release-please updates before cutting the tag — no extra
         # plumbing required to keep them in sync with `${github.ref_name}`.
-        run: just bazel-docker-build-${{ matrix.arch }} ${{ steps.setup.outputs.flags }}
+        run: just bazel-docker-build-${{ matrix.arch }} ${{ steps.setup.outputs.flags }} --build_event_json_file=bep-publish-${{ matrix.arch }}.json
+      # Attach the Build Event Protocol JSON so the action/remote cache hit
+      # rate can be analyzed offline (cf. ci.yml). See the validate-docker
+      # job for the actionSummary.runnerCount[] breakdown this captures.
+      - name: Upload build event JSON (cache-hit-rate analysis)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: bep-publish-${{ matrix.arch }}
+          path: bep-publish-${{ matrix.arch }}.json
+          retention-days: 30
       - name: Extract debug symbols for Sentry upload
         # The genrule depends on `:sipi`, already built and in the
         # remote cache from the build step just above.


### PR DESCRIPTION
## Motivation
The `ci.yml` legs attach their Bazel invocation's Build Event Protocol (BEP) JSON as a `bep-<platform>` artifact so the remote/action cache hit rate can be analyzed offline. The `publish.yml` workflow runs its own Bazel-heavy Docker builds against the same RBE backend but produced no such artifact, leaving a blind spot for release-time cache behavior.

## Summary
- Attach BEP JSON to the `bazel-docker-build` step in the `validate-docker` and `publish-docker` jobs.
- Upload each as an artifact (`bep-validate-<arch>` / `bep-publish-<arch>`, 30-day retention, `always()`).

## Key Changes
### publish.yml
- `validate-docker`: `--build_event_json_file=bep-validate-<arch>.json` on the build step + upload.
- `publish-docker`: `--build_event_json_file=bep-publish-<arch>.json` on the build step + upload.

## Challenges and Decisions
### Which invocation carries the BEP
**Problem:** Each job runs several Bazel invocations (build, extract-debug, smoke); a Bazel invocation writes one BEP file and a later invocation to the same path would overwrite it.
**Solution:** Attach to the `bazel-docker-build` step — the heaviest and most cache-sensitive invocation — matching ci.yml's choice of instrumenting the single primary build+test step.

## Gotchas
- BEP files are per-invocation. If you later want the smoke-test invocation captured too, give it its own distinct `--build_event_json_file` path rather than reusing the build's.

## Test Plan
- [ ] Tag push triggers `publish.yml`; confirm `bep-validate-<arch>` and `bep-publish-<arch>` artifacts appear on both jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)