### PR TITLE
chore(ci): run e2e tests on RBE and speed up the sanitizer job

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -244,10 +244,11 @@ build:asan --@llvm//config:asan=true
 # every leak in one report rather than needing N reruns.
 test:asan --test_env=ASAN_OPTIONS=detect_leaks=1:halt_on_error=0:log_path=$TEST_UNDECLARED_OUTPUTS_DIR/asan-e2e
 
-# The sanitizer runtime needs the symbolizer path inside the test sandbox;
-# passthrough form inherits the client-env value (CI exports it via
-# `just asan-symbolizer`) and is a no-op when unset.
-test:asan --test_env=ASAN_SYMBOLIZER_PATH
+# ASAN_SYMBOLIZER_PATH is NOT forwarded from the client env here: the e2e test
+# macro (`test/e2e/sipi_e2e_test.bzl`) attaches `//bazel:llvm-symbolizer` as a
+# runfile under `--config=asan` and sets the env to its runfiles-relative path,
+# so LSan symbolization works when the test executes on the RBE worker (a
+# runner-side absolute path would not exist there).
 
 # Neutralize production hardening for UBSan — same rationale as `build:asan`.
 build:ubsan --copt=-U_FORTIFY_SOURCE

--- a/.github/actions/bazel-rbe/action.yml
+++ b/.github/actions/bazel-rbe/action.yml
@@ -76,31 +76,39 @@ runs:
         # operations.md). Retune alongside nativelink_worker_count as more
         # repositories onboard.
         FLAGS="$FLAGS --jobs=192"
-        # Cross-compile on the x86_64 worker, run tests on the native runner:
+        # Compile on the x86_64 worker; where tests EXECUTE depends on the leg (below):
         #   --extra_execution_platforms pins the EXEC platform to the worker (x86_64) so
         #     exec-config build tools resolve to x86_64, not the runner's arch (that
         #     mismatch ships an arm64/darwin tool to the x86_64 worker → it can't run).
         #   --platforms sets the TARGET arch this runner builds for.
-        #   --strategy=TestRunner=local runs the cross-built test binary on the runner.
         FLAGS="$FLAGS --remote_executor=$RBE_RUNNER_ENDPOINT --remote_default_exec_properties=cpu_arch=x86_64"
-        # Exec platforms: the x86_64 worker FIRST (compiles/exec tools prefer it), plus
-        # the target platform so Bazel's test toolchain can resolve an exec platform
-        # matching the target arch and run tests on the native runner. For cross legs the
-        # target arch's exec toolchains don't match x86_64-only rules, so compiles still
-        # land on the worker; only the test toolchain picks the target-arch platform.
+        # Exec platforms: the x86_64 worker FIRST (compiles/exec tools prefer it). For
+        # cross legs the target platform is appended so Bazel's test toolchain can
+        # resolve an exec platform matching the target arch and run tests on the native
+        # runner; the target arch's exec toolchains don't match x86_64-only rules, so
+        # compiles still land on the worker.
         if [ "$RBE_TARGET_PLATFORM" = "//platforms:linux_x86_64" ]; then
           EXEC_PLATFORMS="//platforms:linux_x86_64"
         else
           EXEC_PLATFORMS="//platforms:linux_x86_64,$RBE_TARGET_PLATFORM"
         fi
         FLAGS="$FLAGS --extra_execution_platforms=$EXEC_PLATFORMS --platforms=$RBE_TARGET_PLATFORM"
-        FLAGS="$FLAGS --strategy=TestRunner=local"
         if [ "$RBE_TARGET_PLATFORM" != "//platforms:linux_x86_64" ]; then
-          # Cross legs (arm64/darwin runner → x86_64 worker): pin the host config to
-          # x86_64 so rules_rust exec-config tools (process_wrapper, build scripts,
-          # proc-macros) build for the worker, not the local host (rules_rust #327).
-          # And disable local fallback — a fallback to the arm64/darwin host would run
-          # x86_64 exec tools there and crash. (amd64 keeps .bazelrc's graceful fallback.)
-          FLAGS="$FLAGS --host_platform=//platforms:linux_x86_64 --noremote_local_fallback"
+          # Cross legs (arm64/darwin runner → x86_64 worker): run tests on the native
+          # runner (`--strategy=TestRunner=local`) — the cross-built binary can't run on
+          # the x86_64 worker. Pin the host config to x86_64 so rules_rust exec-config
+          # tools (process_wrapper, build scripts, proc-macros) build for the worker, not
+          # the local host (rules_rust #327). And disable local fallback — a fallback to
+          # the arm64/darwin host would run x86_64 exec tools there and crash.
+          FLAGS="$FLAGS --strategy=TestRunner=local --host_platform=//platforms:linux_x86_64 --noremote_local_fallback"
         fi
+        # Native x86_64 leg (amd64 `test` + `sanitizer`): tests EXECUTE on the worker
+        # (exec == target == x86_64), so results cache remotely and the runner skips the
+        # multi-GB output download under `--remote_download_minimal`. e2e tests are
+        # `exclusive-if-local` (isolated workers can't collide on the shared port range),
+        # so they run in parallel here; under `--config=asan` the LLVM symbolizer travels
+        # as a runfile (test/e2e/sipi_e2e_test.bzl), so the sanitizer e2e tests run
+        # remotely too. `bazel-test-differential` re-pins `--strategy=TestRunner=local`
+        # in its recipe (the C++-oracle two-binary spawn stays on the runner). amd64
+        # keeps .bazelrc's graceful fallback.
         echo "flags=$FLAGS" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 # Main CI workflow for pull requests (and manual workflow_dispatch runs).
 #
 # Structure:
-#   1. `changes` — a ~15s path-filter gate. It exists ONLY to skip the two
-#      sanitizer jobs on PRs that don't touch native/build-relevant paths; the
+#   1. `changes` — a ~15s path-filter gate. It exists ONLY to skip the
+#      sanitizer job on PRs that don't touch native/build-relevant paths; the
 #      `test` matrix does NOT depend on it and starts immediately.
 #   2. `test` — the 3-leg build+test matrix (linux-amd64, linux-arm64,
 #      darwin-arm64), each running `just bazel-test` (fastbuild, no
@@ -18,8 +18,8 @@
 #      parity gate and uploads the SARIF CVE scan. Every leg writes its
 #      `just bazel-test` invocation's Build Event Protocol JSON and uploads it
 #      as a `bep-<platform>` artifact for offline cache-hit-rate analysis.
-#   3. `sanitizer-unit` / `sanitizer-e2e` — two parallel path-gated
-#      ASan+UBSan jobs (see the scope-rationale comment above those jobs).
+#   3. `sanitizer` — a path-gated ASan+UBSan job running unit + e2e in one
+#      invocation (see the scope-rationale comment above the job).
 #   4. `docs` — MkDocs build.
 #
 # Coverage instrumentation lives in `.github/workflows/coverage.yml`, which
@@ -50,12 +50,12 @@ permissions:
   contents: read
 
 jobs:
-  # Path-filter gate for the sanitizer jobs ONLY — the `test` matrix has no
+  # Path-filter gate for the sanitizer job ONLY — the `test` matrix has no
   # `needs:` on this job and starts immediately, overlapping the ~15s this
   # takes and the ~5m macOS runner queue.
   #
-  # Why job-level gating instead of `on.paths` on the sanitizer jobs
-  # themselves: `sanitizer-unit`/`sanitizer-e2e` are REQUIRED status checks.
+  # Why job-level gating instead of `on.paths` on the sanitizer job
+  # itself: `sanitizer` is a REQUIRED status check.
   # With `on.paths`, a PR that doesn't match the filter never triggers the
   # job at all, so its required-check entry sits at "Expected" forever and
   # blocks merge. A job that runs and is merely skipped (via `if:`) reports
@@ -284,9 +284,8 @@ jobs:
   # gate — sanitizer findings fail the PR check. Also runnable on-demand via
   # workflow_dispatch (unconditional — bypasses the `changes` filter).
   #
-  # Scope: unit (`sanitizer-unit`) + e2e (`sanitizer-e2e`) under ASan/UBSan
-  # (`just bazel-test-unit` / `bazel-test-e2e`, each `--config=asan
-  # --config=ubsan`). Covering unit — not just e2e — puts the sanitizers over
+  # Scope: unit + e2e under ASan/UBSan in one invocation (`just
+  # bazel-test-sanitized --config=asan --config=ubsan`). Covering unit — not just e2e — puts the sanitizers over
   # the codec/ICC/metadata paths (the unit round-trip + delivery code) where
   # memory bugs in a media server are most likely. Two suites are
   # intentionally excluded:
@@ -302,16 +301,16 @@ jobs:
   #     publish.yml); instrumenting the OCI image adds no memory-safety
   #     signal.
   #
-  # `LSAN_OPTIONS` (leak suppressions) is set per-e2e-test by
-  # `test/e2e/sipi_e2e_test.bzl` (data-deps `//:lsan_suppressions`).
+  # `LSAN_OPTIONS` (leak suppressions) and `ASAN_SYMBOLIZER_PATH` are set
+  # per-e2e-test by `test/e2e/sipi_e2e_test.bzl`, which data-deps
+  # `//:lsan_suppressions` and (under `--config=asan`) `//bazel:llvm-symbolizer`
+  # and points the env at their runfiles paths — so both resolve when the test
+  # executes on the RBE worker. The symbolizer lets ASan/LSan resolve
+  # `sipi+0xOFFSET` frames into function names, needed for the name-based
+  # suppressions in `.lsan_suppressions.txt` (`leak:lua*`) to match.
   # `ASAN_OPTIONS log_path` is set by `.bazelrc`'s `test:asan` block to
   # `$TEST_UNDECLARED_OUTPUTS_DIR/asan-e2e`, surfaced by Bazel under
-  # `bazel-testlogs/**/test.outputs/asan-e2e.<pid>` for every layer; the same
-  # block passes through `ASAN_SYMBOLIZER_PATH` so ASan/LSan can resolve
-  # `sipi+0xOFFSET` frames into function names — needed for the name-based
-  # suppressions in `.lsan_suppressions.txt` (`leak:lua*`) to match. The
-  # symbolizer comes from the hermetic LLVM 22.1.7 toolchain
-  # (`just asan-symbolizer`, version-matched to the instrumented build).
+  # `bazel-testlogs/**/test.outputs/asan-e2e.<pid>` for every layer.
   #
   # `--config=asan` / `--config=ubsan` set `--@llvm//config:{asan,ubsan}=true`,
   # which makes the toolchain build + link the compiler-rt ASan/UBSan runtimes
@@ -319,20 +318,22 @@ jobs:
   # linux-x86_64 only (the macOS toolchain args omit the sanitizer header
   # path).
   #
-  # Split into two jobs so unit and e2e run concurrently; RBE dedups the
-  # shared instrumented `sipi` compile across the two concurrent jobs via the
-  # remote cache, so the split costs no extra compute — only wall-clock is
-  # saved.
-  sanitizer-unit:
+  # One job runs unit + e2e in a single `bazel test` invocation so the
+  # instrumented `sipi` tree compiles exactly once and both suites share that
+  # one ~5500-file ASan/UBSan compile within a single action graph. Two
+  # separate jobs would each compile the full tree (concurrent jobs race, so
+  # neither warms the other's remote cache). See
+  # `docs/src/development/rbe-write-pressure.md`.
+  sanitizer:
     needs: changes
     if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.native == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
-    name: asan-ubsan-unit / amd64
+    name: asan-ubsan / amd64
     permissions:
       contents: read
     concurrency:
