### PR TITLE
perf(memory): switch the production allocator to mimalloc v3

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -113,6 +113,7 @@ is scoped `ffi` only when the seam mechanism itself is the point.
 | `shttps` | `src/shttps/` | Internal HTTP framework (threading, TLS, connection pooling, JWT) |
 | `cache` | `include/SipiCache.h` | File-based LRU cache with dual-limit eviction |
 | `memory-budget` | `include/SipiMemoryBudget.h` | Lock-free decode memory budget |
+| `memory` | `bazel/mimalloc.BUILD.bazel`, `_ALLOCATOR` in `src/cli-rs/BUILD.bazel`, `tools/allocator-replay/` | Process memory behavior: the production allocator, RSS/retention measurement |
 | `observability` | `src/observability/` | Prometheus metrics, tracing |
 | `logging` | `src/logging/` | Structured logging |
 | `cli` | `src/cli/` | C++ CLI app, arg parsing, subcommand dispatch |

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -93,6 +93,16 @@ bazel_dep(name = "sqlite3", version = "3.51.2.bcr.1")
 bazel_dep(name = "libexpat", version = "2.7.1.bcr.1")
 bazel_dep(name = "libmagic", version = "5.47")
 
+# The BCR libmagic BUILD omits HAVE_STRNDUP, compiling a fallback `strndup`
+# that collides with mimalloc's whole-archived override at the final link of
+# `//src/cli-rs:sipi`. All supported platforms provide strndup; see the patch
+# header for the drop condition.
+single_version_override(
+    module_name = "libmagic",
+    patch_strip = 1,
+    patches = ["//bazel/patches:libmagic_have_strndup.patch"],
+)
+
 # Codec libs consumed as BCR drop-ins. libjpeg_turbo is consumed at the classic
 # ≤v8 API target `@libjpeg_turbo//:jpeg` (SipiIOJpeg.cpp uses only that surface;
 # `:turbojpeg` is a separate API we don't consume). libwebp is reached only via
@@ -643,6 +653,19 @@ http_archive(
     sha256 = "f4f377da17b10201a60c1108613e78ee15df6b12016b116b6de42209f47a474f",
     strip_prefix = "jansson-2.13.1",
     url = "https://www.digip.org/jansson/releases/jansson-2.13.1.tar.gz",
+)
+
+# Production allocator (v3 — vendored; BCR carries only 2.x, whose
+# abandoned-segment retention OOMs under SIPI's per-request Kakadu
+# thread churn). Statically linked as the process-wide malloc override into
+# `//src/cli-rs:sipi`, Linux targets only — see `_ALLOCATOR` there and
+# docs/adr/0019-mimalloc-production-allocator.md.
+http_archive(
+    name = "mimalloc",
+    build_file = "//bazel:mimalloc.BUILD.bazel",
+    sha256 = "7b043c26b64dde66344d144fbcac3664858a4eb32197793ea2a18feb32741ca1",
+    strip_prefix = "mimalloc-3.4.3",
+    url = "https://github.com/microsoft/mimalloc/archive/refs/tags/v3.4.3.tar.gz",
 )
 
 http_archive(

--- a/bazel/mimalloc.BUILD.bazel
+++ b/bazel/mimalloc.BUILD.bazel
@@ -1,0 +1,74 @@
+"""Native `cc_library` for mimalloc v3 — the production malloc override.
+
+Vendored because BCR carries only mimalloc 2.x, whose segment architecture
+retains the freed memory of terminated threads (abandoned segments are
+reclaimed lazily and their pages never purged by default). SIPI's JP2 decode
+path creates and destroys a Kakadu worker-thread pool per request, so under
+replayed production load a 2.2.4-linked binary rode to the container limit and
+OOM-ed in minutes — worse than the glibc ratchet it was meant to fix. mimalloc
+v3 replaced segments with per-page management and reclaims dead threads' pages
+on free, which is exactly this workload. See
+docs/adr/0019-mimalloc-production-allocator.md.
+
+The target mirrors the BCR 2.x overlay's `:mimalloc-lib` shape: one
+`alwayslink` (whole-archive) library compiled as C with `MI_MALLOC_OVERRIDE`,
+so the `malloc`/`free`/`operator new` override objects — `src/alloc-override.c`
+is textually included by `src/alloc.c` — are unconditionally in any link that
+depends on this target. Consumed only by `//src/cli-rs:sipi` (Linux); nothing
+else may depend on it (the C++ engine binary stays on glibc as the
+allocator-isolated oracle baseline).
+"""
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "mimalloc",
+    srcs = [
+        # keep sorted — `set(mi_sources …)` from upstream CMakeLists.txt
+        "src/alloc.c",
+        "src/alloc-aligned.c",
+        "src/alloc-posix.c",
+        "src/arena.c",
+        "src/arena-meta.c",
+        "src/bitmap.c",
+        "src/heap.c",
+        "src/init.c",
+        "src/libc.c",
+        "src/options.c",
+        "src/os.c",
+        "src/page.c",
+        "src/page-map.c",
+        "src/prim/prim.c",
+        "src/random.c",
+        "src/stats.c",
+        "src/theap.c",
+        "src/threadlocal.c",
+    ] + glob([
+        "src/*.h",
+        "include/mimalloc/*.h",
+    ]),
+    hdrs = [
+        "include/mimalloc.h",
+        "include/mimalloc-override.h",
+        "include/mimalloc-stats.h",
+    ],
+    # `#include`d into other TUs (alloc.c / page.c / prim.c), never compiled
+    # standalone.
+    textual_hdrs = [
+        "src/alloc-override.c",
+        "src/free.c",
+        "src/page-queue.c",
+        "src/prim/unix/prim.c",
+    ],
+    alwayslink = True,
+    includes = ["include"],
+    linkopts = ["-lpthread", "-lrt"],
+    linkstatic = True,
+    local_defines = [
+        "MI_MALLOC_OVERRIDE",
+        "MI_STATIC_LIB",
+    ],
+    target_compatible_with = ["@platforms//os:linux"],
+)

--- a/bazel/patches/libmagic_have_strndup.patch
+++ b/bazel/patches/libmagic_have_strndup.patch
@@ -1,0 +1,23 @@
+Define `HAVE_STRNDUP` so libmagic's bundled strndup fallback is not compiled.
+
+The BCR `libmagic@5.47` BUILD hand-picks its config defines and omits
+`HAVE_STRNDUP`, so `src/softmagic.c` compiles its own fallback `strndup`
+unconditionally. Every platform this project targets (Linux glibc ≥ 2.28,
+macOS) provides strndup (POSIX.1-2008), so the fallback is dead weight — and
+it collides at link time with mimalloc's whole-archived malloc-override
+`strndup` in `//src/cli-rs:sipi` (ld.lld: duplicate symbol). Defining the
+macro drops the fallback and libmagic uses the interposable libc symbol like
+every other allocation site. Drop this patch if the BCR module ever grows the
+define upstream (the patch fails loudly on file-shape changes — desired
+feedback).
+
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -55,6 +55,7 @@
+         "HAVE_INTTYPES_H",
+         "HAVE_MKSTEMP",
+         "HAVE_STDINT_H",
++        "HAVE_STRNDUP",
+         "HAVE_UNISTD_H",
+         "VERSION=\\\"%s\\\"" % _VERSION,
+     ],

