### PR TITLE
chore(ci): run the differential parity gate on the RBE worker

### DIFF
--- a/.github/actions/bazel-rbe/action.yml
+++ b/.github/actions/bazel-rbe/action.yml
@@ -108,7 +108,7 @@ runs:
         # `exclusive-if-local` (isolated workers can't collide on the shared port range),
         # so they run in parallel here; under `--config=asan` the LLVM symbolizer travels
         # as a runfile (test/e2e/sipi_e2e_test.bzl), so the sanitizer e2e tests run
-        # remotely too. `bazel-test-differential` re-pins `--strategy=TestRunner=local`
-        # in its recipe (the C++-oracle two-binary spawn stays on the runner). amd64
-        # keeps .bazelrc's graceful fallback.
+        # remotely too. The `differential` parity gate also executes on the worker (both
+        # its subject and the C++ oracle are x86_64). amd64 keeps .bazelrc's graceful
+        # fallback.
         echo "flags=$FLAGS" >> "$GITHUB_OUTPUT"

--- a/docs/src/development/rbe.md
+++ b/docs/src/development/rbe.md
@@ -173,9 +173,9 @@ output download under `--remote_download_minimal`. The e2e tests are tagged
 serially. Under `--config=asan` the e2e macro attaches `//bazel:llvm-symbolizer` as a
 runfile and sets `ASAN_SYMBOLIZER_PATH` to its runfiles path, so the sanitizer e2e tests
 run remotely too (a runner-side absolute symbolizer path would not exist on the worker).
-One exception re-pins `--strategy=TestRunner=local` in its own recipe:
-`bazel-test-differential` (spawns the C++ oracle alongside the subject). `docker_smoke`
-stays local via its plain `exclusive` tag and its Docker-daemon dependency.
+The `differential` parity gate also executes on the worker here, adding the C++ oracle
+(`//src/cli:sipi`, also x86_64) alongside the subject. `docker_smoke` is the sole local
+exception, kept on the runner by its plain `exclusive` tag and its Docker-daemon dependency.
 
 ### The `exclusive-if-local` and `no-sandbox` tags on e2e tests
 

--- a/justfile
+++ b/justfile
@@ -239,11 +239,17 @@ bazel-test-smoke *FLAGS='':
 # explicitly here. `exclusive-if-local` + `--test-threads=1` (set by the test
 # macro). CI runs it as a dedicated linux-amd64 step.
 #
-# `--strategy=TestRunner=local` pins execution to the runner: the two-binary
-# spawn (subject + C++ oracle) is a serial parity gate, kept off the RBE worker
-# even on the native x86_64 leg where other e2e tests execute remotely.
+# Executes on the worker on the native x86_64 leg like every other e2e test
+# (exec == target == x86_64): both spawned binaries — the Rust shell subject and
+# the C++ oracle `//src/cli:sipi` reference — are x86_64 and run natively there.
+# `exclusive-if-local` parallelises across isolated workers; `--test-threads=1`
+# still serialises the corpus + flag-probe subtests within this single target.
+# Unstamped for the same caching reason as `bazel-test-e2e` (the
+# `0.0.0-unstamped` fallback lets the test actions cache across commits instead
+# of forcing a `:sipi_version_h` re-link + closure re-materialisation on the
+# worker every commit; see `docs/src/development/rbe-write-pressure.md`).
 bazel-test-differential *FLAGS='':
-    bazel test --stamp --verbose_failures --strategy=TestRunner=local {{FLAGS}} //test/e2e:differential
+    bazel test --verbose_failures {{FLAGS}} //test/e2e:differential
 
 # Drift guard: assert the differential corpus still covers the e2e surface
 # (pins the e2e #[test] count; trips when a test is added/removed so the


### PR DESCRIPTION
## Motivation

`//test/e2e:differential` was the last test still pinned to the GitHub runner. Every other e2e test already executes on the RBE worker on the amd64 leg (exec == target == x86_64), where results cache remotely and the runner skips the multi-GB output download under `--remote_download_minimal`. Differential is the heaviest e2e target (two-binary spawn, full replay corpus) and the slowest, so keeping it local was the biggest remaining wall-clock cost paid on the runner. Docker (`docker_smoke`) is now the sole local target and stays local for its Docker-daemon dependency.

## Summary

- Drop `--strategy=TestRunner=local` from the `bazel-test-differential` recipe so the gate executes on the RBE worker on the amd64 leg like the sibling e2e tests.
- Drop `--stamp` too, matching `bazel-test-e2e`'s caching posture (unstamped test actions cache across commits, reducing RBE write pressure).
- Sync the now-stale comments in `docs/src/development/rbe.md` and `.github/actions/bazel-rbe/action.yml`.

## Key Changes

### justfile
Recipe becomes `bazel test --verbose_failures {{FLAGS}} //test/e2e:differential`. Comment rewritten to explain remote execution on the amd64 worker (`exclusive-if-local` parallelises across isolated workers; `--test-threads=1` still serialises the corpus + flag-probe subtests within the target) and the unstamped caching rationale.

### docs/src/development/rbe.md
Removed the "one exception re-pins `--strategy=TestRunner=local`" note. `docker_smoke` is now the sole local exception on the native x86_64 leg.

### .github/actions/bazel-rbe/action.yml
Removed the stale comment claiming differential re-pins local execution.

### .github/workflows/ci.yml
No change — the step already invokes `just bazel-test-differential` with `steps.setup.outputs.flags`, so it inherits remote execution automatically. The `if: matrix.arch == 'amd64'` guard and the dedicated `manual`-tagged step are retained intentionally.

## Challenges and Decisions

### No hard blocker, just one flag
**Problem:** A stored assumption held that remote e2e execution was blocked for differential (the `no-sandbox`/`realpath` guard was thought unverifiable remotely).
**Solution:** That is superseded — the 28 sibling e2e tests already run remotely on the amd64 leg with the identical `exclusive-if-local` + `no-sandbox` tags and the same `:test_fixtures` materialisation, empirically de-risking the guard. The only thing pinning differential local was the recipe flag.

### Dropping `--stamp` is safe for the parity test
**Problem:** `--stamp` bakes the version into the binary; dropping it yields `0.0.0-unstamped`.
**Solution:** The `/health` version field is already masked in the differential allowlist (`Allow::Health` → `.masking_json("/version")`) because Rust `CARGO_PKG_VERSION` and C++ `SipiVersion` differ by design. An unstamped version string changes only a value that is already ignored, so there is no parity impact.

## Gotchas

- The one net-new behavior vs. the already-remote suite: the C++ oracle server (`//src/cli:sipi`, `SIPI_BIN_REF`) has never run on the worker before — differential is the only test that spawns it. It is a strict superset of what the Rust shell already does remotely (same shttps `realpath` guard, same fixtures), but is observable only on the amd64 RBE worker. Verify via the CI run below, not locally (local dev never contacts the RBE backend).
- If transient remote-connection flakiness appears, add `test --flaky_test_attempts=//test/e2e:differential@3` to `.bazelrc` (alongside the existing e2e retry entries) as a follow-up. Not added preemptively.

## Test Plan

- [ ] On the amd64 `test` leg, the "Run differential parity gate" step is green.
- [ ] The step executed **remotely** — Bazel console shows `… remote` (not `… local`), cross-checked against the attached `bep-linux-amd64.json` `runnerCount[]` breakdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)