### PR TITLE
Tighten and enforce SIPI commit conventions

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,0 +1,26 @@
+# commitlint-rs config — enforced by the `commit-lint` CI job and `just commit-lint`.
+# See docs/src/development/commit-conventions.md for the human-facing rules.
+#
+# The `type` allowlist is the eight allowed types (the machine source for the
+# release-please rendering is .github/release-please/config.json). `scope-empty`
+# makes the scope mandatory so every changelog line reads `concern: subject`.
+# There is deliberately NO `scope` allowlist: we have no closed scope vocabulary
+# yet, so the gate requires a scope but does not restrict which one.
+rules:
+  type:
+    level: error
+    options:
+      - feat
+      - fix
+      - perf
+      - refactor
+      - docs
+      - test
+      - build
+      - chore
+  type-empty:
+    level: error
+  scope-empty:
+    level: error
+  subject-empty:
+    level: error

--- a/.github/actions/commit-lint/action.yml
+++ b/.github/actions/commit-lint/action.yml
@@ -1,0 +1,39 @@
+name: commit-lint
+description: >
+  Lint the PR's commit messages with commitlint-rs — the type allowlist +
+  mandatory scope from `.commitlintrc.yml`. Runs the same `just commit-lint`
+  recipe developers run locally. Self-contained: needs only git + cargo + just,
+  not the Bazel `ci-setup` path. See docs/src/development/commit-conventions.md.
+
+inputs:
+  base-ref:
+    description: >
+      Base commit/ref; commits in `<base-ref>..HEAD` are linted. Pass the PR
+      base SHA (github.event.pull_request.base.sha).
+    required: true
+  version:
+    description: commitlint-rs version to install via cargo.
+    default: "0.2.4"
+
+runs:
+  using: composite
+  steps:
+    - uses: extractions/setup-just@v3
+
+    # Cache the compiled binary so `cargo install` only pays the build cost when
+    # the pinned version changes.
+    - name: Cache commitlint-rs
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cargo/bin/commitlint
+        key: commitlint-rs-${{ runner.os }}-${{ inputs.version }}
+
+    - name: Install commitlint-rs
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: cargo install commitlint-rs --version "${{ inputs.version }}" --locked
+
+    - name: Lint commit messages
+      shell: bash
+      run: just commit-lint "${{ inputs.base-ref }}"

--- a/.github/release-please/config.json
+++ b/.github/release-please/config.json
@@ -8,14 +8,14 @@
     { "type": "feature", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },
     { "type": "perf", "section": "Performance Improvements" },
-    { "type": "revert", "section": "Reverts" },
-    { "type": "docs", "section": "Documentation" },
-    { "type": "style", "section": "Styles" },
-    { "type": "chore", "section": "Miscellaneous Chores" },
     { "type": "refactor", "section": "Code Refactoring" },
+    { "type": "docs", "section": "Documentation" },
     { "type": "test", "section": "Tests" },
     { "type": "build", "section": "Build System" },
-    { "type": "ci", "section": "Continuous Integration" }
+    { "type": "chore", "section": "Miscellaneous Chores" },
+    { "type": "revert", "hidden": true },
+    { "type": "style", "hidden": true },
+    { "type": "ci", "hidden": true }
   ],
   "packages": {".": {}},
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -464,3 +464,21 @@ jobs:
       - uses: extractions/setup-just@v3
       - run: just docs-install-requirements
       - run: just docs-build