--- a/docs/adr/0019-mimalloc-production-allocator.md
+++ b/docs/adr/0019-mimalloc-production-allocator.md
@@ -1,0 +1,110 @@
+---
+status: accepted
+---
+
+# mimalloc is the production allocator, statically linked into the Rust shell binary
+
+On 2026-07-29 — the first day the Rust-shell SIPI 6.x served production traffic
+on vre-prod-01 — the server's container RSS ratcheted ~0.5 GB/h to its 4 GiB
+cgroup limit and the kernel OOM-killed it after six hours (anon-rss 4.1 GB,
+file-rss 31 MB). The engine's own decode-memory accounting
+(`sipi_decode_memory_used_bytes`) returned to ~0 between requests throughout:
+every decode buffer was freed, yet RSS never came back down.
+
+A controlled replay (identical ~1,500-request JP2-only corpus against the
+released v6.2.2 image, 15 minutes per configuration) isolated the allocator as
+the only variable:
+
+| allocator | RSS floor slope (15 min) |
+|---|---|
+| glibc default | +2.5 GiB/h |
+| glibc, `MALLOC_ARENA_MAX=2` | flat within noise |
+| jemalloc (`LD_PRELOAD`) | flat within noise |
+
+**There is no leak.** The ratchet is glibc allocator retention: every JP2
+decode creates and destroys a full Kakadu worker-thread pool
+(`kdu_get_num_processors()` threads per request, `src/formats/SipiIOJ2k.cpp`),
+and that cross-thread malloc/free churn fragments glibc's per-thread arenas (up
+to 8 × cores of them), each of which retains its high-water mark instead of
+returning freed memory to the OS. Production serves exclusively JP2, so every
+request drives this pattern. The churn has a precise birthday: multithreaded
+JP2 decode (`7bdb6349`, first released in 6.2.1) — a pre-6.2.1 build replayed
+under the identical load stays flat on default glibc, because single-threaded
+decode never spreads allocations across arenas.
+
+## Decision
+
+**Link an override allocator with sharded free lists — mimalloc v3, vendored
+as a native `cc_library` (`bazel/mimalloc.BUILD.bazel`) — statically into
+`//src/cli-rs:sipi`, Linux targets only.** macOS dev builds stay on the system
+allocator.
+
+**Why vendored v3 and not the BCR 2.x module:** the BCR drop-in (2.2.4) was
+tried first and **failed the replay gate catastrophically** — RSS pinned at
+~5.9 GiB within two minutes and the container OOM-ed at its 6 GiB limit in
+six, worse than the glibc ratchet it was meant to fix. mimalloc 2.x's segment
+architecture retains terminated threads' freed memory (abandoned segments;
+`abandoned_page_purge` defaults off, reclaim is lazy), and per-request thread
+churn is precisely that worst case; option tuning
+(`MIMALLOC_ABANDONED_PAGE_PURGE=1`, `MIMALLOC_PURGE_DELAY=1`,
+`MIMALLOC_MAX_SEGMENT_RECLAIM=100`) did not save it. mimalloc v3 replaced
+segments with per-page management and reclaims dead threads' pages on free —
+built for this workload — but BCR carries only 2.x, so the
+BCR-drop-in-or-vendor rule (ADR-0015) resolves to vendoring: pin the v3
+release tarball with a hand-written `cc_library` (mimalloc needs no configure
+step, so the BUILD file is small).
+
+**Why mimalloc and not jemalloc**, given jemalloc produced the flat validation
+line: jemalloc upstream was archived in 2025 and its BCR packaging is
+alpha-stage from an individual's fork; Debian's prebuilt `libjemalloc2` links
+`libstdc++`, which `distroless_base` does not ship; and the
+`tikv-jemalloc-sys` crate route is barred by this repo's build-script policy
+(the `aws-lc-sys` precedent in `MODULE.bazel`). mimalloc's free-list sharding
+targets exactly the cross-thread-churn failure mode, the BCR module is
+packaged from `microsoft/mimalloc` by a core Bazel maintainer, it is pure C,
+and it is BUILT for override use. The switch is gated on mimalloc reproducing
+jemalloc's flat line in the same replay harness.
+
+**Mechanism.** `rust_binary` has no `malloc=` attribute, so the module's
+public alias `@mimalloc//:mimalloc` is linked as a plain Linux-only dep
+(`_ALLOCATOR` in `src/cli-rs/BUILD.bazel`) — on Linux that produces the exact
+link line `malloc=` would. The BCR `:mimalloc-lib` is `alwayslink`
+(whole-archive), so the override objects — including the glibc-internal
+`__libc_malloc` aliases and the Itanium-mangled C++ operators — are always in
+the link, ahead of the lazily-scanned static libc++abi and the libc DSO.
+Symbols defined in the executable that shared objects also define are exported
+to the dynamic table by default, so libc-internal allocations preempt to
+mimalloc as well.
+
+**The interposition probe is part of the contract.** The one real hazard is
+*partial* interposition (override symbols silently not exported): the binary's
+`free` would be mimalloc while libc-internal `malloc` stays glibc — latent
+heap corruption (the engine frees `scandir`-allocated entries in
+`src/SipiCache.cpp`). At startup, `allocator::init()` in `src/cli-rs/src/main.rs`
+probes a libc-internal allocation (`getcwd(NULL, 0)`) with
+`mi_is_in_heap_region` and aborts on mismatch rather than serving.
+
+**Allocator observability moves with the allocator.** `sipi::malloc_stats`
+stays allocator-agnostic: the final-link binary registers a stats reader
+(`mi_stats_get` prefix read) via `set_source`; without one, the library falls
+back to glibc `mallinfo2`. The `sipi.malloc.*` OTLP gauges therefore report
+the allocator that is actually serving the heap.
+
+**The C++ engine binary `//src/cli:sipi` stays on glibc**, deliberately: it is
+oracle-only (never deployed), and keeping it un-switched preserves an
+allocator-isolated baseline for memory comparisons. The differential parity
+gate compares HTTP/pixel output and is allocator-neutral.
+
+## Consequences
+
+- `MALLOC_ARENA_MAX=2` is removed from the OCI image env: with glibc's
+  allocator bypassed it configures nothing that serves requests.
+- Downstream crates that replace this binary with their own `main` (per the
+  `cli-rs` extension contract) choose their own allocator; the `sipi` library
+  neither requires nor assumes mimalloc. A downstream `main` that links no
+  override gets correct glibc gauges via the fallback.
+- Kakadu's per-request thread-pool create/destroy remains a perf smell worth
+  revisiting on its own merits (thread-env reuse); this decision removes its
+  memory consequence, not its cost.
+- If mimalloc ever regresses, the validated fallback is a jemalloc
+  `LD_PRELOAD` image layer (flat line on the same harness, 2026-07-29).

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
   - Developing: development/developing.md
   - Fuzz Testing: development/fuzzing.md
   - Benchmarking: development/benchmarking.md
+  - Allocator Replay: development/allocator-replay.md
   - Profiling: development/profiling.md
   - Testing Strategy: development/testing-strategy.md
   - Downstream Dependencies: development/downstream-dependencies.md
