### PR TITLE
perf(docker): cap glibc malloc arenas in the container image

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -972,6 +972,13 @@ oci_image(
     env = {
         "LANG": "C.UTF-8",
         "LC_ALL": "C.UTF-8",
+        # Cap glibc malloc arenas. The engine frees every decode buffer
+        # correctly, but glibc's default (up to 8x cores) per-thread arenas
+        # each retain their peak allocation rather than returning it to the OS,
+        # so RSS climbs to a concurrency x peak-decode watermark and plateaus
+        # under load. Capping arenas lets freed decode buffers coalesce and
+        # trim back, keeping steady-state RSS closer to the true working set.
+        "MALLOC_ARENA_MAX": "2",
         # distroless_base ships ca-certificates at this canonical Debian
         # path; sipi's curl-built libcurl reads SSL_CERT_FILE for outbound
         # HTTPS (e.g. JWT issuer keys). Sentry's own HTTPS transport is the


### PR DESCRIPTION
## Motivation

Investigation of a suspected memory leak on `vre-dev-01` (the "SIPI Container Memory Usage" panel rising under load and never returning to baseline).

**Conclusion: there is no leak.** A live load burst on dev (new Rust shell) showed every instrumented structure release fully — decode-memory budget 27 MB → 0, rate-limit client map 0 → 4 → 0, pool permits → 0. Code review confirmed the Rust crate is fully bounded and the C++ engine is RAII-clean. The retained container memory is (1) reclaimable page cache (the usage-vs-working-set gap from reading image files) and (2) glibc arena retention of freed decode buffers. Both benign.

This PR ships the one cheap, low-risk mitigation from that investigation.

## Summary

- Cap glibc malloc arenas (`MALLOC_ARENA_MAX=2`) in the container image so freed decode buffers trim back to the OS instead of being retained per-thread-arena. Lowers steady-state RSS; no source/behaviour change.

## Key Changes

### src/BUILD.bazel
- Add `MALLOC_ARENA_MAX=2` to the `oci_image` env. glibc's default (up to 8×cores arenas) each retain their peak allocation; under concurrent large decodes RSS climbs to a concurrency×peak watermark and plateaus. Capping arenas lets freed buffers coalesce and trim.

## Challenges and Decisions

### Is it a real leak?
**Investigated:** live dev metrics (Grafana/Prometheus) across a load burst + full Rust/C++ code review.
**Found:** all instrumented structures release; retained memory is page cache + glibc arena retention. Not a leak.
**Decision:** allocator env knob (zero code risk) over jemalloc/tcmalloc swap (deferred unless the plateau is still too high).

### A Kakadu error-path change was considered and dropped
An earlier revision added `decompressor.finish()` on the corrupt-JP2 decode error path. Dropped after reading `kdu_stripe_decompressor.h`: `~kdu_stripe_decompressor()` calls `reset()`, which frees **all** memory (more thorough than `finish()`) and terminates MT processing, running before `env.destroy()` on stack unwind. The error-path cleanup is already automatic and correct; the change was redundant.

### Scope of the commit
No module scope fits a container-image runtime tweak; used the existing `docker` cross-cutting scope (per `docs/src/development/commit-conventions.md`) and `perf` type (deployers care about the RSS effect → Performance Improvements section).

## Gotchas

- `MALLOC_ARENA_MAX` lives **only** in the `oci_image` env; it does not affect `bazel test //test/e2e` (which runs the raw binary), local dev, or the differential oracle. Verified by grep (single occurrence) and an A/B crash-rate test.
- **Pre-existing, unrelated flake:** `//test/e2e:bilevel_tiff` segfaults intermittently at ~25% locally. A controlled A/B (8 runs each) showed the *fully pristine `main` baseline* crashes at the same 2/8 rate, so it is not introduced here. Worth its own investigation (a ~25% crash serving a bilevel TIFF is a real latent bug). CI's `--flaky_test_attempts` retries it.

## Test Plan

- [x] `bazel query //src:image` — BUILD.bazel parses with the new env
- [x] `just commit-lint origin/main` — passes
- [x] Live dev metrics + code review confirm no leak (page cache + glibc arenas)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)