+
+  # Enforce commit conventions (type allowlist + mandatory scope) on the PR's
+  # commits via commitlint-rs. See docs/src/development/commit-conventions.md.
+  commit-lint:
+    name: commit-lint
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-commit-lint-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          lfs: false
+      - uses: ./.github/actions/commit-lint
+        with:
+          base-ref: ${{ github.event.pull_request.base.sha }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,7 +184,7 @@ For CI pipeline details (Docker publishing, release automation), see [`docs/src/
 
 **Releases are automated via release-please.** Correct [Conventional Commit](https://www.conventionalcommits.org/) prefixes are required — they drive SemVer bumps and changelog generation. See [`docs/src/development/ci.md`](docs/src/development/ci.md) for the full prefix-to-release mapping.
 
-Valid prefixes: `feat`, `fix`, `perf`, `revert`, `refactor`, `docs`, `style`, `test`, `build`, `chore`, `ci`. Breaking changes use `!` suffix: `feat!: ...`. The scope is a module name from [`CONVENTIONS.md` § Module Layout](CONVENTIONS.md); if none fits, ask the maintainer before coining a new one.
+Valid types (exactly eight): `feat`, `fix`, `perf`, `refactor`, `docs`, `test`, `build`, `chore`. `revert`, `style`, and `ci` are **not** valid — use `chore(ci): ...`, fold formatting in, and `fix`/`chore` for reverts. Breaking changes use `!` suffix: `feat(scope)!: ...`. **A scope is mandatory** (`type(scope): subject`, no catch-all) — a module name from [`CONVENTIONS.md` § Module Layout](CONVENTIONS.md); if none fits, ask the maintainer before coining a new one. A CI gate (`commitlint-rs`, `just commit-lint`) enforces this. Full schema single-sourced in [`docs/src/development/commit-conventions.md`](docs/src/development/commit-conventions.md).
 
 **A PR lands as one commit by default.** Rebase-merge puts every branch commit on `main` verbatim — there is no squash safety net. Clean up the branch before merge; split into multiple commits only when the work is genuinely several independent, self-contained changes. A `fix:` corrects behavior already on `main`; a bug introduced earlier in the same branch is folded into its introducing commit, never a standalone `fix:`.
 

--- a/README.md
+++ b/README.md
@@ -121,35 +121,18 @@ Releases are published on Dockerhub: https://hub.docker.com/repository/docker/da
 
 ## How should I write my commits?
 
-We are using [Conventional Commit messages](https://www.conventionalcommits.org/).
+We use [Conventional Commit messages](https://www.conventionalcommits.org/), and
+**every commit needs both a type and a scope** — `type(scope): subject`. The most
+important prefixes:
 
-The most important prefixes you should have in mind are:
+* `fix(scope):` — a bug fix, a [SemVer](https://semver.org/) patch.
+* `feat(scope):` — a new feature, a SemVer minor.
+* `feat(scope)!:`, `fix(scope)!:`, etc. — a breaking change (the `!`), a SemVer major.
 
-* `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/)
-  patch.
-* `feat:` which represents a new feature, and correlates to a SemVer minor.
-* `feat!:`,  or `fix!:`, `refactor!:`, etc., which represent a breaking change
-  (indicated by the `!`) and will result in a SemVer major.
-
-Every prefix is visible in the release notes. This is the complete list, in the
-order the sections are rendered:
-
-- 'feat' -> section: 'Features'
-- 'feature' -> section: 'Features'
-- 'fix' -> section: 'Bug Fixes'
-- 'perf' -> section: 'Performance Improvements'
-- 'revert' -> section: 'Reverts'
-- 'docs' -> section: 'Documentation'
-- 'style' -> section: 'Styles'
-- 'chore' -> section: 'Miscellaneous Chores'
-- 'refactor' -> section: 'Code Refactoring'
-- 'test' -> section: 'Tests'
-- 'build' -> section: 'Build System'
-- 'ci' -> section: 'Continuous Integration'
-
-The canonical prefix-to-release mapping, including the SemVer effect of each
-prefix, lives in
-[docs/src/development/ci.md](docs/src/development/ci.md#release-automation-release-please).
+A CI gate (`commitlint-rs`) enforces the type + mandatory scope. The full type
+list, the scope vocabulary, what `fix:` means, and how to run the check locally
+(`just commit-lint`) all live in one place —
+[docs/src/development/commit-conventions.md](docs/src/development/commit-conventions.md).
 
 # Contact Information
 

--- a/docs/src/development/ci.md
+++ b/docs/src/development/ci.md
@@ -16,34 +16,24 @@ to determine the SemVer bump and generate the changelog.
 - `.github/release-please/manifest.json` — current version
 - `.github/workflows/release-please.yml` — GitHub Actions workflow
 
-**How commit types map to releases:**
+**How commit types map to releases:** the type → changelog-section → SemVer-bump
+table is single-sourced in
+[Commit and PR Conventions § Commit message schema](commit-conventions.md#commit-message-schema).
+The machine source release-please actually reads is
+[`.github/release-please/config.json`](../../../.github/release-please/config.json).
 
-| Prefix | SemVer effect | Changelog section |
-|--------|--------------|-------------------|
-| `feat:` | minor bump | Features |
-| `fix:` | patch bump | Bug Fixes |
-| `feat!:` / `fix!:` | major bump | Breaking Changes |
-| `perf:` | patch bump | Performance Improvements |
-| `revert:` | patch bump | Reverts |
-| `docs:` | patch bump | Documentation |
-| `style:` | patch bump | Styles |
-| `chore:` | patch bump | Miscellaneous Chores |
-| `refactor:` | patch bump | Code Refactoring |
-| `test:` | patch bump | Tests |
-| `build:` | patch bump | Build System |
-| `ci:` | patch bump | Continuous Integration |
+Every commit appears in the release notes in its own section, and — because the
+scope is mandatory — each line reads `concern: subject`. A release containing only
+internal-work commits (`refactor`/`docs`/`test`/`build`/`chore`) is a patch release:
+release-please keeps a release PR open for it, and the maintainer decides when to
+merge it.
 
-Every commit with a valid prefix appears in the release notes, in its own
-section. The internal-work sections render after Features / Bug Fixes /
-Performance Improvements / Reverts. A release containing only internal-work
-commits is therefore a patch release — release-please keeps a release PR open
-for it, and the maintainer decides when to merge it.
-
-!!! warning "Correct commit prefixes are critical"
-    A commit without a valid Conventional Commit prefix will be invisible to
-    release-please — it won't trigger a release or appear in the changelog.
-    See [Commit and PR Conventions](commit-conventions.md) for the full
-    commit message schema, scope vocabulary, and what `fix:` means.
+!!! warning "Correct type + scope are critical, and enforced"
+    A commit without a valid type is invisible to release-please — it won't trigger
+    a release or appear in the changelog. Both the type (one of the eight allowed)
+    and a mandatory scope are enforced in CI by the `commit-lint` job (`commitlint-rs`).
+    See [Commit and PR Conventions](commit-conventions.md) for the full schema, the
+    scope vocabulary, what `fix:` means, and `just commit-lint`.
 
 ## Pull request CI
 

--- a/docs/src/development/commit-conventions.md
+++ b/docs/src/development/commit-conventions.md
@@ -34,28 +34,30 @@ to determine SemVer bumps and generate the changelog —
     type(scope): subject
     body
 
-| Prefix | Meaning | Changelog section | Version bump |
+**Every commit has a type and a scope** — both are mandatory (see
+[Scopes](#scopes)). This is the whole table; there are exactly eight types:
+
+| Type | Meaning | Changelog section | Version bump |
 |--------|---------|-------------------|--------------|
 | `feat` | New user-visible functionality | Features | minor |
 | `fix` | Bug fix (see [What `fix:` means](#what-fix-means)) | Bug Fixes | patch |
 | `perf` | Performance improvement | Performance Improvements | patch |
-| `revert` | Revert of a previous commit | Reverts | patch |
 | `refactor` | Code restructuring, no behavior change | Code Refactoring | patch |
 | `docs` | Documentation | Documentation | patch |
 | `test` | Adding or refactoring tests | Tests | patch |
 | `build` | Build system or dependencies | Build System | patch |
-| `ci` | Continuous integration | Continuous Integration | patch |
-| `style` | Formatting, no code change | Styles | patch |
 | `chore` | Miscellaneous maintenance | Miscellaneous Chores | patch |
 
-Every prefix in this table is visible in the release notes, in its own section.
-The bottom seven render after Features / Bug Fixes / Performance Improvements /
-Reverts.
+Every type is visible in the release notes, in its own section, rendered in the
+order above. Because the scope is mandatory, every changelog line reads
+`concern: subject`. This table is the single human source for the type
+vocabulary; the machine source is
+[`.github/release-please/config.json`](../../../.github/release-please/config.json).
 
 Breaking changes take a `!` suffix (or a `BREAKING CHANGE:` footer) and
 bump the **major** version:
 
-    feat!: remove the deprecated cache-purge endpoint
+    feat(cache)!: remove the deprecated cache-purge endpoint
 
 Example:
 
@@ -64,6 +66,21 @@ Example:
 The release-please config sentence-cases subjects in the changelog, so
 write the subject in normal prose case (`feat(cache): add dual-limit
 eviction`, not `feat(cache): Add ...`).
+
+### Removed types
+
+`revert`, `style`, and `ci` are **not** valid types — the commit-lint gate
+rejects them, and release-please hides them if one ever slips onto `main`.
+
+- **CI/build automation** → `chore(ci): ...` (lands in Miscellaneous Chores).
+  Dividing CI into concerns is not worthwhile, and a dedicated Continuous
+  Integration changelog section is noise; it belongs under maintenance.
+- **Formatting-only changes** → fold into the functional commit, or
+  `chore(<scope>): ...`. `rustfmt`/`clang-format` are enforced gates, so a
+  standalone formatting commit should be rare.
+- **Reverts** → `fix(<scope>): revert ...` or `chore(<scope>): revert ...`
+  depending on whether it corrects released behavior. (release-please's built-in
+  revert auto-negation no longer applies; reverts are rare and handled by hand.)
 
 ### What `fix:` means
 
@@ -83,6 +100,9 @@ unrelated work, give it its **own** `fix:` commit — don't bury it inside
 the `feat:`/`refactor:` you happened to be writing.
 
 ## Scopes
+
+**A scope is mandatory.** Every commit is `type(scope): subject`, so every
+release-notes line reads `concern: subject`. There is no scopeless form.
 
 The scope names the **concern the change serves** — the module whose
 responsibility it belongs to, not the directory the edited files happen to
@@ -107,16 +127,40 @@ these names, lowercase:
 Rules:
 
 - Lowercase, kebab-case. `ci` not `CI`; `bazel` not `bazel-build`.
-- Scope is optional. Omit it for genuinely repo-wide changes
-  (`chore: ...`, `ci: ...`).
 - A commit that spans several modules may list them comma-separated:
   `refactor(cli-rs,server-rs): ...`.
 - **Concern over location.** When code for one module's responsibility lives
   under another module's directory, scope by the responsibility, not the
   enclosing directory. `server-rs/src/metrics.rs` → `observability`.
-- **If none of the enumerated scopes genuinely fits, ask the maintainer
-  before inventing a new one.** New scopes are added to the canonical
-  list in `CONVENTIONS.md` deliberately, not ad hoc.
+- **No catch-all.** There is no `repo`/`all` scope. If none of the enumerated
+  scopes genuinely fits, ask the maintainer before inventing one — new scopes
+  are added to the canonical list in `CONVENTIONS.md` deliberately, not ad hoc.
+
+The commit-lint gate enforces only that a scope is *present* (it does not yet
+restrict *which* scope — there is no closed vocabulary). The list above is the
+advisory vocabulary; keep to it.
+
+## Enforcement
+
+Commit messages are gated in CI by
+[`commitlint-rs`](https://github.com/KeisukeYamashita/commitlint-rs) via the
+`commit-lint` job in [`ci.yml`](../../../.github/workflows/ci.yml) (a composite
+action at `.github/actions/commit-lint`). The rules live in
+[`.commitlintrc.yml`](../../../.commitlintrc.yml): the `type` allowlist above is
+mandatory, `scope-empty` makes the scope mandatory, and the subject must be
+non-empty.
+
+Run the same check locally before pushing:
+
+    just commit-lint            # lints origin/main..HEAD
+    just commit-lint <base-ref> # lints <base-ref>..HEAD
+
+`commitlint-rs` is in the Nix dev shell (`nix develop`); CI installs it with
+`cargo install`.
+
+Merge commits are skipped by the linter (message rules do not apply to them). The
+rebase workflow is enforced separately by the `require linear history`
+branch-protection rule, which blocks any merge commit from landing on `main`.
 
 ## Commit Organization
 

--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,11 @@
             go-containerregistry
             just
 
+            # commitlint-rs — the `commit-lint` gate (`just commit-lint`).
+            # Enforces the type allowlist + mandatory scope from `.commitlintrc.yml`.
+            # Local only; CI installs it via `cargo install commitlint-rs`.
+            commitlint-rs
+
             # jpylyzer — JP2 conformance validator. Runs against
             # regenerated JP2 goldens to confirm the SIPI UUID box reads as an
             # informational `Unknown UUID` and the file otherwise passes

--- a/justfile
+++ b/justfile
@@ -148,6 +148,38 @@ bazel-rustfmt-check *FLAGS='':
 bazel-clippy-check *FLAGS='':
     bazel build //src/server-rs/... //src/cli-rs/... //test/e2e/... --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect --output_groups=clippy_checks --@rules_rust//rust/settings:clippy_flags=-Dwarnings {{FLAGS}}
 
+# Lint commit messages with commitlint-rs — the CI `commit-lint` gate. Enforces
+# the type allowlist + mandatory scope from `.commitlintrc.yml` on every commit in
+# `<from>..HEAD` (`from` defaults to origin/main). `commitlint` is in the Nix dev
+# shell; CI installs it via `cargo install`.
+#
+# We feed one message at a time on stdin instead of commitlint's `--from/--to`
+# range mode: commitlint-rs reads stdin whenever stdin is not a TTY (always true
+# in CI and under `just`), so range mode is unreachable in automation. The loop
+# also attributes each failure to its commit and is a no-op on an empty range.
+# `--no-merges` skips merge commits, so neither the synthetic `refs/pull/N/merge`
+# commit GitHub checks out for a PR nor a merge a developer created locally is
+# message-checked here. That is deliberate: message rules do not apply to merges,
+# and the `require linear history` branch-protection rule is what actually blocks a
+# merge commit from landing on `main`. See `docs/src/development/commit-conventions.md`.
+commit-lint from="origin/main":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    base="$(git merge-base "{{from}}" HEAD)"
+    fail=0
+    while IFS= read -r sha; do
+        [ -n "$sha" ] || continue
+        if ! git log -1 --pretty=%B "$sha" | commitlint; then
+            echo "  ↳ offending commit: $(git log -1 --pretty='%h %s' "$sha")" >&2
+            fail=1
+        fi
+    done < <(git rev-list --no-merges --reverse "$base..HEAD")
+    if [ "$fail" -ne 0 ]; then
+        echo "commit-lint: one or more commits violate the convention (see above)" >&2
+        exit 1
+    fi
+    echo "commit-lint: all commits in $base..HEAD OK"
+
 # (Re)generate rust-project.json so rust-analyzer understands the Bazel crate
 # graph (cargo can't see the rules_rust targets). The file is git-ignored — it
 # holds machine-absolute paths. Re-run after adding/moving a Rust target or dep.


### PR DESCRIPTION
## Motivation
Commit conventions drive release-please (SemVer bumps + changelog), but the rules
were loose and duplicated. Scope was optional, so release-notes lines came out
scopeless ("Enable misc plugin"); `revert`/`style`/`ci` added changelog sections
nobody needs; and the type list was copied across five places. Nothing enforced any
of it — with rebase-merge, whatever lands on the branch ships verbatim.

## Summary
- Every commit now needs a **type and a mandatory scope**, so every release-notes line reads `concern: subject`.
- Type set reduced to eight (dropped `revert`, `style`, `ci`); the vocabulary is single-sourced in `commit-conventions.md`.
- A CI gate (`commitlint-rs`) plus a local `just commit-lint` enforce it.

## Key Changes
### Rules + single-sourcing
- `.github/release-please/config.json`: eight visible types; `revert`/`style`/`ci` set `hidden: true` (release-please shows `revert` by default otherwise).
- `docs/src/development/commit-conventions.md` is the single human source — mandatory-scope rule, merged SemVer column, new **Removed types** and **Enforcement** sections.
- `README.md`, `docs/src/development/ci.md`, `CLAUDE.md`: dropped their duplicated type lists, now point at `commit-conventions.md`.

### Enforcement (commitlint-rs)
- `.commitlintrc.yml`: `type` allowlist + `scope-empty` (mandatory scope). No scope allowlist — there is no closed vocabulary yet.
- `just commit-lint [from]`: lints each commit in `<from>..HEAD`.
- `flake.nix`: `commitlint-rs` in the dev shell (local).
- `.github/actions/commit-lint` composite action (`cargo install` + cached) wired into a new `commit-lint` job in `ci.yml` (PR-only). No standalone workflow.

## Challenges and Decisions
### Tool choice — commitlint-rs over cocogitto/conform
**Problem:** the hard requirement is a *mandatory scope*, which Conventional Commits treats as optional.
**Tried:** cocogitto (what dsp-repository #299 uses) and conform both validate format only — neither can require a scope (conform's source: `// Scope is optional`; its "Enforce scope" issue was auto-closed NOT_PLANNED). A hand-rolled script would re-solve a solved problem.
**Solution:** commitlint-rs is the only Rust/no-Node tool with a first-class `scope-empty` rule. Bus-factor (small project) is hedged: tiny codebase, and its config/CLI mirror the mature JS commitlint as an escape hatch.

### commitlint-rs range mode is unusable in automation
**Problem:** `commitlint --from/--to` silently reads stdin whenever stdin is not a TTY (always, in CI and under `just`), so it lints empty stdin and false-fails.
**Solution:** the `commit-lint` recipe loops over `git rev-list` and pipes each commit's message to `commitlint` on stdin. commitlint still does all rule logic; the loop only feeds messages and attributes failures to the offending commit. Empty range is a no-op.

## Gotchas
- Provisioning is split by design: **nixpkgs locally**, **`cargo install` in CI** — do not expect commitlint on CI runners without the composite action.
- Divergence from dsp-repository (which uses cocogitto + a bash wrapper and keeps optional scope): SIPI is intentionally stricter. Aligning the sibling onto commitlint-rs is a possible follow-up.
- Reverts lose release-please's auto-negation (since `revert` is no longer a type); use `fix(scope): revert ...`. Reverts are rare and handled by hand.

## Test Plan
- [x] `.commitlintrc.yml` rules verified: `feat(image): x` passes; `feat: x` (no scope) fails; `ci(x): y` fails; `chore(ci): y` passes; `feat(cache)!: x` passes; `wip stuff` fails.
- [x] `just commit-lint` clean on an empty range; fails with per-commit attribution on a bad commit; both commits in this PR pass.
- [x] `jq` validates `config.json` (8 visible, 3 hidden); all new YAML parses.
- [ ] CI `commit-lint` job runs green on this PR (self-testing, since the workflow change is in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
