### PR TITLE
chore(bazel): pin LC_ALL for macOS test actions to avoid nix-bash locale segfault

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -153,6 +153,20 @@ build:macos --action_env=MACOSX_DEPLOYMENT_TARGET=13.3
 # Apple's CDN, so no SDK/xcrun env overrides are needed.
 build:macos --repo_env=PATH
 
+# Pin an explicit locale for test actions on macOS hosts. The Nix dev-shell
+# bash (5.3, linked against CoreFoundation) segfaults ~10-25% of runs inside
+# the Bazel test wrapper while disposing locale env vars:
+# dispose_temporary_env → libintl_setlocale → CFLocaleCopyPreferredLanguages
+# → _os_log_preferences_refresh (SIGSEGV). It fires at teardown after the tests
+# pass, so Bazel reports the target (e.g. //test/e2e:bilevel_tiff) as a flaky
+# segfault with zero sipi frames involved. An explicit LC_ALL makes setlocale
+# skip the CoreFoundation default-locale resolution and sidesteps the crash
+# (verified: 0 crashes vs a ~2/20 baseline). `test:macos` (auto-applied by
+# `--enable_platform_specific_config` above) scopes this to macOS hosts — local
+# dev and the darwin CI legs, which run the same bash — and never touches the
+# Linux CI/RBE legs, where bash does not link CoreFoundation and cannot hit this.
+test:macos --test_env=LC_ALL=C
+
 # Force `rules_android`'s `android_sdk_repository_extension` to take the
 # empty-SDK branch instead of validating an actual Android SDK install.
 # `rules_android` is pulled transitively by `protobuf` (BCR) and its


### PR DESCRIPTION
## Motivation

`//test/e2e:bilevel_tiff` segfaults ~10-25% of runs on macOS dev machines. It was long suspected to be a latent sipi crash serving 1-bit bilevel TIFFs. It is not: the tests all pass and the segfault is in the **Nix dev-shell bash**, not sipi.

## Summary

- Pin `LC_ALL=C` for **macOS-host** test actions via `test:macos --test_env=LC_ALL=C` in `.bazelrc`.
- No change to Linux CI/RBE legs (structurally can't hit the crash).

## Key Changes

### `.bazelrc`
- Added `test:macos --test_env=LC_ALL=C`, auto-applied by the existing `build --enable_platform_specific_config`, with a comment documenting the root cause.

## Challenges and Decisions

### The crash is the bash test wrapper, not sipi
**Problem:** `//test/e2e:bilevel_tiff` reported `(Segmentation fault)` ~10-25% of runs, attributed to a latent bilevel-TIFF decode bug.
**Investigated:** Static analysis showed the bilevel decode path is size-correct and `scale()` isn't even invoked (`/max/` = no downscale). A direct start→serve→SIGTERM→reap cycle on the same sipi binary ran 40/40 clean, and 2000-request steady-state load under lldb never crashed.
**Solution:** macOS auto-captured crash reports (`~/Library/Logs/DiagnosticReports/bash-*.ips`) showed the crashing process is `/nix/store/…-bash-5.3p9/bin/bash` (linked against CoreFoundation), faulting in `dispose_temporary_env → libintl_setlocale → CFLocaleCopyPreferredLanguages → _os_log_preferences_refresh`. The tests pass first (`test result: ok. 5 passed`); the wrapper shell crashes at teardown while disposing locale env vars. An explicit `LC_ALL` makes `setlocale` skip the CoreFoundation default-locale path.

### Why not flake.nix, why `test:macos`
**Problem:** Nix is local-only, so the fix should not touch Linux CI.
**Tried:** Exporting `LC_ALL=C` in the dev shell alone — still 2/12 crashes, because Bazel does not forward client env into test actions. So flake.nix cannot fix it without a committed `.bazelrc --test_env` passthrough anyway.
**Solution:** `test:macos` (via the repo's existing `--enable_platform_specific_config`) is git-tracked, applies to all macOS hosts (local dev + darwin CI legs, same bash), and never to the Linux CI/RBE legs where bash isn't linked against CoreFoundation.

## Gotchas

- This is macOS-dev-only. On Linux (CI/RBE) bash does not link CoreFoundation, so the crash cannot occur there — any prior belief that CI's `--flaky_test_attempts` was retrying *this* crash was a misattribution.
- Diagnose macOS segfaults via the auto-symbolicated `.ips` reports in `~/Library/Logs/DiagnosticReports/` — ASan is macOS-unsupported in this repo (`.bazelrc` `build:asan` is Linux-only).

## Test Plan

- [x] `bazel test //test/e2e:bilevel_tiff --cache_test_results=no` — 15/15 clean with the fix (vs ~2/20 baseline).
- [x] `bazel` confirms `Found applicable config definition test:macos … --test_env=LC_ALL=C` on macOS host.
- [x] `just commit-lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)