@@ -93,6 +94,7 @@ plugins:
           - development/downstream-dependencies.md: "Runtime packages and downstream consumers"
           - development/fuzzing.md: "Fuzz testing with libFuzzer"
           - development/benchmarking.md: "Microbenchmarks with Google Benchmark: just bench, bench-compare, the regression decision rule"
+          - development/allocator-replay.md: "Allocator replay harness: RSS-floor measurement of the JP2 decode path, leak-vs-retention method, allocator baselines"
           - development/profiling.md: "Profiling with Tracy: just bazel-build-tracy, when to use Tracy vs Prometheus/Grafana vs bench, adding zones"
           - development/testing-strategy.md: "Testing strategy, coverage matrices, and feature inventory"
           - development/commit-conventions.md: "Commit organization and PR description conventions"

--- a/docs/src/development/allocator-replay.md
+++ b/docs/src/development/allocator-replay.md
@@ -1,0 +1,75 @@
+# Allocator replay harness
+
+`tools/allocator-replay/` measures the **container RSS behavior of the
+production image under a fixed JP2 decode load** — the harness that
+root-caused the 2026-07-29 vre-prod-01 OOM and gated the mimalloc switch
+([ADR-0019](../../adr/0019-mimalloc-production-allocator.md)).
+
+Run it whenever a change touches the JP2 decode path's threading or
+allocation behavior (`src/formats/SipiIOJ2k.cpp`, Kakadu thread handling,
+decode buffering), the allocator itself (`bazel/mimalloc.BUILD.bazel`, the
+`_ALLOCATOR` dep in `src/cli-rs/BUILD.bazel`), or allocator-relevant image
+env. Microbenchmarks (`just bench decode`) measure speed; this harness
+measures what those decodes do to resident memory over time — a regression
+here reaches production as an OOM, not a slow chart.
+
+## What it measures, and how to read it
+
+The replay drives a containerized sipi with a deterministic JP2-only request
+mix (large decodes weighted, per-request cache-key variety) and samples
+container RSS every ~2 s. The signal is the **per-minute RSS floor** — the
+lowest sample each minute:
+
+- **Peaks** are legitimate in-flight decodes; ignore them (but they size the
+  container limit: transient 2–3 GiB at this load is normal).
+- **A flat floor** means freed memory actually leaves the process. Flat is
+  within ±0.5 GiB/h of zero over 15 minutes.
+- **A ratcheting floor** means memory that the engine freed is not coming
+  back. Vary *only the allocator* (env or image) on the identical load to
+  split the two possible causes: if another allocator flat-lines, it is
+  allocator retention; if every allocator ratchets, it is a leak.
+
+Fifteen minutes is enough to show or rule out a ratchet at this request
+rate; it says nothing about multi-day creep.
+
+## Usage
+
+```bash
+just bazel-build                 # the CLI generates the corpus on first run
+just bazel-docker-build-arm64    # or -amd64: the image under test
+
+cd $(mktemp -d)                  # runs write <name>.csv/<name>.errors to $PWD
+REPO=<repo-root>
+
+# the image under test (daschswiss/sipi:latest by default)
+$REPO/tools/allocator-replay/replay.sh candidate 900
+
+# allocator variants on the same load, e.g. reproducing the glibc baseline
+# against a release image:
+IMAGE=daschswiss/sipi:v6.2.2 $REPO/tools/allocator-replay/replay.sh glibc 900
+IMAGE=daschswiss/sipi:v6.2.2 $REPO/tools/allocator-replay/replay.sh arena2 900 -e MALLOC_ARENA_MAX=2
+```
+
+Each run prints the per-minute floors and a least-squares floor slope at the
+end. `<name>.errors` should contain only the corpus's known non-200s (the
+`!3000,3000` upscale 400s on small images); anything else is a finding.
+
+## Baselines (2026-07-29, ~100 req/min, 6 workers, 6 GiB limit)
+
+| configuration | floor slope | note |
+|---|---|---|
+| glibc default (v6.2.2) | **+2.5 GiB/h** | reproduces the prod OOM ratchet |
+| glibc, `MALLOC_ARENA_MAX=2` | flat | the 6.2.3 stopgap |
+| jemalloc `LD_PRELOAD` | flat | validated fallback |
+| mimalloc 2.2.4 (BCR) | **OOM at min 6** | abandoned-segment retention; never ship |
+| mimalloc v3.4.3 (shipped) | flat | floors 0.5–1 GiB |
+| pre-6.2.1 build, glibc | flat | single-threaded decode: no churn, no ratchet |
+
+The last row is the provenance pin: the glibc ratchet began with the 6.2.1
+multithreaded-decode change (`7bdb6349`) — per-request Kakadu worker-thread
+creation is the churn that drives every allocator's worst case, which is why
+this harness must run again if that threading model changes.
+
+In production, the same split is visible without a replay via the
+`sipi.malloc.*` gauges (`in_use` vs `retained`; see
+`src/server-rs/src/malloc_stats.rs`).

--- a/docs/src/development/commit-conventions.md
+++ b/docs/src/development/commit-conventions.md
@@ -114,7 +114,7 @@ module list — which is also the scope vocabulary — lives in
 these names, lowercase:
 
 - **Module scopes:** `image`, `formats`, `metadata`, `iiifparser`,