-      group: ${{ github.workflow }}-sanitizer-unit-${{ github.head_ref || github.ref }}
+      group: ${{ github.workflow }}-sanitizer-${{ github.head_ref || github.ref }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v6
@@ -350,90 +351,31 @@ jobs:
           rbe-client-cert: ${{ secrets.REMOTEBUILD_CLIENT_CERT }}
           rbe-client-key: ${{ secrets.REMOTEBUILD_CLIENT_KEY }}
 
-      - name: Run unit tests under ASan + UBSan
+      - name: Run unit + e2e tests under ASan + UBSan
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
-        run: |
-          export ASAN_SYMBOLIZER_PATH="$(just asan-symbolizer)"
-          just bazel-test-unit --config=asan --config=ubsan --build_tag_filters=-no-sanitizer --test_tag_filters=-no-sanitizer ${{ steps.setup.outputs.flags }} --build_event_json_file=bep-sanitizer-unit.json
+        run: just bazel-test-sanitized --config=asan --config=ubsan --build_tag_filters=-no-sanitizer --test_tag_filters=-no-sanitizer ${{ steps.setup.outputs.flags }} --build_event_json_file=bep-sanitizer.json
 
       - name: Check for sanitizer findings
         if: always()
         run: bash tools/check_sanitizer_findings.sh
 
       # BEP for cache-hit-rate analysis (see the `test` job's upload step).
-      # This leg's instrumented sanitizer build has its own cache behavior
-      # worth tracking separately.
+      # The instrumented sanitizer build has its own cache behavior worth
+      # tracking separately.
       - name: Upload build event JSON (cache-hit-rate analysis)
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: bep-sanitizer-unit
+          name: bep-sanitizer
           retention-days: 30
-          path: bep-sanitizer-unit.json
+          path: bep-sanitizer.json
 
       - name: Upload sanitizer reports
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: sanitizer-reports-unit
-          retention-days: 30
-          path: bazel-testlogs/**/test.outputs/asan-e2e.*
-
-  sanitizer-e2e:
-    needs: changes
-    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.native == 'true'
-    runs-on: ubuntu-24.04
-    timeout-minutes: 60
-    name: asan-ubsan-e2e / amd64
-    permissions:
-      contents: read
-    concurrency:
-      group: ${{ github.workflow }}-sanitizer-e2e-${{ github.head_ref || github.ref }}
-      cancel-in-progress: true
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          lfs: false
-
-      - name: CI setup (bazelisk, just, LFS, repo cache, RBE flags)
-        id: setup
-        uses: ./.github/actions/ci-setup
-        with:
-          lfs: "true"
-          rbe-runner-endpoint: ${{ vars.REMOTEBUILD_RUNNER_ENDPOINT }}
-          rbe-ca-cert: ${{ secrets.REMOTEBUILD_CA_CERT }}
-          rbe-client-cert: ${{ secrets.REMOTEBUILD_CLIENT_CERT }}
-          rbe-client-key: ${{ secrets.REMOTEBUILD_CLIENT_KEY }}
-
-      - name: Run e2e tests under ASan + UBSan
-        env:
-          GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
-        run: |
-          export ASAN_SYMBOLIZER_PATH="$(just asan-symbolizer)"
-          just bazel-test-e2e --config=asan --config=ubsan --test_tag_filters=-no-sanitizer ${{ steps.setup.outputs.flags }} --build_event_json_file=bep-sanitizer-e2e.json
-
-      - name: Check for sanitizer findings
-        if: always()
-        run: bash tools/check_sanitizer_findings.sh
-
-      # BEP for cache-hit-rate analysis (see the `test` job's upload step).
-      # This leg's instrumented sanitizer build has its own cache behavior
-      # worth tracking separately.
-      - name: Upload build event JSON (cache-hit-rate analysis)
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: bep-sanitizer-e2e
-          retention-days: 30
-          path: bep-sanitizer-e2e.json
-
-      - name: Upload sanitizer reports
-        if: failure()
-        uses: actions/upload-artifact@v7
-        with:
-          name: sanitizer-reports-e2e
+          name: sanitizer-reports
           retention-days: 30
           path: bazel-testlogs/**/test.outputs/asan-e2e.*
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ just bench <tier>                # tier ∈ parse|decode|process|encode; -c opt 
 just bench-compare before after  # U-test deltas + geomean via //tools/benchmark:compare
 
 # Sanitizer + fuzz
-just bazel-build-sanitized       # bazel build --config=asan --config=ubsan //src/cli:sipi  (ci.yml sanitizer-unit/sanitizer-e2e jobs)
+just bazel-build-sanitized       # bazel build --config=asan --config=ubsan //src/cli:sipi  (ci.yml sanitizer job)
 just bazel-build-fuzz            # bazel build --config=fuzz //fuzz/handlers:iiif_handler_uri_parser_fuzz  (fuzz.yml CI on linux-x86_64; darwin-aarch64 supported for local dev)
 just bazel-run-fuzz <corpus> <duration> [seed]  # libFuzzer args; recipe builds + execs the binary directly
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -51,7 +51,7 @@
 - Memory fixes verified under ASan (no leaks, no UB)
 - New HTTP behavior tested in Rust e2e
 - Tests verify behavior (dimensions, content, structure), not just HTTP status codes
-- **Sanitizer gate:** PRs touching native/build-relevant paths (`src/`, `include/`, `test/`, `bazel/`, …) automatically run the sanitizer jobs in `ci.yml` (`asan-ubsan-unit` / `asan-ubsan-e2e`). Zero findings required to merge. The sanitizer build runs the unit and e2e suites under ASan/UBSan; first-party translation units are instrumented at compile time
+- **Sanitizer gate:** PRs touching native/build-relevant paths (`src/`, `include/`, `test/`, `bazel/`, …) automatically run the `sanitizer` job in `ci.yml` (`asan-ubsan / amd64`). Zero findings required to merge. The sanitizer build runs the unit and e2e suites under ASan/UBSan; first-party translation units are instrumented at compile time
 - **Bazel test parity:** PRs that add a new unit test must add the matching `cc_test` target in `test/unit/<mod>/BUILD.bazel`. CI runs `just bazel-coverage`, which exercises every `cc_test` under `//test/unit/...` plus `//test/approval/...` and `//test/e2e/...` in a single pass — a missing `cc_test` target = no CI coverage
 
 ### Performance

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -51,9 +51,12 @@ alias(
     visibility = ["//visibility:public"],
 )
 
-# Consumed by the sanitizer CI jobs and local sanitizer runs to symbolize
+# Consumed by the sanitizer CI job and local sanitizer runs to symbolize
 # ASan/LSan reports (`sipi+0xOFFSET` frames) — required for the name-based
 # suppressions in `.lsan_suppressions.txt` to match symbolized frames.
+# e2e test targets attach this as a `data` dep under `:asan_enabled` and point
+# `ASAN_SYMBOLIZER_PATH` at its runfiles path, so the symbolizer travels with
+# the test and resolves whether it runs on the runner or the RBE worker.
 alias(
     name = "llvm-symbolizer",
     actual = select({
@@ -61,6 +64,15 @@ alias(
         "//platforms:is_linux_aarch64": "@llvm-toolchain-minimal-22.1.7-linux-arm64//:bin/llvm-symbolizer",
         "//conditions:default": "@llvm-toolchain-minimal-22.1.7-darwin-arm64//:bin/llvm-symbolizer",
     }),
+    visibility = ["//visibility:public"],
+)
+
+# True whenever `--config=asan` (i.e. `--@llvm//config:asan=true`) is in effect.
+# Lets test targets attach the LLVM symbolizer as a runfile only under the
+# sanitizer build, so non-sanitizer runs don't drag it into their closure.
+config_setting(
+    name = "asan_enabled",
+    flag_values = {"@llvm//config:asan": "true"},
     visibility = ["//visibility:public"],
 )
 

--- a/docs/src/development/ci.md
+++ b/docs/src/development/ci.md
@@ -46,15 +46,15 @@ provisioning" below). Nix remains the local dev-shell provisioner only.
 ### `changes` gate
 
 A `changes` job runs first and inspects the diff to decide whether the
-two sanitizer jobs (below) need to run: it looks for changes under
+sanitizer job (below) needs to run: it looks for changes under
 `src/`, `include/`, `test/`, `fuzz/`, `bazel/`, `platforms/`, `config/`,
 `scripts/`, `MODULE.bazel*`, `.bazelrc`, `.bazelversion`, `BUILD.bazel`,
 `justfile`, `.lsan_suppressions.txt`, `ci.yml`, and `.github/actions/`.
-A docs-only PR skips both sanitizer jobs — a skipped required job still
+A docs-only PR skips the sanitizer job — a skipped required job still
 satisfies branch rulesets. The `test` matrix has no `needs:` on this
 job and starts immediately, in parallel with it. A manual
-`workflow_dispatch` run bypasses the filter and always runs both
-sanitizer jobs.
+`workflow_dispatch` run bypasses the filter and always runs the
+sanitizer job.
 
 ### Test matrix
 
@@ -90,20 +90,20 @@ A separate `docs` job runs `just docs-build` (mkdocs strict-mode
 build) on ubuntu-latest. The `docs-build` job is the gate that
 catches broken cross-links and stale nav entries on every PR.
 
-### Path-gated sanitizer jobs
+### Path-gated sanitizer job
 
-The jobs `sanitizer-unit` (`asan-ubsan-unit / amd64`) and
-`sanitizer-e2e` (`asan-ubsan-e2e / amd64`) run ASan+UBSan over the
-unit and e2e suites respectively, in parallel, gated by the `changes`
-job above. Splitting unit and e2e into two concurrent jobs saves
-wall-clock time; RBE dedups the shared instrumented `sipi` compile
-across both via the remote cache, so the split costs no extra
-compute. Runs on linux-x86_64 only
+The `sanitizer` job (`asan-ubsan / amd64`) runs ASan+UBSan over the
+unit and e2e suites in a single `just bazel-test-sanitized` invocation,
+gated by the `changes` job above. Running both suites in one `bazel
+test` compiles the instrumented `sipi` tree exactly once — a single
+action graph shares the ~5500-file compile across both suites (two
+separate jobs would each compile the full tree). Runs on linux-x86_64 only
 (the macOS toolchain args omit the sanitizer header path). ASan/LSan
-symbol resolution (`ASAN_SYMBOLIZER_PATH`) now comes from the
-hermetic LLVM 22.1.7 toolchain via the `//bazel:llvm-symbolizer` alias
-and the `just asan-symbolizer` recipe (version-matched to clang
-22.1.7) — not from a Nix `.#llvm-tools` shell.
+symbol resolution uses the hermetic LLVM 22.1.7 `//bazel:llvm-symbolizer`
+(version-matched to clang 22.1.7), which the e2e macro attaches as a test
+runfile under `--config=asan` and points `ASAN_SYMBOLIZER_PATH` at — so the
+tests (unit + e2e) execute on the RBE worker, symbolizer included, rather
+than on the runner.
 
 ### CI environment provisioning
 
@@ -138,8 +138,10 @@ and the build short-circuits. Internal PRs are unaffected.
 
 Branch rulesets require the three `test / *` legs
 (`test / linux-amd64`, `test / linux-arm64`, `test / darwin-arm64`)
-plus the two `asan-ubsan-*` jobs. The `docs` job and the `changes`
-gate itself are not required checks.
+plus the `asan-ubsan / amd64` job. The `docs` job and the `changes`
+gate itself are not required checks. (This job was previously split
+into `asan-ubsan-unit / amd64` + `asan-ubsan-e2e / amd64`; the ruleset
+must be updated to the merged name.)
 
 ## Post-merge coverage
 
@@ -237,10 +239,8 @@ just bazel-test-smoke
 # Coverage (matches `coverage.yml`; needs the .#llvm-tools shell locally)
 nix develop .#llvm-tools --command just bazel-coverage
 
-# Sanitizer build + e2e (matches the `sanitizer-unit`/`sanitizer-e2e`
-# jobs folded into ci.yml)
-just bazel-build-sanitized
-just bazel-test-e2e --config=asan --config=ubsan
+# Sanitizer unit + e2e (matches the `sanitizer` job in ci.yml)
+just bazel-test-sanitized --config=asan --config=ubsan
 
 # Fuzz build + run (what fuzz.yml runs; linux-x86_64 only)
 just bazel-build-fuzz

--- a/docs/src/development/nix.md
+++ b/docs/src/development/nix.md
@@ -47,7 +47,7 @@ Three shells are exposed:
 |---|---|---|
 | `default` | `llvmPackages_19.libcxxStdenv` | Clang + libc++ for non-Bazel tooling (clang-tidy, ad-hoc shell compiles). The Bazel cc actions run under the hermetic LLVM 22.1.7 toolchain, not this stdenv. 99% of work happens here. |
 | `gcc` | `pkgs.gcc14Stdenv` | Diagnostic escape hatch when the LLVM toolchain produces a confusing error. Not used by CI. |
-| `llvm-tools` | `llvmPackages_19.libcxxStdenv` | `default` + `llvmPackages_19.llvm` (host `llvm-cov`, `llvm-profdata`, `llvm-symbolizer`). For LOCAL coverage/sanitizer runs only — local devs running `just bazel-coverage` or sanitizer e2e should enter this shell. CI resolves the same tools hermetically from the Bazel toolchain (`//bazel:llvm-*` aliases), not from this shell. |
+| `llvm-tools` | `llvmPackages_19.libcxxStdenv` | `default` + `llvmPackages_19.llvm` (host `llvm-cov`, `llvm-profdata`). For LOCAL coverage runs only — local devs running `just bazel-coverage` should enter this shell. CI resolves the same tools hermetically from the Bazel toolchain (`//bazel:llvm-*` aliases), not from this shell. Sanitizer runs no longer need it: the e2e macro attaches the hermetic `//bazel:llvm-symbolizer` as a test runfile under `--config=asan`. |
 
 ```bash
 nix develop .#gcc              # GCC + libstdc++ environment

--- a/docs/src/development/rbe-write-pressure.md
+++ b/docs/src/development/rbe-write-pressure.md
@@ -101,13 +101,14 @@ run for no test coverage. Scope the test pattern (or use
 `--build_tag_filters`) so the image and other non-test artifacts are not pulled
 into the test graph.
 
-### 3. Deduplicate the concurrent sanitizer builds
+### 3. Deduplicate the concurrent sanitizer builds — DONE
 
-`sanitizer-unit` and `sanitizer-e2e` each remotely compile the full
-`--config=asan --config=ubsan` tree (~5500 `CppCompile` each) and run
-concurrently, so the worker materializes two near-identical instrumented
-closures. Serializing them (or merging into one build that runs both test sets)
-lets the second reuse the first's cached objects.
+Previously `sanitizer-unit` and `sanitizer-e2e` each remotely compiled the full
+`--config=asan --config=ubsan` tree (~5500 `CppCompile` each) and ran
+concurrently, so the worker materialized two near-identical instrumented
+closures. They are now merged into a single `sanitizer` job that runs both test
+sets in one `bazel test` invocation (`just bazel-test-sanitized`), so the shared
+instrumented tree compiles exactly once.
 
 ### 4. Raise the cache-hit rate generally
 
@@ -133,7 +134,7 @@ problem) for permanently worse hit rates, i.e. *more* remote execution and
 
 Every `ci.yml` test leg writes its Bazel invocation's BEP JSON via
 `--build_event_json_file` and uploads it as an artifact (`bep-<platform>`,
-`bep-sanitizer-unit`, `bep-sanitizer-e2e`; 30-day retention). See the upload
+`bep-sanitizer`; 30-day retention). See the upload
 steps in `.github/workflows/ci.yml`.
 
 ```bash

--- a/docs/src/development/rbe.md
+++ b/docs/src/development/rbe.md
@@ -155,35 +155,54 @@ If the worker is unreachable and the build falls back to the local arm64/darwin 
 the x86_64 `process_wrapper` binary would be dispatched there and crash. Cross legs
 therefore disable local fallback. The amd64 leg retains the `.bazelrc` graceful fallback.
 
-### Tests run on the native runner
+### Where tests execute
 
 ```
---strategy=TestRunner=local
+--strategy=TestRunner=local   # cross legs only (arm64/darwin)
 ```
 
-Test binaries are cross-compiled on the worker but executed locally on the native runner.
-This is the standard "compile remote, test local" pattern: the runner has the right
-kernel ABI, Docker daemon (for smoke tests), and filesystem for running the binary.
+**Cross legs (arm64/darwin).** Test binaries are cross-compiled on the x86_64 worker but
+executed locally on the native runner — the cross-built binary can't run on the x86_64
+worker, and the runner has the right kernel ABI and filesystem. `bazel-rbe` emits
+`--strategy=TestRunner=local` only on these legs.
 
-### The `no-sandbox` tag on e2e tests
+**Native x86_64 legs (amd64 `test` + `sanitizer`).** Tests EXECUTE on the worker
+(exec == target == x86_64): results cache remotely and the runner skips the multi-GB
+output download under `--remote_download_minimal`. The e2e tests are tagged
+`exclusive-if-local` (see below), so on isolated workers they run in parallel rather than
+serially. Under `--config=asan` the e2e macro attaches `//bazel:llvm-symbolizer` as a
+runfile and sets `ASAN_SYMBOLIZER_PATH` to its runfiles path, so the sanitizer e2e tests
+run remotely too (a runner-side absolute symbolizer path would not exist on the worker).
+One exception re-pins `--strategy=TestRunner=local` in its own recipe:
+`bazel-test-differential` (spawns the C++ oracle alongside the subject). `docker_smoke`
+stays local via its plain `exclusive` tag and its Docker-daemon dependency.
 
-E2E tests are tagged `no-sandbox` in `test/e2e/sipi_e2e_test.bzl` and in the inline
-`docker_smoke` target in `test/e2e/BUILD.bazel`. This choice is permanent and correct;
-do not change it to `local`.
+### The `exclusive-if-local` and `no-sandbox` tags on e2e tests
 
-The distinction matters for RBE:
+E2E tests are tagged `exclusive-if-local` and `no-sandbox` in
+`test/e2e/sipi_e2e_test.bzl` (`docker_smoke` keeps plain `exclusive` in
+`test/e2e/BUILD.bazel`). Neither is `local`, and that is permanent and correct.
 
+- `exclusive-if-local` runs the tests serially only when they execute locally (dev, cross
+  legs), preventing port collisions between binaries that all bind `11024 + PID % 16384`
+  on the shared runner. On the native x86_64 RBE leg each test runs on its own isolated
+  worker, so there is no shared port range and Bazel runs them in parallel. Plain
+  `exclusive` would disable remote execution entirely — Bazel can't guarantee exclusivity
+  on a machine it doesn't own — which is why `docker_smoke` (which must stay on the runner
+  for its Docker daemon) keeps `exclusive`.
 - `local` propagates to the test's COMPILE action and pins the compile to the runner.
   On a cross leg this routes an arm64/darwin process_wrapper to the x86_64 worker —
   it crashes. `local` breaks cross-compilation.
-- `no-sandbox` disables the macOS Bazel sandbox for the TEST RUN only (the compile is
+- `no-sandbox` disables the Bazel sandbox for the TEST RUN only (the compile is
   unaffected). It does not prevent cross-compilation.
 
 The reason e2e tests need `no-sandbox` at all: SIPI's `validate_resolved_path` guard
-in `src/SipiHttpServer.cpp` canonicalises the request path via `realpath(3)`. In the
-macOS Bazel sandbox, `repo_root()` returns the writable runfiles path rather than the
+in `src/SipiHttpServer.cpp` canonicalises the request path via `realpath(3)`. Under the
+Bazel sandbox, `repo_root()` returns the writable runfiles path rather than the
 `TEST_TMPDIR` copy, so sipi rejects legitimate test files with HTTP 400. Disabling the
-sandbox sidesteps this runfiles-symlink interaction. The guard itself is correct and
+sandbox sidesteps this runfiles-symlink interaction. This is also the open question when
+e2e tests execute remotely: the NativeLink executor must honor `no-sandbox` (materialise
+real files under a stable root) for the guard to pass. The guard itself is correct and
 must not be weakened for testing.
 
 ## The hermetic-llvm headers glob patch
@@ -366,7 +385,7 @@ fetched). The smoke test then finds the image regardless of its cache state.
 4. On Linux: runs `just bazel-test-smoke` (which first calls `bazel run //src:image_load`).
 5. On linux-amd64 PRs: runs Docker Scout.
 
-`ci.yml`'s path-gated `sanitizer-unit`/`sanitizer-e2e` jobs, plus `coverage.yml`,
+`ci.yml`'s path-gated `sanitizer` job, plus `coverage.yml`,
 `fuzz.yml`, and `publish.yml`, all go
 through the same `ci-setup` action so every Bazel invocation benefits from the shared
 remote cache.

--- a/docs/src/development/testing-strategy.md
+++ b/docs/src/development/testing-strategy.md
@@ -594,7 +594,7 @@ Two Rust-shell features the C++-era gap list assumed are permanently **removed**
 | 4-bit palette PNG upload | :white_check_mark: | `upload.rs` | `upload_4bit_palette_png` |
 | Cache API routes (`/api/cache`) | N/A — removed | — | route unregistered, Lua `cache` table bindings absent from `src/` |
 | Favicon endpoint | :white_check_mark: | `differential.rs::favicon` | |
-| Memory safety (ASan/LSan) | :white_check_mark: | `ci.yml`'s `sanitizer-unit`/`sanitizer-e2e` jobs | unit + e2e suites, each against an ASan+UBSan-instrumented binary (see Cross-Cutting section below) |
+| Memory safety (ASan/LSan) | :white_check_mark: | `ci.yml`'s `sanitizer` job | unit + e2e suites against an ASan+UBSan-instrumented binary (see Cross-Cutting section below) |
 | Thread safety (TSan) | :x: GAP | — | Untested for data races; future optional nightly variant |
 | Performance regression detection | :white_check_mark: | `latency.rs` | smoke thresholds only (info.json / cache-miss / cache-hit); load-baseline tier intentionally deferred to staging (see Cross-Cutting section) |
 | Corrupt/truncated image handling | :white_check_mark: | `iiif_compliance.rs::corrupt_jpeg_handling`, `corrupt_png_handling`, `corrupt_image_handling` (truncated JP2) | JP2 decode converts Kakadu's thrown error into a `SipiImageError` (like JPEG/PNG); the server returns a clean error and stays up (DEV-6731) |
@@ -687,7 +687,7 @@ Two Rust-shell features the C++-era gap list assumed are permanently **removed**
 
 Memory leaks and undefined behavior are not a separate pyramid layer but a **build variant** that runs existing tests with compiler instrumentation. This is critical for sipi as a long-running C++ server where leaks accumulate.
 
-**Current state:** ASan+UBSan infrastructure is in place — Bazel `--config=asan` and `--config=ubsan` blocks in `.bazelrc`, `just bazel-build-sanitized` (`bazel build --config=asan --config=ubsan //src/cli:sipi`), and two path-gated jobs in `ci.yml` (`sanitizer-unit`, `sanitizer-e2e`) that exercise the unit and e2e suites respectively against the resulting binary. Known findings to triage on first run:
+**Current state:** ASan+UBSan infrastructure is in place — Bazel `--config=asan` and `--config=ubsan` blocks in `.bazelrc`, `just bazel-build-sanitized` (`bazel build --config=asan --config=ubsan //src/cli:sipi`), and one path-gated `sanitizer` job in `ci.yml` that exercises the unit and e2e suites against the instrumented binary in a single `just bazel-test-sanitized` invocation. Known findings to triage on first run:
 
 - **`SipiFilenameHash::operator=` memory leak** — `operator=` allocates `new vector<char>` without deleting the old `hash` pointer. Confirmed by code inspection. Fix: add `delete hash;` before the new allocation, or switch to `std::unique_ptr`.
 - **Potential: `SipiFilenameHash` copy constructor** — also `new`s without freeing, but only leaks if the destination object was previously constructed with a different hash (doesn't happen via typical usage).
@@ -707,7 +707,7 @@ Memory leaks and undefined behavior are not a separate pyramid layer but a **bui
 |-----------|--------|---------|
 | `--config=asan` / `--config=ubsan` in `.bazelrc` | Done | `-fsanitize=address` / `-fsanitize=undefined` plus `-fno-omit-frame-pointer`, `-fno-optimize-sibling-calls`, `--strip=never`, `--compilation_mode=dbg` (DWARF inline so `.lsan_suppressions.txt` symbol-name suppressions match) |
 | `just bazel-build-sanitized` | Done | Wraps `bazel build --config=asan --config=ubsan //src/cli:sipi` |
-| PR CI (`ci.yml`'s `sanitizer-unit`/`sanitizer-e2e` jobs) | Done | Bazel-built binary at `bazel-bin/src/cli/sipi`; `sanitizer-unit` runs `just bazel-test-unit`, `sanitizer-e2e` runs `just bazel-test-e2e`, both `--config=asan --config=ubsan`, in parallel; `.lsan_suppressions.txt` consumed by LSan via `LSAN_OPTIONS` |
+| PR CI (`ci.yml`'s `sanitizer` job) | Done | Bazel-built binary at `bazel-bin/src/cli/sipi`; runs `just bazel-test-sanitized` (unit + e2e in one invocation) `--config=asan --config=ubsan`; `.lsan_suppressions.txt` consumed by LSan via `LSAN_OPTIONS` |
 | TSan variant | Future | Optional nightly, separate from ASan (can't combine) |
 
 **Strategy:** PR CI runs both the unit and e2e suites against an ASan+UBSan-instrumented binary, as two parallel jobs gated on native/build-relevant path changes. TSan remains a future option.

--- a/justfile
+++ b/justfile
@@ -193,12 +193,28 @@ bazel-rust-project:
 # `resource_limits` / `latency`. Useful for inner-loop development; CI
 # runs e2e tests via `bazel-coverage`.
 #
-# `--stamp` is on so `cli_version_flag` reads the stamped
-# `STABLE_SIPI_VERSION` rather than the `0.0.0-unstamped` fallback. Only
-# the `:sipi_version_h` action's cache key depends on `STABLE_*` values,
-# so the stamp adds at most one re-link per workspace_status change.
+# Unstamped, like `bazel-test`: `cli_version_flag` accepts the
+# `0.0.0-unstamped` fallback (see `test/e2e/tests/cli.rs`), so the e2e
+# test actions cache across commits instead of forcing a
+# `:sipi_version_h` re-link (and its closure re-materialisation on the
+# RBE worker) every commit. See `docs/src/development/rbe-write-pressure.md`.
 bazel-test-e2e *FLAGS='':
-    bazel test --stamp --verbose_failures {{FLAGS}} //test/e2e:all_e2e
+    bazel test --verbose_failures {{FLAGS}} //test/e2e:all_e2e
+
+# Build + run the unit and e2e suites in ONE invocation under the
+# sanitizer configs — CI's `sanitizer` job passes `--config=asan
+# --config=ubsan --build_tag_filters=-no-sanitizer
+# --test_tag_filters=-no-sanitizer`. Running both suites through a single
+# `bazel test` compiles the instrumented `sipi` tree exactly once — both
+# suites share that one ~5500-file `CppCompile` set within a single action
+# graph (two separate jobs would each compile the full tree). Combining
+# them here is the reason for this recipe over `bazel-test-unit` +
+# `bazel-test-e2e`. `--build_tests_only` keeps the `//src/...` wildcard
+# from building the non-test OCI image + CLI binary under instrumentation.
+# Unstamped for the same caching reason as `bazel-test-e2e`. See
+# `docs/src/development/rbe-write-pressure.md`.
+bazel-test-sanitized *FLAGS='':
+    bazel test --build_tests_only --verbose_failures //src/... //test/unit/... //test/e2e:all_e2e {{FLAGS}}
 
 # Run the Docker smoke test against the Bazel-built OCI image.
 #
@@ -220,11 +236,14 @@ bazel-test-smoke *FLAGS='':
 # retained C++ server (reference, via `$SIPI_BIN_REF`) and diffs their
 # responses across the divergence allowlist. `manual`-tagged so it stays out of
 # `:all_e2e` and `bazel-coverage`'s `//test/e2e/...` wildcard — run it
-# explicitly here. The two-binary spawn is `exclusive`/`local` with
-# `--test-threads=1` (set by the test macro). CI runs it as a dedicated
-# linux-amd64 step.
+# explicitly here. `exclusive-if-local` + `--test-threads=1` (set by the test
+# macro). CI runs it as a dedicated linux-amd64 step.
+#
+# `--strategy=TestRunner=local` pins execution to the runner: the two-binary
+# spawn (subject + C++ oracle) is a serial parity gate, kept off the RBE worker
+# even on the native x86_64 leg where other e2e tests execute remotely.
 bazel-test-differential *FLAGS='':
-    bazel test --stamp --verbose_failures {{FLAGS}} //test/e2e:differential
+    bazel test --stamp --verbose_failures --strategy=TestRunner=local {{FLAGS}} //test/e2e:differential
 
 # Drift guard: assert the differential corpus still covers the e2e surface
 # (pins the e2e #[test] count; trips when a test is added/removed so the
@@ -234,7 +253,7 @@ differential-coverage-check:
 
 # Sanitized build: Debug + ASan + UBSan via Bazel
 # `--config=asan --config=ubsan`. The resulting binary at
-# `bazel-bin/src/cli/sipi` is what ci.yml's sanitizer jobs' e2e tests consume
+# `bazel-bin/src/cli/sipi` is what ci.yml's sanitizer job's e2e tests consume
 # via `SIPI_BIN`. DWARF stays inline (`--strip=never` in
 # `.bazelrc`) so the symbol-name suppressions in `.lsan_suppressions.txt`
 # match. `--verbose_failures` surfaces the full failing compile/link
@@ -248,19 +267,6 @@ differential-coverage-check:
 bazel-build-sanitized *FLAGS='':
     bazel build --config=asan --config=ubsan --verbose_failures --stamp {{FLAGS}} //src/cli:sipi
     @echo "Binary at: $(pwd)/bazel-bin/src/cli/sipi"
-
-# Print the absolute path of the hermetic (LLVM 22, version-matched) symbolizer.
-# ASan/LSan need it to resolve `sipi+0xOFFSET` frames, and the name-based
-# suppressions in `.lsan_suppressions.txt` (e.g. `leak:lua*`) can only match
-# once frames are symbolized. Used by the sanitizer CI jobs in ci.yml via
-# `export ASAN_SYMBOLIZER_PATH="$(just asan-symbolizer)"`, and available for
-# local sanitizer runs.
-asan-symbolizer:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    bazel build //bazel:llvm-symbolizer 1>&2
-    EXEC_ROOT="$(bazel info execution_root)"
-    echo "$EXEC_ROOT/$(bazel cquery --output=files //bazel:llvm-symbolizer 2>/dev/null)"
 
 # Tracy-instrumented profiling build: `-c opt --config=tracy`. Local dev only,
 # never CI-gated (like `bench` / `valgrind`). `-c opt` so the timeline reflects

--- a/test/e2e/BUILD.bazel
+++ b/test/e2e/BUILD.bazel
@@ -9,7 +9,7 @@ Layout:
   * `:sipi_e2e`        `rust_library` exposing the shared helpers
                        (`SipiServer`, `repo_root`, `http_client`, …)
                        consumed by every test binary.
-  * 27 × `rust_test`   one target per non-docker `tests/<name>.rs`,
+  * 28 × `rust_test`   one target per non-docker `tests/<name>.rs`,
                        defined via `sipi_e2e_test()` (see
                        `sipi_e2e_test.bzl`). The macro injects the
                        shared `data`/`env`/`args`/`tags` so the
@@ -23,7 +23,7 @@ Layout:
   * `:docker_smoke`    inline `rust_test` — its data shape (OCI image
                        tarball) and tags (`requires-docker`) diverge
                        from the macro's defaults.
-  * `:all_e2e`         `test_suite` aggregating the 27 non-docker
+  * `:all_e2e`         `test_suite` aggregating the 28 non-docker
                        targets (not `:differential` / `:docker_smoke`).
                        `just bazel-test-e2e` wraps `bazel test
                        //test/e2e:all_e2e`.
@@ -42,8 +42,10 @@ Runtime contracts (set per-target by `sipi_e2e_test()` or below):
                        which `repo_root()` resolves fixture paths.
   * `--test-threads=1` Sipi can't tolerate parallel test load on the
                        JP2 → JPEG decode path. Enforced by `args` in
-                       the macro AND by `tags = ["exclusive"]` so
-                       siblings can't collide on the shared port pool.
+                       the macro AND by `tags = ["exclusive-if-local"]`
+                       so siblings can't collide on the shared port pool
+                       when run locally (on RBE each runs on its own
+                       isolated worker, so parallel execution is safe).
   * `CARGO_PROFILE`    Bazel's default `--compilation_mode=fastbuild`
                        (dbg-equivalent) matches Cargo's `test` default.
                        Don't switch to `--compilation_mode=opt`.
@@ -114,6 +116,11 @@ sipi_e2e_test(name = "bilevel_tiff", deps = _e2e_test_deps)
 sipi_e2e_test(name = "cache", deps = _e2e_test_deps)
 
 sipi_e2e_test(name = "cli", deps = _e2e_test_deps)
+
+# The heavy Kakadu JP2 / format conversions, split out of `cli` and run in
+# parallel within the test binary (see tests/cli_conversions.rs). Its own
+# target so RBE schedules it on a separate worker from the lightweight `cli`.
+sipi_e2e_test(name = "cli_conversions", deps = _e2e_test_deps)
 
 sipi_e2e_test(name = "cli_json", deps = _e2e_test_deps)
 
@@ -189,7 +196,7 @@ sipi_e2e_test(name = "upload", deps = _e2e_test_deps)
 #      `:all_e2e` matrix step and `bazel-coverage` skip it. CI runs it as its
 #      own step (linux-amd64, like the rustfmt gate) via
 #      `just bazel-test-differential`; the heavy two-binary spawn is
-#      `exclusive` + `no-sandbox` from the macro.
+#      `exclusive-if-local` + `no-sandbox` from the macro.
 #
 sipi_e2e_test(
     name = "differential",
@@ -289,6 +296,7 @@ test_suite(
         ":bilevel_tiff",
         ":cache",
         ":cli",
+        ":cli_conversions",
         ":cli_json",
         ":config",
         ":connection",

--- a/test/e2e/sipi_e2e_test.bzl
+++ b/test/e2e/sipi_e2e_test.bzl
@@ -18,6 +18,11 @@ What the macro injects:
                                  LSan under `--config=asan`.
       - `:snapshots`             `insta` snapshot files under
                                  `tests/snapshots/`.
+      - `//bazel:llvm-symbolizer` attached only under `--config=asan` (via a
+                                 `select` on `//bazel:asan_enabled`). Travels
+                                 as a runfile so `ASAN_SYMBOLIZER_PATH` resolves
+                                 whether the test runs on the local runner or
+                                 the RBE worker.
 
   * `env`:
       - `SIPI_BIN`               `$(rootpath //src/cli-rs:sipi)` — runfiles-
@@ -38,6 +43,11 @@ What the macro injects:
                                  Cheap (~80 B) and unconditional — the
                                  file only takes effect when LSan is
                                  active (`--config=asan`).
+      - `ASAN_SYMBOLIZER_PATH`   `$(rootpath //bazel:llvm-symbolizer)`, set only
+                                 under `--config=asan`. Points LSan at the
+                                 runfiles-relative symbolizer so it works
+                                 remotely; there is no runner-side env to
+                                 forward.
 
   * `args`:
       - `--test-threads=1`       sipi can't tolerate parallel test load
@@ -48,16 +58,24 @@ What the macro injects:
                                  AND between sibling e2e targets.
 
   * `tags`:
-      - `exclusive`              Bazel runs at most one `exclusive`
-                                 test at a time on a given runner,
-                                 preventing port collisions between
-                                 test binaries that all spin up sipi
-                                 on `11024 + (PID % 16384)`.
+      - `exclusive-if-local`     When tests run locally — dev machines, and the
+                                 arm64/darwin CI legs whose cross-built binary
+                                 can't run on the x86_64 worker — Bazel runs at
+                                 most one at a time, preventing port collisions
+                                 between test binaries that all spin up sipi on
+                                 `11024 + (PID % 16384)` on the shared runner.
+                                 On the native x86_64 RBE leg each test executes
+                                 on its own isolated worker, so there is no
+                                 shared port space to collide on and Bazel runs
+                                 them in parallel. Plain `exclusive` would
+                                 disable remote execution entirely (Bazel can't
+                                 guarantee exclusivity on a machine it doesn't
+                                 own).
       - `no-sandbox`             Skips the sandbox for this target's actions.
-                                 Required because macOS Bazel's sandbox
-                                 interferes with `realpath()` resolution
-                                 against the materialised `:test_fixtures`
-                                 tree — sipi's path-traversal guard
+                                 Required because Bazel's sandbox interferes
+                                 with `realpath()` resolution against the
+                                 materialised `:test_fixtures` tree — sipi's
+                                 path-traversal guard
                                  (`SipiHttpServer.cpp:validate_resolved_path`)
                                  then rejects every IIIF request with
                                  "Invalid IIIF identifier".
@@ -65,11 +83,6 @@ What the macro injects:
                                  the test's COMPILE on the local host, which
                                  breaks RBE cross-compilation (x86_64 exec
                                  tools can't run on an arm64/darwin runner).
-                                 Local test EXECUTION is ensured separately by
-                                 CI's `--strategy=TestRunner=local` (and is the
-                                 default with no remote executor), so
-                                 `no-sandbox` covers the sandbox need without
-                                 pinning the compile.
 
 The macro DOES cover the `differential` parity target through
 `extra_data` / `extra_env`: that target adds the retained C++ server
@@ -110,6 +123,34 @@ def sipi_e2e_test(
       extra_tags: additional Bazel tags (merged on top of `["exclusive",
         "no-sandbox"]`).
     """
+    base_env = {
+        # The Rust shell is the binary under test: it
+        # serves `server` natively and forwards every offline subcommand to
+        # the C++ CLI via sipi_cli_main, so it covers both the server and CLI
+        # e2e suites. The C++ `//src/cli:sipi` server is retired at the delete.
+        "SIPI_BIN": "$(rootpath //src/cli-rs:sipi)",
+        # Points at the `copy_to_directory` output that materialises
+        # `version.txt`, `test/_test_data/`, `config/`, `scripts/`,
+        # `server/` as real files (no symlinks). Required so sipi's
+        # `realpath()`-based path-traversal guard
+        # (`SipiHttpServer.cpp:validate_resolved_path`) keeps
+        # imgroot's resolved prefix and per-request files in
+        # agreement — under a runfiles tree of symlinks the prefix
+        # check rejects every IIIF request. The same materialisation
+        # also fixes Lua `require` and `insta` snapshot lookups.
+        "SIPI_REPO_ROOT": "$(rootpath //:test_fixtures)",
+        # `insta` writes/reads snapshots under
+        # `<INSTA_WORKSPACE_ROOT>/<package_dir>/tests/snapshots/`.
+        # `:snapshots` data dep materialises the goldens at
+        # `<runfiles_workspace_root>/test/e2e/tests/snapshots/`,
+        # so pointing INSTA_WORKSPACE_ROOT at the runfiles
+        # workspace root (`.`, matching the `SIPI_WORKSPACE_ROOT`
+        # convention from the C++ unit tests) lets insta resolve
+        # them under `./test/e2e/tests/snapshots/<n>.snap`.
+        "INSTA_WORKSPACE_ROOT": ".",
+        "LSAN_OPTIONS": "suppressions=$(rootpath //:lsan_suppressions)",
+    } | extra_env
+
     rust_test(
         name = name,
         srcs = [
@@ -125,39 +166,22 @@ def sipi_e2e_test(
         # `:snapshots` attaches the insta golden tree unconditionally —
         # only a couple of tests consume it but the cost is trivial and
         # makes adding new `assert_*_snapshot!()` calls a no-op wiring-wise.
+        # Under `--config=asan` the LLVM symbolizer travels as a runfile so
+        # `ASAN_SYMBOLIZER_PATH` resolves on the RBE worker as well as the
+        # local runner (LSan needs it to match the `leak:lua*` suppressions).
         data = [
             "//src/cli-rs:sipi",
             "//:test_fixtures",
             "//:lsan_suppressions",
             ":snapshots",
-        ] + extra_data,
-        env = {
-            # The Rust shell is the binary under test: it
-            # serves `server` natively and forwards every offline subcommand to
-            # the C++ CLI via sipi_cli_main, so it covers both the server and CLI
-            # e2e suites. The C++ `//src/cli:sipi` server is retired at the delete.
-            "SIPI_BIN": "$(rootpath //src/cli-rs:sipi)",
-            # Points at the `copy_to_directory` output that materialises
-            # `version.txt`, `test/_test_data/`, `config/`, `scripts/`,
-            # `server/` as real files (no symlinks). Required so sipi's
-            # `realpath()`-based path-traversal guard
-            # (`SipiHttpServer.cpp:validate_resolved_path`) keeps
-            # imgroot's resolved prefix and per-request files in
-            # agreement — under a runfiles tree of symlinks the prefix
-            # check rejects every IIIF request. The same materialisation
-            # also fixes Lua `require` and `insta` snapshot lookups.
-            "SIPI_REPO_ROOT": "$(rootpath //:test_fixtures)",
-            # `insta` writes/reads snapshots under
-            # `<INSTA_WORKSPACE_ROOT>/<package_dir>/tests/snapshots/`.
-            # `:snapshots` data dep materialises the goldens at
-            # `<runfiles_workspace_root>/test/e2e/tests/snapshots/`,
-            # so pointing INSTA_WORKSPACE_ROOT at the runfiles
-            # workspace root (`.`, matching the `SIPI_WORKSPACE_ROOT`
-            # convention from the C++ unit tests) lets insta resolve
-            # them under `./test/e2e/tests/snapshots/<n>.snap`.
-            "INSTA_WORKSPACE_ROOT": ".",
-            "LSAN_OPTIONS": "suppressions=$(rootpath //:lsan_suppressions)",
-        } | extra_env,
+        ] + extra_data + select({
+            "//bazel:asan_enabled": ["//bazel:llvm-symbolizer"],
+            "//conditions:default": [],
+        }),
+        env = select({
+            "//bazel:asan_enabled": base_env | {"ASAN_SYMBOLIZER_PATH": "$(rootpath //bazel:llvm-symbolizer)"},
+            "//conditions:default": base_env,
+        }),
         args = ["--test-threads=1"],
-        tags = ["exclusive", "no-sandbox"] + extra_tags,
+        tags = ["exclusive-if-local", "no-sandbox"] + extra_tags,
     )

--- a/test/e2e/sipi_e2e_test.bzl
+++ b/test/e2e/sipi_e2e_test.bzl
@@ -53,9 +53,11 @@ What the macro injects:
       - `--test-threads=1`       sipi can't tolerate parallel test load
                                  on the JP2 → JPEG decode path
                                  (musl-static-binary connection drops).
-                                 Combined with `tags = ["exclusive"]`
-                                 this forces serial execution within
-                                 AND between sibling e2e targets.
+                                 Combined with `tags = ["exclusive-if-local"]`
+                                 this forces serial execution within AND
+                                 between sibling e2e targets on a shared
+                                 local runner; on RBE each target runs on
+                                 its own isolated worker and they parallelise.
 
   * `tags`:
       - `exclusive-if-local`     When tests run locally — dev machines, and the
@@ -120,8 +122,8 @@ def sipi_e2e_test(
       extra_data: additional runtime files. Most targets don't need any;
         when a test reads a file outside `:test_fixtures` add it here.
       extra_env: additional env vars (merged on top of the shared dict).
-      extra_tags: additional Bazel tags (merged on top of `["exclusive",
-        "no-sandbox"]`).
+      extra_tags: additional Bazel tags (merged on top of
+        `["exclusive-if-local", "no-sandbox"]`).
     """
     base_env = {
         # The Rust shell is the binary under test: it

--- a/test/e2e/src/lib.rs
+++ b/test/e2e/src/lib.rs
@@ -737,6 +737,362 @@ pub fn test_data_dir() -> PathBuf {
     repo_root().join("test").join("_test_data")
 }
 
+// =============================================================================
+// CLI-mode test helpers (offline `sipi convert`/`query`/... verbs).
+//
+// Shared by the `cli*` e2e targets. The JP2 codec work is heavy under ASan, so
+// the heavy conversions are split out of `//test/e2e:cli` into the sibling
+// `//test/e2e:cli_conversions` target, which fans them out across threads via
+// `run_conversions`; these helpers keep both files small and their assertions
+// identical.
+// =============================================================================
+
+/// Run `sipi convert <input> <output> --format <format>` from the test-data
+/// dir and return the process output.
+pub fn cli_convert(input: &str, output: &str, format: &str) -> std::process::Output {
+    Command::new(sipi_bin_path())
+        .arg("convert")
+        .arg(input)
+        .arg(output)
+        .arg("--format")
+        .arg(format)
+        .current_dir(test_data_dir())
+        .output()
+        .unwrap_or_else(|e| panic!("Failed to run sipi CLI: {}", e))
+}
+
+/// Run `sipi <args...>` from the test-data dir and return the process output.
+pub fn cli_run(args: &[&str]) -> std::process::Output {
+    Command::new(sipi_bin_path())
+        .args(args)
+        .current_dir(test_data_dir())
+        .output()
+        .unwrap_or_else(|e| panic!("Failed to run sipi {:?}: {}", args, e))
+}
+
+/// A scratch path under `$TMPDIR` (or `/tmp`) for CLI conversion outputs.
+pub fn cli_tmp_path(name: &str) -> PathBuf {
+    let dir = std::env::var("TMPDIR").unwrap_or_else(|_| "/tmp".to_string());
+    PathBuf::from(dir).join(name)
+}
+
+/// Decode `file<i>.jp2` from the ISO 15444-4 conformance set to TIFF and assert
+/// the output exists and is non-empty (port of `test_iso_15444_4_decode_jp2`).
+pub fn assert_jp2_decode(i: u32) {
+    let input = test_data_dir()
+        .join("images/iso-15444-4/testfiles_jp2")
+        .join(format!("file{}.jp2", i));
+    let output = cli_tmp_path(&format!("sipi_cli_decode_{}.tif", i));
+
+    let result = cli_convert(input.to_str().unwrap(), output.to_str().unwrap(), "tif");
+    assert!(
+        result.status.success(),
+        "JP2→TIFF decode for file{}.jp2 failed: {}",
+        i,
+        String::from_utf8_lossy(&result.stderr)
+    );
+    assert!(output.exists(), "output TIFF should exist for file{}", i);
+    let meta = std::fs::metadata(&output).expect("read output metadata");
+    assert!(
+        meta.len() > 0,
+        "output TIFF should not be empty for file{}",
+        i
+    );
+
+    let _ = std::fs::remove_file(&output);
+}
+
+/// TIFF → JP2 → TIFF round-trip for `reference_jp2/jp2_<i>.tif` (port of
+/// `test_iso_15444_4_round_trip`): assert each step succeeds and the
+/// round-tripped TIFF is a sane size. No-op if the fixture is absent.
+pub fn assert_jp2_roundtrip(i: u32) {
+    let reference_tif = test_data_dir()
+        .join("images/iso-15444-4/reference_jp2")
+        .join(format!("jp2_{}.tif", i));
+
+    if !reference_tif.exists() {
+        eprintln!("Skipping round-trip for jp2_{}.tif — not found", i);
+        return;
+    }
+
+    let intermediate_jp2 = cli_tmp_path(&format!("sipi_cli_rt_{}.jp2", i));
+    let output_tif = cli_tmp_path(&format!("sipi_cli_rt_{}.tif", i));
+
+    let result1 = cli_convert(
+        reference_tif.to_str().unwrap(),
+        intermediate_jp2.to_str().unwrap(),
+        "jpx",
+    );
+    assert!(
+        result1.status.success(),
+        "TIFF→JP2 for jp2_{}.tif failed: {}",
+        i,
+        String::from_utf8_lossy(&result1.stderr)
+    );
+    assert!(
+        intermediate_jp2.exists(),
+        "intermediate JP2 should exist for file {}",
+        i
+    );
+
+    let result2 = cli_convert(
+        intermediate_jp2.to_str().unwrap(),
+        output_tif.to_str().unwrap(),
+        "tif",
+    );
+    assert!(
+        result2.status.success(),
+        "JP2→TIFF round-trip for file {} failed: {}",
+        i,
+        String::from_utf8_lossy(&result2.stderr)
+    );
+    assert!(
+        output_tif.exists(),
+        "round-trip TIFF should exist for file {}",
+        i
+    );
+
+    let ref_size = std::fs::metadata(&reference_tif).unwrap().len();
+    let out_size = std::fs::metadata(&output_tif).unwrap().len();
+    assert!(
+        out_size > 0,
+        "round-trip TIFF for file {} should not be empty",
+        i
+    );
+    // Round-trip may not be byte-identical, but should be within ~2x size.
+    assert!(
+        out_size < ref_size * 3,
+        "round-trip TIFF for file {} is suspiciously large ({} vs ref {})",
+        i,
+        out_size,
+        ref_size
+    );
+
+    let _ = std::fs::remove_file(&intermediate_jp2);
+    let _ = std::fs::remove_file(&output_tif);
+}
+
+/// Convert a TIFF to JP2 and back, then to JPEG and PNG, asserting each output
+/// carries valid magic bytes (port of the `cli_metadata_fidelity` test).
+pub fn assert_metadata_fidelity() {
+    let input = test_data_dir().join("images/unit/lena512.tif");
+    if !input.exists() {
+        eprintln!("Skipping metadata fidelity: lena512.tif not found");
+        return;
+    }
+
+    // TIFF → JP2 → TIFF, then assert the round-trip is a valid TIFF.
+    let jp2_output = cli_tmp_path("sipi_cli_meta.jp2");
+    let r1 = cli_convert(input.to_str().unwrap(), jp2_output.to_str().unwrap(), "jpx");
+    assert!(
+        r1.status.success(),
+        "TIFF→JP2 metadata test failed: {}",
+        String::from_utf8_lossy(&r1.stderr)
+    );
+    let tif_output = cli_tmp_path("sipi_cli_meta_rt.tif");
+    let r2 = cli_convert(
+        jp2_output.to_str().unwrap(),
+        tif_output.to_str().unwrap(),
+        "tif",
+    );
+    assert!(
+        r2.status.success(),
+        "JP2→TIFF metadata test failed: {}",
+        String::from_utf8_lossy(&r2.stderr)
+    );
+    let tif_bytes = std::fs::read(&tif_output).expect("read output TIFF");
+    assert!(tif_bytes.len() > 4, "output TIFF too small");
+    let is_tiff = (tif_bytes[0] == b'I' && tif_bytes[1] == b'I')
+        || (tif_bytes[0] == b'M' && tif_bytes[1] == b'M');
+    assert!(
+        is_tiff,
+        "output should be valid TIFF (starts with II or MM)"
+    );
+
+    // Format diversity: TIFF → JPEG and TIFF → PNG.
+    let jpg_output = cli_tmp_path("sipi_cli_meta.jpg");
+    let r3 = cli_convert(input.to_str().unwrap(), jpg_output.to_str().unwrap(), "jpg");
+    assert!(
+        r3.status.success(),
+        "TIFF→JPEG conversion failed: {}",
+        String::from_utf8_lossy(&r3.stderr)
+    );
+    let jpg_bytes = std::fs::read(&jpg_output).expect("read JPEG output");
+    assert!(
+        jpg_bytes.len() > 2 && jpg_bytes[0] == 0xFF && jpg_bytes[1] == 0xD8,
+        "output should be valid JPEG"
+    );
+
+    let png_output = cli_tmp_path("sipi_cli_meta.png");
+    let r4 = cli_convert(input.to_str().unwrap(), png_output.to_str().unwrap(), "png");
+    assert!(
+        r4.status.success(),
+        "TIFF→PNG conversion failed: {}",
+        String::from_utf8_lossy(&r4.stderr)
+    );
+    let png_bytes = std::fs::read(&png_output).expect("read PNG output");
+    assert!(
+        png_bytes.len() > 8 && &png_bytes[1..4] == b"PNG",
+        "output should be valid PNG"
+    );
+
+    for path in [&jp2_output, &tif_output, &jpg_output, &png_output] {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+/// The ADR-0009 Service → Access pipeline through the CLI (port of
+/// `cli_verify_pipeline_service_and_access_files`): `convert service-file`
+/// stamps an Essentials packet that `verify service-file` accepts, then
+/// `convert access-file` drops it and `verify access-file` accepts the result;
+/// the cross-checks assert each verify mode rejects the wrong file kind.
+pub fn assert_verify_pipeline() {
+    let service = cli_tmp_path("sipi_cli_verify_service.jp2");
+    let access = cli_tmp_path("sipi_cli_verify_access.jpg");
+    let _ = std::fs::remove_file(&service);
+    let _ = std::fs::remove_file(&access);
+
+    let r1 = cli_run(&[
+        "convert",
+        "service-file",
+        "images/unit/lena512.tif",
+        service.to_str().unwrap(),
+    ]);
+    assert!(
+        r1.status.success(),
+        "convert service-file must succeed; stderr:\n{}",
+        String::from_utf8_lossy(&r1.stderr)
+    );
+
+    let r2 = cli_run(&["verify", "service-file", service.to_str().unwrap()]);
+    assert!(
+        r2.status.success(),
+        "verify service-file must accept its own convert service-file output; stderr:\n{}",
+        String::from_utf8_lossy(&r2.stderr)
+    );
+
+    let r3 = cli_run(&[
+        "convert",
+        "access-file",
+        service.to_str().unwrap(),
+        access.to_str().unwrap(),
+    ]);
+    assert!(
+        r3.status.success(),
+        "convert access-file must succeed on a Service File input; stderr:\n{}",
+        String::from_utf8_lossy(&r3.stderr)
+    );
+
+    let r4 = cli_run(&["verify", "access-file", access.to_str().unwrap()]);
+    assert!(
+        r4.status.success(),
+        "verify access-file must accept its own convert access-file output; stderr:\n{}",
+        String::from_utf8_lossy(&r4.stderr)
+    );
+
+    // Cross-checks: an Access File must fail verify service-file (no
+    // Essentials) and a Service File must fail verify access-file (carries one).
+    let r5 = cli_run(&["verify", "service-file", access.to_str().unwrap()]);
+    assert!(
+        !r5.status.success(),
+        "verify service-file must reject an Access File (no Essentials packet)"
+    );
+    let r6 = cli_run(&["verify", "access-file", service.to_str().unwrap()]);
+    assert!(
+        !r6.status.success(),
+        "verify access-file must reject a Service File (carries an Essentials packet)"
+    );
+
+    let _ = std::fs::remove_file(&service);
+    let _ = std::fs::remove_file(&access);
+}
+
+/// A labelled CLI-conversion task for [`run_conversions`]. The `label` is what
+/// the executor prints if the task fails, so it should name the conversion
+/// precisely (e.g. `"jp2_roundtrip_7"`).
+pub struct ConversionTask {
+    label: String,
+    run: Box<dyn FnOnce() + Send>,
+}
+
+/// Build a labelled [`ConversionTask`] from a closure (usually a call to one of
+/// the `assert_*` conversion helpers).
+pub fn conversion_task(
+    label: impl Into<String>,
+    run: impl FnOnce() + Send + 'static,
+) -> ConversionTask {
+    ConversionTask {
+        label: label.into(),
+        run: Box::new(run),
+    }
+}
+
+/// Thread count for [`run_conversions`]: `SIPI_E2E_CONVERT_THREADS` if set and
+/// parseable, otherwise the machine's available parallelism. A single-core
+/// action degrades to serial execution (no regression versus the old one-test
+/// form); a many-core RBE worker fans the conversions out.
+pub fn conversion_threads() -> usize {
+    std::env::var("SIPI_E2E_CONVERT_THREADS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .map(|n| n.max(1))
+        .unwrap_or_else(|| std::thread::available_parallelism().map_or(1, |n| n.get()))
+}
+
+/// Run `tasks` across up to `threads` OS threads. Each task spawns its own
+/// `sipi` subprocess, so they are independent. Every task is isolated with
+/// `catch_unwind`, so one failure never hides another: ALL failures are
+/// collected across every task, then reported together — the resulting panic
+/// lists each failed task by its label. (The individual panic messages, with
+/// their `file:line`, still print to stderr as they occur.)
+pub fn run_conversions(tasks: Vec<ConversionTask>, threads: usize) {
+    let threads = threads.clamp(1, tasks.len().max(1));
+
+    // Round-robin the tasks into `threads` buckets so the work spreads evenly.
+    let mut buckets: Vec<Vec<ConversionTask>> = (0..threads).map(|_| Vec::new()).collect();
+    for (i, task) in tasks.into_iter().enumerate() {
+        buckets[i % threads].push(task);
+    }
+
+    let handles: Vec<_> = buckets
+        .into_iter()
+        .map(|bucket| {
+            std::thread::spawn(move || {
+                let mut failures: Vec<String> = Vec::new();
+                for task in bucket {
+                    let ConversionTask { label, run } = task;
+                    if let Err(payload) =
+                        std::panic::catch_unwind(std::panic::AssertUnwindSafe(run))
+                    {
+                        let msg = payload
+                            .downcast_ref::<String>()
+                            .map(|s| s.as_str())
+                            .or_else(|| payload.downcast_ref::<&str>().copied())
+                            .unwrap_or("<non-string panic>");
+                        failures.push(format!("{label}: {msg}"));
+                    }
+                }
+                failures
+            })
+        })
+        .collect();
+
+    let mut failures: Vec<String> = Vec::new();
+    for handle in handles {
+        match handle.join() {
+            Ok(mut bucket_failures) => failures.append(&mut bucket_failures),
+            Err(_) => failures.push("<a conversion worker thread itself panicked>".to_string()),
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} conversion task(s) failed:\n  - {}",
+        failures.len(),
+        failures.join("\n  - ")
+    );
+}
+
 /// Terminate any process listening on the given port (cleanup from previous
 /// test runs). Sends SIGTERM first and polls for exit; falls back to SIGKILL
 /// only if the process is still alive after the deadline. Forced SIGKILL

--- a/test/e2e/tests/cli.rs
+++ b/test/e2e/tests/cli.rs
@@ -1,215 +1,13 @@
 use insta::assert_snapshot;
-use sipi_e2e::{repo_root, sipi_bin_path, test_data_dir};
-use std::path::PathBuf;
+use sipi_e2e::{cli_convert, cli_run, cli_tmp_path, repo_root, sipi_bin_path, test_data_dir};
 use std::process::Command;
 
 // =============================================================================
-// CLI mode tests — `sipi convert <input> <output> --format <fmt>`
+// Lightweight CLI-mode tests (version, quality plumbing, help snapshot, query,
+// compare, watermark). The heavy Kakadu JP2 conversions — decodes, round-trips,
+// format-fidelity, and the verify pipeline — run in the sibling `cli_conversions`
+// target, which fans them out in parallel (see `tests/cli_conversions.rs`).
 // =============================================================================
-
-fn sipi_convert(input: &str, output: &str, format: &str) -> std::process::Output {
-    let sipi_bin = sipi_bin_path();
-
-    Command::new(&sipi_bin)
-        .arg("convert")
-        .arg(input)
-        .arg(output)
-        .arg("--format")
-        .arg(format)
-        .current_dir(test_data_dir())
-        .output()
-        .unwrap_or_else(|e| panic!("Failed to run sipi CLI: {}", e))
-}
-
-fn tmp_path(name: &str) -> PathBuf {
-    let dir = std::env::var("TMPDIR").unwrap_or_else(|_| "/tmp".to_string());
-    PathBuf::from(dir).join(name)
-}
-
-#[test]
-fn cli_file_conversion() {
-    // Port of test_iso_15444_4_decode_jp2 + test_iso_15444_4_round_trip:
-    // Convert JP2 → TIFF and TIFF → JP2 → TIFF round-trip using CLI mode.
-    let data = test_data_dir().join("images");
-
-    // Part 1: JP2 → TIFF decode (files 1 and 4 — others have known issues)
-    for i in [1, 4] {
-        let input = data
-            .join("iso-15444-4/testfiles_jp2")
-            .join(format!("file{}.jp2", i));
-        let output = tmp_path(&format!("sipi_cli_decode_{}.tif", i));
-
-        let result = sipi_convert(input.to_str().unwrap(), output.to_str().unwrap(), "tif");
-
-        assert!(
-            result.status.success(),
-            "JP2→TIFF decode for file{}.jp2 failed: {}",
-            i,
-            String::from_utf8_lossy(&result.stderr)
-        );
-
-        // Output file should exist and have content
-        assert!(output.exists(), "output TIFF should exist for file{}", i);
-        let meta = std::fs::metadata(&output).expect("read output metadata");
-        assert!(
-            meta.len() > 0,
-            "output TIFF should not be empty for file{}",
-            i
-        );
-
-        let _ = std::fs::remove_file(&output);
-    }
-
-    // Part 2: TIFF → JP2 → TIFF round-trip (files 1-9)
-    for i in 1..=9 {
-        let reference_tif = data
-            .join("iso-15444-4/reference_jp2")
-            .join(format!("jp2_{}.tif", i));
-
-        if !reference_tif.exists() {
-            eprintln!("Skipping round-trip for jp2_{}.tif — not found", i);
-            continue;
-        }
-
-        let intermediate_jp2 = tmp_path(&format!("sipi_cli_rt_{}.jp2", i));
-        let output_tif = tmp_path(&format!("sipi_cli_rt_{}.tif", i));
-
-        // TIFF → JP2
-        let result1 = sipi_convert(
-            reference_tif.to_str().unwrap(),
-            intermediate_jp2.to_str().unwrap(),
-            "jpx",
-        );
-
-        assert!(
-            result1.status.success(),
-            "TIFF→JP2 for jp2_{}.tif failed: {}",
-            i,
-            String::from_utf8_lossy(&result1.stderr)
-        );
-        assert!(
-            intermediate_jp2.exists(),
-            "intermediate JP2 should exist for file {}",
-            i
-        );
-
-        // JP2 → TIFF
-        let result2 = sipi_convert(
-            intermediate_jp2.to_str().unwrap(),
-            output_tif.to_str().unwrap(),
-            "tif",
-        );
-
-        assert!(
-            result2.status.success(),
-            "JP2→TIFF round-trip for file {} failed: {}",
-            i,
-            String::from_utf8_lossy(&result2.stderr)
-        );
-        assert!(
-            output_tif.exists(),
-            "round-trip TIFF should exist for file {}",
-            i
-        );
-
-        // Output TIFF should have reasonable size (not zero, not corrupt)
-        let ref_size = std::fs::metadata(&reference_tif).unwrap().len();
-        let out_size = std::fs::metadata(&output_tif).unwrap().len();
-        assert!(
-            out_size > 0,
-            "round-trip TIFF for file {} should not be empty",
-            i
-        );
-        // Round-trip may not be byte-identical, but should be within 2x size
-        assert!(
-            out_size < ref_size * 3,
-            "round-trip TIFF for file {} is suspiciously large ({} vs ref {})",
-            i,
-            out_size,
-            ref_size
-        );
-
-        let _ = std::fs::remove_file(&intermediate_jp2);
-        let _ = std::fs::remove_file(&output_tif);
-    }
-}
-
-#[test]
-fn cli_metadata_fidelity() {
-    // Convert a TIFF with metadata to JP2 and back, verify the output
-    // is a valid image with reasonable properties.
-    let data = test_data_dir().join("images");
-    let input = data.join("unit/lena512.tif");
-
-    if !input.exists() {
-        eprintln!("Skipping: lena512.tif not found");
-        return;
-    }
-
-    // TIFF → JP2
-    let jp2_output = tmp_path("sipi_cli_meta.jp2");
-    let result1 = sipi_convert(input.to_str().unwrap(), jp2_output.to_str().unwrap(), "jpx");
-    assert!(
-        result1.status.success(),
-        "TIFF→JP2 metadata test failed: {}",
-        String::from_utf8_lossy(&result1.stderr)
-    );
-
-    // JP2 → TIFF (back)
-    let tif_output = tmp_path("sipi_cli_meta_rt.tif");
-    let result2 = sipi_convert(
-        jp2_output.to_str().unwrap(),
-        tif_output.to_str().unwrap(),
-        "tif",
-    );
-    assert!(
-        result2.status.success(),
-        "JP2→TIFF metadata test failed: {}",
-        String::from_utf8_lossy(&result2.stderr)
-    );
-
-    // Verify output is valid — check TIFF magic bytes (II or MM)
-    let tif_bytes = std::fs::read(&tif_output).expect("read output TIFF");
-    assert!(tif_bytes.len() > 4, "output TIFF too small");
-    let is_tiff = (tif_bytes[0] == b'I' && tif_bytes[1] == b'I')
-        || (tif_bytes[0] == b'M' && tif_bytes[1] == b'M');
-    assert!(
-        is_tiff,
-        "output should be valid TIFF (starts with II or MM)"
-    );
-
-    // Also convert to JPEG and PNG to test format diversity
-    let jpg_output = tmp_path("sipi_cli_meta.jpg");
-    let result3 = sipi_convert(input.to_str().unwrap(), jpg_output.to_str().unwrap(), "jpg");
-    assert!(
-        result3.status.success(),
-        "TIFF→JPEG conversion failed: {}",
-        String::from_utf8_lossy(&result3.stderr)
-    );
-    let jpg_bytes = std::fs::read(&jpg_output).expect("read JPEG output");
-    assert!(
-        jpg_bytes.len() > 2 && jpg_bytes[0] == 0xFF && jpg_bytes[1] == 0xD8,
-        "output should be valid JPEG"
-    );
-
-    let png_output = tmp_path("sipi_cli_meta.png");
-    let result4 = sipi_convert(input.to_str().unwrap(), png_output.to_str().unwrap(), "png");
-    assert!(
-        result4.status.success(),
-        "TIFF→PNG conversion failed: {}",
-        String::from_utf8_lossy(&result4.stderr)
-    );
-    let png_bytes = std::fs::read(&png_output).expect("read PNG output");
-    assert!(
-        png_bytes.len() > 8 && &png_bytes[1..4] == b"PNG",
-        "output should be valid PNG"
-    );
-
-    // Cleanup
-    for path in [&jp2_output, &tif_output, &jpg_output, &png_output] {
-        let _ = std::fs::remove_file(path);
-    }
-}
 
 #[test]
 fn cli_version_flag() {
@@ -280,7 +78,7 @@ fn sipi_convert_quality(input: &str, output: &str, quality: u32) -> std::process
 #[test]
 fn cli_convert_quality_succeeds_and_emits_jpeg() {
     let input = test_data_dir().join("images/unit/lena512.tif");
-    let output = tmp_path("sipi_cli_quality_ok.jpg");
+    let output = cli_tmp_path("sipi_cli_quality_ok.jpg");
     let _ = std::fs::remove_file(&output);
 
     let result = sipi_convert_quality(input.to_str().unwrap(), output.to_str().unwrap(), 80);
@@ -312,8 +110,8 @@ fn cli_convert_quality_actually_affects_output() {
     // avoid erroring. A low-quality encode must be meaningfully smaller than a
     // high-quality one — false if the option is dropped or mis-threaded.
     let input = test_data_dir().join("images/unit/lena512.tif");
-    let low = tmp_path("sipi_cli_quality_low.jpg");
-    let high = tmp_path("sipi_cli_quality_high.jpg");
+    let low = cli_tmp_path("sipi_cli_quality_low.jpg");
+    let high = cli_tmp_path("sipi_cli_quality_high.jpg");
     let _ = std::fs::remove_file(&low);
     let _ = std::fs::remove_file(&high);
 
@@ -380,25 +178,18 @@ fn sipi_server_help_heading_order() {
 }
 
 // =============================================================================
-// The offline verbs beyond `convert`/`--version`: `query`, `compare`, `verify`,
-// and `convert`'s `-w/--watermark`. All delegate to the C++ CLI (`sipi_cli_main`)
-// on both binaries, so this is plain e2e coverage, not differential-relevant.
+// The offline verbs `query` and `compare`. Both delegate to the C++ CLI
+// (`sipi_cli_main`) on both binaries, so this is plain e2e coverage, not
+// differential-relevant. (`verify` runs in the `cli_conversions` batch;
+// `convert`'s `-w/--watermark` lives below.)
 // =============================================================================
-
-fn sipi_run(args: &[&str]) -> std::process::Output {
-    Command::new(sipi_bin_path())
-        .args(args)
-        .current_dir(test_data_dir())
-        .output()
-        .unwrap_or_else(|e| panic!("Failed to run sipi {:?}: {}", args, e))
-}
 
 #[test]
 fn cli_query_dumps_image_info() {
     // `sipi query <file>` streams SipiImage::operator<<, a fixed-field text
     // dump (SipiImage.cpp) — not a --json contract. lena512 is a known 512x512
     // fixture (see info_json_dimensions_match_lena512 in iiif_compliance.rs).
-    let result = sipi_run(&["query", "images/unit/lena512.tif"]);
+    let result = cli_run(&["query", "images/unit/lena512.tif"]);
     assert!(
         result.status.success(),
         "sipi query must succeed; stderr:\n{}",
@@ -418,7 +209,7 @@ fn cli_query_dumps_image_info() {
 #[test]
 fn cli_compare_identical_files_reports_match() {
     // Comparing a file against itself: img1 == img2, exit 0 ("Files identical!").
-    let result = sipi_run(&[
+    let result = cli_run(&[
         "compare",
         "images/unit/lena512.tif",
         "images/unit/lena512.tif",
@@ -435,7 +226,7 @@ fn cli_compare_differing_files_reports_mismatch() {
     // Two genuinely different images: run_compare returns -1 (truncates to a
     // non-zero exit code on the wire) and writes diff.tif — assert only the
     // non-zero contract, not the platform-specific truncated value.
-    let result = sipi_run(&[
+    let result = cli_run(&[
         "compare",
         "images/unit/lena512.tif",
         "images/unit/mario.tif",
@@ -447,75 +238,6 @@ fn cli_compare_differing_files_reports_mismatch() {
 }
 
 #[test]
-fn cli_verify_pipeline_service_and_access_files() {
-    // The ADR-0009 Service -> Access pipeline through the CLI, end to end:
-    // a plain source has neither `verify` mode's precondition met until it
-    // passes through `convert service-file` (which stamps an Essentials
-    // packet) and then `convert access-file` (which requires one on input
-    // and drops it on output). Exercises 4 previously-untested subcommands
-    // together rather than in isolation, since each verify mode's precondition
-    // is exactly what the matching convert mode produces.
-    let service = tmp_path("sipi_cli_verify_service.jp2");
-    let access = tmp_path("sipi_cli_verify_access.jpg");
-    let _ = std::fs::remove_file(&service);
-    let _ = std::fs::remove_file(&access);
-
-    let r1 = sipi_run(&[
-        "convert",
-        "service-file",
-        "images/unit/lena512.tif",
-        service.to_str().unwrap(),
-    ]);
-    assert!(
-        r1.status.success(),
-        "convert service-file must succeed; stderr:\n{}",
-        String::from_utf8_lossy(&r1.stderr)
-    );
-
-    let r2 = sipi_run(&["verify", "service-file", service.to_str().unwrap()]);
-    assert!(
-        r2.status.success(),
-        "verify service-file must accept its own convert service-file output; stderr:\n{}",
-        String::from_utf8_lossy(&r2.stderr)
-    );
-
-    let r3 = sipi_run(&[
-        "convert",
-        "access-file",
-        service.to_str().unwrap(),
-        access.to_str().unwrap(),
-    ]);
-    assert!(
-        r3.status.success(),
-        "convert access-file must succeed on a Service File input; stderr:\n{}",
-        String::from_utf8_lossy(&r3.stderr)
-    );
-
-    let r4 = sipi_run(&["verify", "access-file", access.to_str().unwrap()]);
-    assert!(
-        r4.status.success(),
-        "verify access-file must accept its own convert access-file output; stderr:\n{}",
-        String::from_utf8_lossy(&r4.stderr)
-    );
-
-    // Cross-checks: an Access File must fail verify service-file (no
-    // Essentials) and a Service File must fail verify access-file (carries one).
-    let r5 = sipi_run(&["verify", "service-file", access.to_str().unwrap()]);
-    assert!(
-        !r5.status.success(),
-        "verify service-file must reject an Access File (no Essentials packet)"
-    );
-    let r6 = sipi_run(&["verify", "access-file", service.to_str().unwrap()]);
-    assert!(
-        !r6.status.success(),
-        "verify access-file must reject a Service File (carries an Essentials packet)"
-    );
-
-    let _ = std::fs::remove_file(&service);
-    let _ = std::fs::remove_file(&access);
-}
-
-#[test]
 fn cli_convert_watermark_changes_output_bytes() {
     // `-w/--watermark` on the bare `convert` verb (attach_generic_transform_opts,
     // cli_app.cpp) is implemented but had no e2e coverage. Compare a plain
@@ -523,12 +245,12 @@ fn cli_convert_watermark_changes_output_bytes() {
     // must differ, and the watermarked output must still be a valid JPEG.
     let input = test_data_dir().join("images/unit/lena512.tif");
     let watermark = test_data_dir().join("images/unit/watermark_correct.tif");
-    let plain = tmp_path("sipi_cli_watermark_plain.jpg");
-    let watermarked = tmp_path("sipi_cli_watermark_applied.jpg");
+    let plain = cli_tmp_path("sipi_cli_watermark_plain.jpg");
+    let watermarked = cli_tmp_path("sipi_cli_watermark_applied.jpg");
     let _ = std::fs::remove_file(&plain);
     let _ = std::fs::remove_file(&watermarked);
 
-    let r_plain = sipi_convert(input.to_str().unwrap(), plain.to_str().unwrap(), "jpg");
+    let r_plain = cli_convert(input.to_str().unwrap(), plain.to_str().unwrap(), "jpg");
     assert!(
         r_plain.status.success(),
         "plain convert must succeed; stderr:\n{}",

--- a/test/e2e/tests/cli_conversions.rs
+++ b/test/e2e/tests/cli_conversions.rs
@@ -1,0 +1,40 @@
+use sipi_e2e::{
+    assert_jp2_decode, assert_jp2_roundtrip, assert_metadata_fidelity, assert_verify_pipeline,
+    conversion_task, conversion_threads, run_conversions, ConversionTask,
+};
+
+// =============================================================================
+// The heavy Kakadu JP2 / format conversions, previously the serial bulk of the
+// `cli` test (~4 min under ASan). They are independent — each spawns its own
+// `sipi convert` subprocess — so they run as a labelled task list across
+// `conversion_threads()` workers (see `run_conversions`). A failure names the
+// exact task (e.g. `jp2_roundtrip_7: ...`) and never masks the others.
+//
+// Tune the fan-out with `SIPI_E2E_CONVERT_THREADS`; the default is the host's
+// available parallelism, so a single-core action still runs correctly (serial).
+// =============================================================================
+
+#[test]
+fn cli_conversions() {
+    let mut tasks: Vec<ConversionTask> = vec![
+        // JP2 → TIFF decodes (files 1 and 4; others in the conformance set
+        // have known issues). Part 1 of the former `cli_file_conversion`.
+        conversion_task("jp2_decode_file1", || assert_jp2_decode(1)),
+        conversion_task("jp2_decode_file4", || assert_jp2_decode(4)),
+        // TIFF → JP2 → TIFF → JPEG → PNG format fidelity.
+        conversion_task("metadata_fidelity", assert_metadata_fidelity),
+        // ADR-0009 Service → Access pipeline (convert + verify, both kinds).
+        conversion_task("verify_pipeline", assert_verify_pipeline),
+    ];
+
+    // TIFF → JP2 → TIFF round-trips over the reference set (Part 2 of the
+    // former `cli_file_conversion`), one task each so the slowest fixture — not
+    // their sum — bounds the wall-clock.
+    for i in 1..=9 {
+        tasks.push(conversion_task(format!("jp2_roundtrip_{i}"), move || {
+            assert_jp2_roundtrip(i)
+        }));
+    }
+
+    run_conversions(tasks, conversion_threads());
+}

--- a/tools/differential_coverage_check.sh
+++ b/tools/differential_coverage_check.sh
@@ -20,7 +20,7 @@ cd "$(dirname "$0")/.."
 # Baseline: #[test] + #[tokio::test] across test/e2e/tests/*.rs EXCLUDING the
 # differential corpus file itself. Bump this (with a corpus update) whenever an
 # e2e test is added or removed.
-EXPECTED_E2E_TESTS=278
+EXPECTED_E2E_TESTS=276
 
 # Count via awk on a concatenated stream with literal `[ \t]` + exact string
 # compare — deterministic across awk/grep implementations. (Earlier a


### PR DESCRIPTION
## Motivation

On a warm remote cache with no code change, the `asan-ubsan-e2e` leg took ~21 min and never benefited from the cache. BEP analysis of a run (`actions/runs/30198701886`) found three causes: the two sanitizer jobs ran concurrently and each cold-compiled the full ~5500-file ASan/UBSan tree; `bazel-test-e2e` was `--stamp`ed so its e2e test actions never cache-hit across commits; and all e2e tests ran locally (the `cli` target alone ~4 min under ASan, 21.5 GB downloaded to the runner) instead of on the RBE worker. The backend is now a 250-core / 512 GB box with ample headroom to run tests remotely.

## Summary

- Merge `sanitizer-unit` + `sanitizer-e2e` into one `sanitizer` job that compiles the instrumented tree once and caches unstamped test actions across commits.
- Execute e2e tests on the RBE worker for the native x86_64 legs (isolated workers run them in parallel; the runner skips the multi-GB output download) — including the ASan leg.
- Split the `cli` e2e target so its heavy Kakadu JP2 conversions run in parallel instead of serially behind `--test-threads=1`.

## Key Changes

### Sanitizer job merge + de-stamp
- New unstamped `just bazel-test-sanitized` recipe (unit + e2e in one `bazel test`, `--build_tests_only`); `ci.yml` runs it in a single `sanitizer` job (`asan-ubsan / amd64`).
- De-stamped `bazel-test-e2e` — `cli_version_flag` accepts the `0.0.0-unstamped` fallback, so e2e test actions cache across commits.

### e2e on RBE for the native x86_64 legs
- `test/e2e/sipi_e2e_test.bzl`: `exclusive` → `exclusive-if-local`. Plain `exclusive` disables remote execution; the tag only exists to avoid `11024 + PID%16384` port collisions on a shared runner, which can't happen on isolated workers.
- `.github/actions/bazel-rbe/action.yml`: `--strategy=TestRunner=local` emitted only for the cross arm64/darwin legs.
- **ASan leg included:** a new `//bazel:asan_enabled` config_setting attaches `//bazel:llvm-symbolizer` as a test runfile under `--config=asan` and points `ASAN_SYMBOLIZER_PATH` at its runfiles path, so LSan symbolization works on the worker. Replaces the old `.bazelrc` client-env passthrough and the `just asan-symbolizer` recipe (removed).
- `bazel-test-differential` re-pins `--strategy=TestRunner=local` (spawns the C++ oracle alongside the subject); `docker_smoke` stays local via its plain `exclusive` tag.

### `cli` target split (parallel JP2 conversions)
- `cli` keeps the lightweight tests; new `cli_conversions` target runs the heavy conversions (2 JP2 decodes, 9 TIFF→JP2→TIFF round-trips, format fidelity, verify pipeline) as a labelled task list via a small parallel executor in the `sipi_e2e` lib (`ConversionTask` / `run_conversions`). Fan-out is `SIPI_E2E_CONVERT_THREADS`, defaulting to the host's available parallelism (serial on a single-core action — no regression).
- Each task is `catch_unwind`-isolated, so one failure never masks another and the panic names the exact task (`jp2_roundtrip_7: ...`).
- Drift-guard ratchet 278 → 276 (CLI tests are non-replayable; no differential corpus change).

## Challenges and Decisions

### What actually blocks e2e from running on RBE
**Problem:** first suspected Docker/local-daemon coupling. **Tried:** tagging `docker_smoke`/`differential` `local` — rejected, since `local` also pins the compile locally and breaks the arm64/darwin cross-compile. **Solution:** the real blocker is the `exclusive` tag (Bazel disables remote execution for exclusive tests). `exclusive-if-local` keeps serial exclusivity locally while allowing parallel remote execution on isolated workers. Confirmed on CI: all e2e targets ran `strat=remote` on `test / linux-amd64` and passed, so the realpath/`no-sandbox` guard survives remote execution.

### Making the ASan leg remote too (symbolizer path)
**Problem:** `ASAN_SYMBOLIZER_PATH` was a runner-side `execution_root/...` absolute path absent on the worker; without it the `leak:lua*` suppressions can't match. **Solution:** attach the hermetic `//bazel:llvm-symbolizer` as a test runfile (scoped to `--config=asan`) and set the env to its `$(rootpath)`. Unit tests reference no LSan suppressions (leak-free), so they need no symbolizer and run remotely as-is.

### Parallelising the `cli` conversions
**Problem:** the conversions were the sanitizer job's wall-clock long pole, serial under `--test-threads=1`. **Decision:** a data-driven task list + executor (per the maintainer's suggestion) rather than one target per conversion — readable, and defaulting the fan-out to `available_parallelism()` means it degrades to today's serial behaviour on a core-limited action (no regression) while fanning out on a fat worker.

## Gotchas

- **Required status checks rename:** `asan-ubsan-unit / amd64` + `asan-ubsan-e2e / amd64` → `asan-ubsan / amd64`. Update the branch ruleset, or PRs will block on the now-never-reported old checks.
- **Broadened remote surface:** the amd64 `test` leg's unit + approval + e2e all execute remotely now. Only e2e is `no-sandbox`; the first CI run confirmed the leg passes.
- **`SIPI_E2E_CONVERT_THREADS`** tunes the `cli_conversions` fan-out; leave unset to use host parallelism.

## Test Plan

- [ ] CI green on this PR (canary): `bep-linux-amd64.json` e2e `testResult`s show `strat=remote` (confirmed on the first run); runner download volume well below 21.5 GB.
- [ ] `bep-sanitizer.json`: e2e `testResult`s show `strat=remote` (ASan leg now remote), and `cli` / `cli_conversions` are separate targets that schedule in parallel.
- [x] `cli` and `cli_conversions` pass locally (fastbuild): `bazel test //test/e2e:cli //test/e2e:cli_conversions`.
- [x] `just bazel-rustfmt-check` and `just bazel-clippy-check` clean; drift guard passes at 276.
- [ ] Update the branch ruleset to the merged `asan-ubsan / amd64` check name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)