-  `handlers`, `shttps`, `cache`, `memory-budget`, `observability`,
+  `handlers`, `shttps`, `cache`, `memory-budget`, `memory`, `observability`,
   `logging`, `cli`, `ffi`, `lua`, `server-rs`, `cli-rs`
 - **Test-layer scopes** (`e2e`, `approval`) — for changes to a test
   layer's own harness or fixtures. A test *about* a specific concern takes

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -972,13 +972,6 @@ oci_image(
     env = {
         "LANG": "C.UTF-8",
         "LC_ALL": "C.UTF-8",
-        # Cap glibc malloc arenas. The engine frees every decode buffer
-        # correctly, but glibc's default (up to 8x cores) per-thread arenas
-        # each retain their peak allocation rather than returning it to the OS,
-        # so RSS climbs to a concurrency x peak-decode watermark and plateaus
-        # under load. Capping arenas lets freed decode buffers coalesce and
-        # trim back, keeping steady-state RSS closer to the true working set.
-        "MALLOC_ARENA_MAX": "2",
         # distroless_base ships ca-certificates at this canonical Debian
         # path; sipi's curl-built libcurl reads SSL_CERT_FILE for outbound
         # HTTPS (e.g. JWT issuer keys). Sentry's own HTTPS transport is the

--- a/src/cli-rs/BUILD.bazel
+++ b/src/cli-rs/BUILD.bazel
@@ -83,9 +83,41 @@ _DEPS = [
     "//src/cli:cli_app",
 ]
 
+# Process-wide allocator: mimalloc v3 (vendored, `bazel/mimalloc.BUILD.bazel`)
+# statically linked as the malloc/free override on Linux (what production
+# runs); macOS dev builds stay on the system allocator. The library is
+# alwayslink, so the override objects are whole-archived ahead of the
+# lazily-scanned libc++abi/libc. The allocator belongs on the final-link
+# target only: a dep on //src/ffi:sipi_ffi would leak it into every cc_test
+# and the glibc-baselined C++ engine binary //src/cli:sipi. main.rs verifies
+# interposition at startup (a partially interposed process is latent heap
+# corruption). See docs/adr/0019-mimalloc-production-allocator.md.
+#
+# Never under ASan: AddressSanitizer interposes malloc/free with its own
+# allocator, and two interposers in one binary is undefined behavior (the
+# asan-ubsan e2e leg crashed every C++ CLI verb). The `mimalloc` crate
+# feature carries the same condition into the Rust source, so the
+# interposition probe and stats reader drop out together with the dep.
+config_setting(
+    name = "linux_sans_asan",
+    constraint_values = ["@platforms//os:linux"],
+    flag_values = {"@llvm//config:asan": "false"},
+)
+
+_ALLOCATOR = select({
+    ":linux_sans_asan": ["@mimalloc//:mimalloc"],
+    "//conditions:default": [],
+})
+
+_ALLOCATOR_FEATURE = select({
+    ":linux_sans_asan": ["mimalloc"],
+    "//conditions:default": [],
+})
+
 rust_binary(
     name = "sipi",
     srcs = _SRCS,
+    crate_features = _ALLOCATOR_FEATURE,
     crate_name = "sipi_cli",
     edition = "2021",
     rustc_flags = _CPP_STDLIB_LINK,
@@ -95,10 +127,11 @@ rust_binary(
     tags = ["no-sanitizer"],
     deps = [
         "@crates//:clap",
+        "@crates//:libc",
         "@crates//:rustls",
         "@crates//:sentry",
         "@crates//:sentry-rust-minidump",
-    ] + _DEPS,
+    ] + _DEPS + _ALLOCATOR,
 )
 
 # Inline #[cfg(test)] unit tests — the clap `server` arg-parsing pins (e.g. that
@@ -109,6 +142,7 @@ rust_binary(
 rust_test(
     name = "sipi_unit_test",
     crate = ":sipi",
+    crate_features = _ALLOCATOR_FEATURE,
     edition = "2021",
     rustc_flags = _CPP_STDLIB_LINK,
     tags = ["no-sanitizer"],

--- a/src/cli-rs/src/main.rs
+++ b/src/cli-rs/src/main.rs
@@ -20,6 +20,9 @@ use std::os::raw::{c_char, c_int};
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
+    #[cfg(feature = "mimalloc")]
+    allocator::init();
+
     // The `rustls-no-provider` feature on `sentry` (below) pulls in TLS support
     // without forcing a crypto provider — install `ring` explicitly. `sentry`'s
     // plain `rustls` feature would otherwise resolve to reqwest's aws-lc-rs
@@ -92,6 +95,133 @@ fn main() -> ExitCode {
         Some(idx) if argv[idx] == "health" => commands::health::run(&argv[idx..]),
         // Everything else → the C++ CLI, verbatim.
         _ => run_cli(&argv),
+    }
+}
+
+/// The binary's side of the allocator contract: this target links mimalloc as
+/// the process-wide malloc override on Linux (`_ALLOCATOR` in BUILD.bazel),
+/// so it owns verifying the override took and supplying allocator stats to
+/// the `sipi` library's gauges (`sipi::malloc_stats` deliberately stays
+/// allocator-agnostic — a downstream crate with its own `main` chooses its
+/// own allocator). The `mimalloc` crate feature is set by BUILD.bazel under
+/// exactly the condition the dep is linked (Linux, non-ASan), so this module
+/// and its `mi_*` extern references drop out together with the library.
+/// See docs/adr/0019-mimalloc-production-allocator.md.
+#[cfg(feature = "mimalloc")]
+mod allocator {
+    use std::ffi::c_void;
+
+    extern "C" {
+        fn mi_version() -> core::ffi::c_int;
+        fn mi_is_in_heap_region(p: *const c_void) -> bool;
+        fn mi_stats_get(stats_size: usize, stats: *mut MiStatsPrefix);
+    }
+
+    /// `mi_stat_count_t` from `mimalloc-stats.h`.
+    #[repr(C)]
+    #[derive(Clone, Copy, Default)]
+    struct MiStatCount {
+        total: i64,
+        peak: i64,
+        current: i64,
+    }
+
+    /// Leading fields of `mi_stats_t` (`mimalloc-stats.h`, `MI_STAT_VERSION`
+    /// 5 — the vendored v3 layout, where `reset`/`purged` are single-`i64`
+    /// counters), through the last field the gauges read. `mi_stats_get`
+    /// copies `min(stats_size, sizeof(mi_stats_t))` bytes, so a prefix read
+    /// is part of its contract — the trailing counters/bins are never copied.
+    #[repr(C)]
+    #[derive(Default)]
+    struct MiStatsPrefix {
+        version: i32,
+        pages: MiStatCount,
+        reserved: MiStatCount,
+        committed: MiStatCount,
+        reset: i64,
+        purged: i64,
+        page_committed: MiStatCount,
+        pages_abandoned: MiStatCount,
+        threads: MiStatCount,
+        malloc_normal: MiStatCount,
+        malloc_huge: MiStatCount,
+        malloc_requested: MiStatCount,
+    }
+
+    const MI_STAT_VERSION: i32 = 5;
+
+    /// Verify interposition (abort on failure) and register the mimalloc
+    /// stats reader with the library's allocator gauges.
+    pub(super) fn init() {
+        verify_interposition();
+        sipi::malloc_stats::set_source(stats);
+    }
+
+    /// Verify that the statically linked mimalloc interposes *libc-internal*
+    /// allocations, not just the binary's own — the two bind through
+    /// different mechanisms. Code linked into the binary resolves
+    /// `malloc`/`free` at static link time and can never miss; allocations
+    /// made inside libc.so.6 (`getcwd(NULL, 0)`, `scandir`, …) go through
+    /// libc's own GOT and reach mimalloc only if the executable exports the
+    /// override symbols to its dynamic table. A process where those two
+    /// disagree is in a latent heap-corruption state — glibc-malloc'd
+    /// pointers handed to mimalloc's `free` (e.g. the `scandir` entries the
+    /// engine's cache frees) — so a failed probe aborts rather than serving.
+    ///
+    /// `getcwd(NULL, 0)` is the probe because glibc documents it as
+    /// allocating the buffer itself, inside libc.so.6.
+    fn verify_interposition() {
+        // SAFETY: `getcwd(NULL, 0)` is the documented glibc extension that
+        // allocates a sufficiently large buffer and returns it (NULL on error).
+        let p = unsafe { libc::getcwd(std::ptr::null_mut(), 0) };
+        if p.is_null() {
+            // getcwd failure (e.g. deleted cwd) says nothing about the allocator.
+            return;
+        }
+        // SAFETY: `p` is a valid pointer returned by getcwd; mi_is_in_heap_region
+        // only inspects mimalloc's own region map and never dereferences `p`.
+        if unsafe { mi_is_in_heap_region(p.cast()) } {
+            // SAFETY: `p` was allocated by (interposed) malloc and is freed
+            // exactly once, through the same allocator.
+            unsafe { libc::free(p.cast()) };
+        } else {
+            // Deliberately leak `p`: freeing a glibc-malloc'd pointer through
+            // the statically bound mimalloc `free` is the very defect being
+            // detected.
+            // SAFETY: mi_version takes no arguments and reads a constant.
+            let version = unsafe { mi_version() };
+            eprintln!(
+                "fatal: mimalloc v{version} is linked, but libc-internal allocations \
+                 bypass it (override symbols not exported to the dynamic table); \
+                 refusing to run with mixed allocators"
+            );
+            std::process::abort();
+        }
+    }
+
+    /// Read mimalloc's accounting into the library's allocator-neutral
+    /// [`sipi::malloc_stats::MallocStats`] shape (field mapping documented
+    /// there). `None` on a stats-version bump — wrong-layout numbers are
+    /// worse than no numbers.
+    fn stats() -> Option<sipi::malloc_stats::MallocStats> {
+        let mut prefix = MiStatsPrefix::default();
+        // SAFETY: `prefix` is a properly aligned #[repr(C)] prefix of
+        // `mi_stats_t`; `mi_stats_get` zeroes then copies at most
+        // `size_of::<MiStatsPrefix>()` bytes into it.
+        unsafe { mi_stats_get(std::mem::size_of::<MiStatsPrefix>(), &mut prefix) };
+        if prefix.version != MI_STAT_VERSION {
+            return None;
+        }
+        let in_use = prefix
+            .malloc_normal
+            .current
+            .saturating_add(prefix.malloc_huge.current);
+        Some(sipi::malloc_stats::MallocStats {
+            in_use_bytes: in_use,
+            retained_bytes: prefix.committed.current.saturating_sub(in_use).max(0),
+            mmap_bytes: prefix.malloc_huge.current,
+            arena_bytes: prefix.committed.current,
+        })
     }
 }
 

--- a/src/server-rs/BUILD.bazel
+++ b/src/server-rs/BUILD.bazel
@@ -35,6 +35,7 @@ rust_library(
         "src/iiif.rs",
         "src/info.rs",
         "src/lib.rs",
+        "src/malloc_stats.rs",
         "src/metrics.rs",
         "src/path.rs",
         "src/preflight_cache.rs",

--- a/src/server-rs/src/lib.rs
+++ b/src/server-rs/src/lib.rs
@@ -22,6 +22,7 @@ pub mod config_file;
 pub mod ffi;
 pub mod iiif;
 pub mod info;
+pub mod malloc_stats;
 pub mod metrics;
 pub mod path;
 pub mod preflight_cache;

--- a/src/server-rs/src/malloc_stats.rs
+++ b/src/server-rs/src/malloc_stats.rs
@@ -1,0 +1,162 @@
+//! Allocator introspection for the OTLP metrics bridge.
+//!
+//! Container RSS alone cannot distinguish "the process is using this memory"
+//! from "the process freed it but the allocator retained it" — the difference
+//! between a leak and allocator retention, which decide two entirely different
+//! fixes. [`stats`] reads the process allocator's own accounting so
+//! [`crate::metrics`] can export both sides as gauges.
+//!
+//! This library does not choose the process allocator — the final-link binary
+//! does (`//src/cli-rs:sipi` links mimalloc on Linux; a downstream crate with
+//! its own `main` may choose differently). The binary registers its
+//! allocator's reader via [`set_source`]; without one, [`stats`] falls back to
+//! glibc `mallinfo2(3)`, which is correct exactly when no override allocator
+//! is linked. (The fallback cannot self-detect an override: non-libc symbols
+//! like `mi_stats_get` are not exported to the dynamic table, so `dlsym`
+//! cannot probe for them.)
+//!
+//! `mallinfo2` is resolved at runtime via `dlsym` rather than linked directly:
+//! the hermetic toolchain links Linux targets against generated glibc stubs
+//! whose version floor (~2.28) predates the symbol (glibc 2.33), so a direct
+//! extern reference fails at link time even though every deployment target
+//! (Debian 12 base image, glibc 2.36) provides it at runtime. On a runtime
+//! glibc without the symbol, [`stats`] returns `None` and the gauges observe
+//! nothing.
+//!
+//! Non-glibc builds (macOS dev hosts) compile the `None` fallback below.
+
+use std::sync::OnceLock;
+
+/// One allocator reading, reduced to the fields that answer the
+/// leak-vs-retention question. Field docs give the glibc `mallinfo2` and
+/// mimalloc `mi_stats_get` mappings.
+#[derive(Clone, Copy, Debug)]
+pub struct MallocStats {
+    /// Bytes handed out by `malloc` and not yet freed — what the process is
+    /// actually using. Grows without bound only under a true leak.
+    /// glibc: `uordblks`; mimalloc: `malloc_normal + malloc_huge` current.
+    pub in_use_bytes: i64,
+    /// Freed bytes the allocator retains instead of returning to the OS —
+    /// allocator retention. This is the series that explains an RSS ratchet
+    /// with no leak. glibc: `fordblks`; mimalloc: `committed − in_use`.
+    pub retained_bytes: i64,
+    /// Bytes in allocations served directly by `mmap`, outside the regular
+    /// heap structures. glibc: `hblkhd`; mimalloc: `malloc_huge` current.
+    pub mmap_bytes: i64,
+    /// Bytes the allocator holds from the OS that back RSS. glibc: `arena`
+    /// (sbrk'd heap; `arena + mmap` ≈ the allocator's share of RSS);
+    /// mimalloc: `committed` current.
+    pub arena_bytes: i64,
+}
+
+/// The reader registered by the final-link binary for its chosen allocator.
+static SOURCE: OnceLock<fn() -> Option<MallocStats>> = OnceLock::new();
+
+/// Register the allocator-stats reader for the process allocator the binary
+/// linked (call once at startup, before the server runs). Later calls are
+/// ignored.
+pub fn set_source(source: fn() -> Option<MallocStats>) {
+    let _ = SOURCE.set(source);
+}
+
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+mod imp {
+    use super::MallocStats;
+    use std::ffi::c_void;
+    use std::sync::OnceLock;
+
+    /// `struct mallinfo2` from `<malloc.h>` (glibc ≥ 2.33): ten `size_t`
+    /// fields. Only `arena`, `hblkhd`, `uordblks`, and `fordblks` are read;
+    /// the rest exist to keep the ABI layout exact.
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct Mallinfo2 {
+        arena: usize,
+        ordblks: usize,
+        smblks: usize,
+        hblks: usize,
+        hblkhd: usize,
+        usmblks: usize,
+        fsmblks: usize,
+        uordblks: usize,
+        fordblks: usize,
+        keepcost: usize,
+    }
+
+    type Mallinfo2Fn = unsafe extern "C" fn() -> Mallinfo2;
+
+    /// Resolve `mallinfo2` once from the already-loaded glibc. `None` on a
+    /// runtime glibc older than 2.33.
+    fn mallinfo2() -> Option<Mallinfo2Fn> {
+        static SYM: OnceLock<Option<Mallinfo2Fn>> = OnceLock::new();
+        *SYM.get_or_init(|| {
+            // SAFETY: RTLD_DEFAULT is a valid pseudo-handle and the name is a
+            // NUL-terminated literal; dlsym only performs a lookup.
+            let addr = unsafe { libc::dlsym(libc::RTLD_DEFAULT, c"mallinfo2".as_ptr()) };
+            if addr.is_null() {
+                None
+            } else {
+                // SAFETY: a non-null dlsym result for "mallinfo2" is glibc's
+                // `struct mallinfo2 mallinfo2(void)`, matching `Mallinfo2Fn`'s
+                // ABI (mirrored `Mallinfo2` layout, no arguments).
+                Some(unsafe { std::mem::transmute::<*mut c_void, Mallinfo2Fn>(addr) })
+            }
+        })
+    }
+
+    pub(super) fn stats() -> Option<MallocStats> {
+        // SAFETY: the pointer was resolved from the live glibc by `mallinfo2()`
+        // above; calling it has no preconditions (it takes no arguments and
+        // returns the struct by value).
+        let info = unsafe { mallinfo2()?() };
+        // Saturate rather than wrap: the gauges are i64 and a >8 EiB reading
+        // is a glibc bug, not a value worth preserving exactly.
+        let clamp = |v: usize| i64::try_from(v).unwrap_or(i64::MAX);
+        Some(MallocStats {
+            in_use_bytes: clamp(info.uordblks),
+            retained_bytes: clamp(info.fordblks),
+            mmap_bytes: clamp(info.hblkhd),
+            arena_bytes: clamp(info.arena),
+        })
+    }
+}
+
+#[cfg(not(all(target_os = "linux", target_env = "gnu")))]
+mod imp {
+    pub(super) fn stats() -> Option<super::MallocStats> {
+        None
+    }
+}
+
+/// Read the allocator's current state: the registered [`set_source`] reader
+/// when the binary installed one, else the glibc `mallinfo2` fallback; `None`
+/// when neither applies (non-glibc build with no source, or glibc < 2.33).
+pub(crate) fn stats() -> Option<MallocStats> {
+    match SOURCE.get() {
+        Some(source) => source(),
+        None => imp::stats(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn stats_is_callable_and_sane() {
+        // On glibc hosts this exercises the dlsym path and the ABI struct; on
+        // non-glibc hosts it pins the stub to `None`. A wrong `Mallinfo2`
+        // layout shows up here as garbage negative-clamped values.
+        if let Some(stats) = super::stats() {
+            assert!(stats.in_use_bytes >= 0);
+            assert!(stats.retained_bytes >= 0);
+            assert!(stats.mmap_bytes >= 0);
+            assert!(stats.arena_bytes >= 0);
+            // The test binary itself has live allocations.
+            assert!(stats.in_use_bytes > 0, "a running process has allocations");
+        } else {
+            assert!(
+                !cfg!(all(target_os = "linux", target_env = "gnu")),
+                "glibc build must resolve mallinfo2 (glibc >= 2.33)"
+            );
+        }
+    }
+}

--- a/src/server-rs/src/metrics.rs
+++ b/src/server-rs/src/metrics.rs
@@ -46,6 +46,7 @@ use opentelemetry::{global, KeyValue};
 use tokio::sync::Semaphore;
 
 use crate::ffi::{self, SipiMetricsSnapshot};
+use crate::malloc_stats::{self, MallocStats};
 use crate::preflight_cache;
 use crate::routes;
 
@@ -177,6 +178,27 @@ pub(crate) fn register(pool: Arc<Semaphore>, permits_total: usize) {
         .with_description("Preflight access-cache misses (hook ran)")
         .with_callback(|observer| observer.observe(preflight_cache::misses(), &[]))
         .build();
+    // ── Process allocator metrics ───────────────────────────────────────────
+    // Gauges splitting container RSS into "in use" vs "freed but retained by
+    // the allocator" — the series that tells a leak apart from allocator
+    // retention when RSS climbs. The binary registers a reader for its linked
+    // allocator (mimalloc in production); the fallback reads glibc `mallinfo2`
+    // (see `crate::malloc_stats`). When neither applies `stats()` is `None`
+    // and the gauges observe nothing.
+    for (name, description, extract) in MALLOC_GAUGES {
+        let extract = *extract;
+        meter
+            .i64_observable_gauge(*name)
+            .with_description(*description)
+            .with_unit("By")
+            .with_callback(move |observer| {
+                if let Some(stats) = malloc_stats::stats() {
+                    observer.observe(extract(&stats), &[]);
+                }
+            })
+            .build();
+    }
+
     meter
         .i64_observable_gauge("sipi.preflight_cache.entries")
         .with_description(
@@ -373,6 +395,33 @@ const GAUGES: &[GaugeRow] = &[
     ),
 ];
 
+/// The process-allocator gauges: OTel name, description, and the field to
+/// read from a [`MallocStats`] reading. All byte-valued. Field semantics per
+/// allocator are documented on [`MallocStats`].
+type MallocGaugeRow = (&'static str, &'static str, fn(&MallocStats) -> i64);
+const MALLOC_GAUGES: &[MallocGaugeRow] = &[
+    (
+        "sipi.malloc.in_use_bytes",
+        "Bytes allocated and not yet freed",
+        |s| s.in_use_bytes,
+    ),
+    (
+        "sipi.malloc.retained_bytes",
+        "Freed bytes the allocator retains instead of returning to the OS",
+        |s| s.retained_bytes,
+    ),
+    (
+        "sipi.malloc.mmap_bytes",
+        "Bytes in mmap-served allocations outside the regular heap",
+        |s| s.mmap_bytes,
+    ),
+    (
+        "sipi.malloc.arena_bytes",
+        "Bytes the allocator holds from the OS backing RSS",
+        |s| s.arena_bytes,
+    ),
+];
+
 /// Build one observable `u64` counter whose callback snapshots the engine
 /// metrics and reports `extract`'s field. A failed snapshot observes nothing
 /// (fail-safe on the collection thread). The handle is dropped (see
@@ -420,7 +469,7 @@ fn gauge(
 
 #[cfg(test)]
 mod tests {
-    use super::{COUNTERS, GAUGES};
+    use super::{COUNTERS, GAUGES, MALLOC_GAUGES};
     use crate::ffi::SipiMetricsSnapshot;
     use std::collections::HashSet;
     use std::mem::size_of;
@@ -485,12 +534,14 @@ mod tests {
         }
     }
 
-    /// Every engine instrument name, counters then gauges.
+    /// Every table-driven instrument name: engine counters and gauges, then
+    /// the allocator gauges.
     fn names() -> Vec<&'static str> {
         COUNTERS
             .iter()
             .map(|(name, ..)| *name)
             .chain(GAUGES.iter().map(|(name, ..)| *name))
+            .chain(MALLOC_GAUGES.iter().map(|(name, ..)| *name))
             .collect()
     }
 }

--- a/tools/allocator-replay/make-corpus.sh
+++ b/tools/allocator-replay/make-corpus.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Generate the JP2-only replay corpus for the allocator harness.
+#
+# Prod serves exclusively JPEG 2000, and the Kakadu decode path is where the
+# allocator-behavior story lives (see docs/adr/0019 and
+# docs/src/development/allocator-replay.md), so the corpus is large JP2s
+# synthesized from the repo's test images with the sipi CLI. Idempotent:
+# existing outputs are kept.
+#
+# Usage: make-corpus.sh <out-dir> [sipi-binary]
+#   out-dir      target directory for the generated images
+#   sipi-binary  default: bazel-bin/src/cli/sipi (run `just bazel-build` first)
+set -euo pipefail
+
+OUT="${1:?usage: make-corpus.sh <out-dir> [sipi-binary]}"
+SIPI="${2:-bazel-bin/src/cli/sipi}"
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+IMG="$REPO/test/_test_data/images"
+
+[ -x "$SIPI" ] || { echo "sipi binary not found at $SIPI — run 'just bazel-build' first" >&2; exit 1; }
+mkdir -p "$OUT"
+
+gen() { # gen <output> <size> <source>
+  [ -f "$OUT/$1" ] && { echo "kept $1"; return; }
+  "$SIPI" convert -s "^$2" -F jp2 "$3" "$OUT/$1"
+  echo "made $1 ($2)"
+}
+
+gen big4k.jp2 4000,4000 "$IMG/unit/CIELab16.tif"
+gen big6k.jp2 6000,4500 "$IMG/knora/Leaves8NotJpeg.jpg"
+gen big8k.jp2 8000,8000 "$IMG/knora/Leaves8.tif"
+# 12k from the 8k output: a full decode is ~430 MB, matching observed prod
+# peaks (decode-memory estimates up to ~350 MB on vre-prod-01).
+gen big12k.jp2 12000,12000 "$OUT/big8k.jp2"

--- a/tools/allocator-replay/replay.sh
+++ b/tools/allocator-replay/replay.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Allocator replay: drive a containerized sipi with a fixed JP2 decode load and
+# record container RSS over time. The per-minute RSS *floor* (lowest sample per
+# minute) tracks what the allocator refuses to give back; peaks are legitimate
+# in-flight decodes. A ratcheting floor under a load whose live data returns to
+# zero between requests is allocator retention (or a leak — vary ONLY the
+# allocator to tell them apart). Method, baselines, and interpretation:
+# docs/src/development/allocator-replay.md.
+#
+# Usage: replay.sh <name> <duration-s> [docker args...]
+#   name         run label; writes <name>.csv, <name>.errors into $PWD
+#   duration-s   e.g. 900 (15 min is enough to show or rule out a ratchet)
+#   docker args  appended to `docker run` — allocator/env variants, e.g.
+#                -e MALLOC_ARENA_MAX=2  or  -e LD_PRELOAD=/opt/lib/libx.so
+# Env:
+#   IMAGE   image under test        (default daschswiss/sipi:latest)
+#   CORPUS  corpus dir              (default: generated via make-corpus.sh
+#                                    into <repo>/bazel-bin/allocator-corpus)
+#   WORKERS concurrent clients      (default 6)
+#   MEMLIM  container memory limit  (default 6g)
+set -euo pipefail
+
+NAME="${1:?usage: replay.sh <name> <duration-s> [docker args...]}"
+DURATION="${2:?usage: replay.sh <name> <duration-s> [docker args...]}"
+shift 2
+
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+IMAGE="${IMAGE:-daschswiss/sipi:latest}"
+WORKERS="${WORKERS:-6}"
+MEMLIM="${MEMLIM:-6g}"
+CORPUS="${CORPUS:-$REPO/bazel-bin/allocator-corpus}"
+
+[ -f "$CORPUS/big12k.jp2" ] || "$REPO/tools/allocator-replay/make-corpus.sh" "$CORPUS"
+
+CID=$(docker run -d \
+  -m "$MEMLIM" --cpus 6 \
+  -e SIPI_NTHREADS=8 \
+  "$@" \
+  -v "$REPO/config:/sipi/config" \
+  -v "$REPO/test/_test_data/images:/sipi/images" \
+  -v "$CORPUS:/sipi/images/big" \
+  -v "$REPO/scripts:/sipi/scripts" \
+  -v "$REPO/server:/sipi/server" \
+  -p 0:1024 \
+  "$IMAGE")
+trap 'docker rm -f "$CID" >/dev/null 2>&1 || true' EXIT
+
+PORT=$(docker port "$CID" 1024/tcp | grep '0.0.0.0' | head -1 | rev | cut -d: -f1 | rev)
+BASE="http://127.0.0.1:$PORT"
+
+for i in $(seq 1 60); do
+  curl -sf -o /dev/null "$BASE/health" 2>/dev/null && break
+  sleep 1
+  [ "$i" = 60 ] && { echo "server never became ready" >&2; docker logs "$CID" | tail -20 >&2; exit 1; }
+done
+echo "[$NAME] $IMAGE ready on :$PORT (mem limit $MEMLIM, $WORKERS workers)"
+
+# JP2-only mix, big images weighted: prod serves exclusively J2K, and the
+# per-request Kakadu worker-thread pool is the churn under test. The worker
+# index arithmetic is deterministic, so every run replays the same sequence.
+IMAGES=(
+  "big/big8k.jp2" "big/big4k.jp2" "big/big12k.jp2" "big/big6k.jp2"
+  "big/big8k.jp2" "unit/cmyk_lossy.jp2" "big/big4k.jp2" "unit/lena512.jp2"
+)
+SIZES=("max" "pct:75" "pct:50" "pct:25" "!1024,1024" "!3000,3000")
+ROTS=("0" "90" "180" "270")
+QUALS=("default.jpg" "default.png" "gray.jpg")
+
+REQDIR=$(mktemp -d)
+worker() {
+  local w="$1" n=0 e=0
+  while [ -f "$REQDIR/run" ]; do
+    local img=${IMAGES[$(( (n + w) % ${#IMAGES[@]} ))]}
+    local size=${SIZES[$(( (n / 3 + w) % ${#SIZES[@]} ))]}
+    local rot=${ROTS[$(( (n / 7 + w) % ${#ROTS[@]} ))]}
+    local qual=${QUALS[$(( (n / 5 + w) % ${#QUALS[@]} ))]}
+    local url="$BASE/$img/full/$size/$rot/$qual"
+    local code
+    code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 180 "$url" || echo "000")
+    if [ "$code" != "200" ]; then
+      e=$((e+1))
+      echo "$code $url" >> "$NAME.errors"
+    fi
+    n=$((n+1))
+    echo "$n $e" > "$REQDIR/w$w"
+  done
+}
+
+touch "$REQDIR/run"
+for w in $(seq 1 "$WORKERS"); do worker "$w" & done
+
+CSV="$NAME.csv"
+echo "elapsed_s,mem,req_total,err_total" > "$CSV"
+START=$(date +%s)
+while :; do
+  NOW=$(date +%s); EL=$((NOW-START))
+  [ "$EL" -ge "$DURATION" ] && break
+  MEM=$(docker inspect --format '{{.State.Status}}' "$CID" 2>/dev/null | grep -q running \
+    && docker stats --no-stream --format '{{.MemUsage}}' "$CID" | awk -F/ '{print $1}' | sed 's/ //g' \
+    || echo "DEAD")
+  REQ=$(cat "$REQDIR"/w* 2>/dev/null | awk '{r+=$1; e+=$2} END {print r","e}')
+  echo "$EL,$MEM,$REQ" >> "$CSV"
+  if [ "$MEM" = "DEAD" ]; then
+    echo "[$NAME] container died at ${EL}s:" >&2
+    docker inspect --format 'oom={{.State.OOMKilled}} exit={{.State.ExitCode}}' "$CID" >&2
+    break
+  fi
+done
+
+rm -f "$REQDIR/run"; sleep 2
+wait 2>/dev/null || true
+rm -rf "$REQDIR"
+
+# Per-minute floors + least-squares slope (skipping warm-up minute 0). A slope
+# within ±0.5 GiB/h of zero over 15 min is flat; the 2026-07-29 glibc failure
+# baseline is +2.5 GiB/h at this load.
+awk -F, 'NR>1 && $2!="DEAD" {
+  v=$2
+  if (v ~ /GiB/) { sub(/GiB/,"",v); v*=1024 } else { sub(/MiB/,"",v) }
+  m=int($1/60)
+  if (!(m in min) || v+0<min[m]) min[m]=v+0
+  last=m; req[m]=$3; err[m]=$4
+} END {
+  n=0; sx=0; sy=0; sxx=0; sxy=0
+  for (m=0;m<=last;m++) if (m in min) {
+    printf "  min %2d: floor=%5.0f MiB  reqs=%s errs=%s\n", m, min[m], req[m], err[m]
+    if (m>0) { n++; sx+=m; sy+=min[m]; sxx+=m*m; sxy+=m*min[m] }
+  }
+  if (n>1) {
+    slope=(n*sxy-sx*sy)/(n*sxx-sx*sx)
+    printf "[%s] floor slope: %+.1f MiB/min (%+.2f GiB/h) over %d min\n", n_, slope, slope*60/1024, n
+  }
+}' n_="$NAME" "$CSV"


### PR DESCRIPTION
Part of INFRA-1376

## Motivation
On 2026-07-29 — the first day the Rust-shell SIPI 6.x served production traffic on vre-prod-01 — container RSS ratcheted ~0.5 GB/h into the 4 GiB cgroup limit and the kernel OOM-killed the server after six hours, while the engine's own decode-memory accounting returned to zero between requests. Root cause (established by a controlled allocator replay, not code inspection): glibc allocator retention, not a leak. Since the 6.2.1 multithreaded-decode change, every JP2 decode creates and destroys a full Kakadu worker-thread pool, and that cross-thread malloc/free churn fragments glibc's per-thread arenas, each of which retains its high-water mark.

## Summary
- The production binary now runs mimalloc v3 as its process-wide allocator on Linux; under replayed production load RSS is flat where glibc ratcheted +2.5 GiB/h.
- New `sipi.malloc.*` OTLP gauges split RSS into "in use" vs "freed but retained by the allocator" — the series that distinguishes a leak from retention.
- `MALLOC_ARENA_MAX=2` (the 6.2.3 stopgap) is removed from the image env; it configures nothing once glibc is bypassed.

## Key Changes
### Allocator (perf commit)
- mimalloc **v3.4.3 vendored** as a native `cc_library` (`bazel/mimalloc.BUILD.bazel`), statically linked into `//src/cli-rs:sipi` via a Linux-only `select` — macOS dev builds stay on the system allocator, and the glibc-baselined C++ engine binary `//src/cli:sipi` is deliberately untouched (allocator-isolated oracle baseline).
- Startup interposition probe in `main.rs`: verifies a libc-internal allocation (`getcwd(NULL,0)`) lands in mimalloc's heap and aborts on partial interposition (a mixed-allocator process is latent heap corruption).
- `single_version_override` patch for BCR libmagic: it omits `HAVE_STRNDUP`, and its bundled `strndup` fallback collides with mimalloc's whole-archived override at the final link.

### Observability (feat commit)
- `sipi::malloc_stats` is allocator-agnostic: the final-link binary registers a stats reader for the allocator it linked (`mi_stats_get` v5 prefix read); the fallback reads glibc `mallinfo2` via `dlsym` (the hermetic toolchain's glibc stubs predate the symbol, so no direct extern).
- Four gauges: `sipi.malloc.{in_use,retained,mmap,arena}_bytes`.

### Decision record (in the perf commit)
- ADR-0019 with the full evidence chain and alternatives.

### Replay harness (test commit)
- `tools/allocator-replay/` (corpus generator + replay driver) and `docs/src/development/allocator-replay.md`: the RSS-floor measurement that root-caused the incident and gated the switch, committed so it reruns for any future change to the JP2 decode path's threading/allocation or the allocator itself. Baselines for every configuration measured today are in the doc.

## Challenges and Decisions
### The BCR mimalloc failed the gate
**Problem:** the first cut linked BCR mimalloc 2.2.4. Under the identical 15-minute JP2 replay it pinned RSS at 5.9 GiB within two minutes and the container OOM-ed at minute six — worse than glibc.
**Tried:** option tuning (`MIMALLOC_ABANDONED_PAGE_PURGE=1`, `MIMALLOC_PURGE_DELAY=1`, `MIMALLOC_MAX_SEGMENT_RECLAIM=100`) — still rode to the limit.
**Solution:** mimalloc 2.x's segment architecture retains terminated threads' freed memory (abandoned segments), and per-request thread churn is its worst case. v3 replaced segments with per-page management and reclaims dead threads' pages on free; BCR carries only 2.x, so per ADR-0015 the v3 release tarball is vendored (mimalloc needs no configure step; the BUILD file is small).

### Why mimalloc and not jemalloc
jemalloc also validated flat in the replay, but upstream was archived in 2025, its BCR packaging is alpha from an individual's fork, Debian's prebuilt links libstdc++ (absent from distroless), and the `tikv-jemalloc-sys` crate route is barred by this repo's build-script policy (`aws-lc-sys` precedent). It remains the documented fallback.

### ASan and the allocator cannot coexist
**Problem:** the first CI run's asan-ubsan leg crashed every C++ CLI-verb e2e test with empty stderr, while server-mode tests passed.
**Tried:** nothing else — the mechanism is structural: AddressSanitizer interposes malloc/free with its own allocator, and two interposers in one binary is undefined.
**Solution:** a `linux_sans_asan` config_setting (keyed on `--@llvm//config:asan`) gates the dep, and a `mimalloc` crate feature carries the identical condition into the Rust source so the interposition probe and stats reader compile out together with the library. Verified by cquery under both configs.

## Gotchas
- Platform-conditional `unsafe` code evades macOS clippy: the glibc-only `dlsym` blocks failed `undocumented_unsafe_blocks` only on the Linux legs. If you add cfg-gated unsafe code, the SAFETY comment is checkable only where the cfg is true.
- Never ship an allocator without replaying the workload against it — same brand, different architecture generation, opposite result. Harness: 15-min JP2-only replay, 6 concurrent clients, per-minute RSS floors.
- `mi_stats_get` supports prefix reads by contract (`min(stats_size, sizeof)`); the Rust prefix struct pins `MI_STAT_VERSION == 5` and returns `None` on mismatch.
- The allocator dep belongs on the final-link `rust_binary` only; putting it on `//src/ffi:sipi_ffi` would leak it into every cc_test and the oracle.

## Test Plan
- [x] Replay gate: glibc +2.5 GiB/h vs mimalloc v3 flat (floors 0.5–1 GiB, 15 min, 1,279 requests, zero 5xx)
- [x] Interposition verified on the built image: `nm -D` shows `malloc`/`free`/`calloc`/`realloc`/`strndup` defined in dynsym; probe passes at container start
- [x] `just bazel-build`, `bazel-build-server`, unit tests, `bazel-test-e2e` (28/28), rustfmt + clippy gates — green on macOS
- [ ] CI: linux-x86_64 + linux-aarch64 legs (first Linux-glibc CI exercise of the probe and the vendored build), differential gate, docker smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)
