### PR TITLE
fix(memory): read mimalloc stats through a header-checked C shim

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -416,6 +416,17 @@ build --remote_max_connections=200
 # shared location across workspaces.
 common --repository_cache=~/.cache/bazel-repo
 
+# Mirror fallbacks for single-host upstream distfiles (www.lua.org,
+# www.cl.cam.ac.uk, www.digip.org — the first two failed CI within one
+# 2026-08-04 window on every leg whose repository cache didn't already hold
+# the tarball). Pinned checksums verify every candidate, so mirrors add
+# availability, never trust. See the config file for the rewrite semantics. The path must stay relative:
+# Bazel resolves it against the workspace root itself
+# (BazelRepositoryModule passes env.getWorkspace() to the UrlRewriter), and
+# %workspace% is NOT expanded for this flag — the literal token fails
+# every command at startup.
+common --downloader_config=bazel/downloader.cfg
+
 # BCR curl ships with three configurable TLS backends (boringssl default,
 # mbedtls, openssl) selected via a `string_flag`. Pin to `openssl` so the
 # resolved cc dep is `@openssl//:{ssl,crypto}` rather than BoringSSL —

--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -30,6 +30,17 @@ outputs:
   flags:
     description: Bazel flag string from bazel-rbe; pass to a `just bazel-*` recipe.
     value: ${{ steps.rbe.outputs.flags }}
+  repo-cache-key:
+    description: >
+      Primary key of the Bazel repository cache restore. Feed it to the
+      caller's end-of-job `actions/cache/save` step (see the restore step
+      below for why saving lives in the caller).
+    value: ${{ steps.repo-cache.outputs.cache-primary-key }}
+  repo-cache-hit:
+    description: >
+      'true' when the restore hit the primary key exactly — the caller's save
+      step should skip then (saving an existing key is a no-op warning).
+    value: ${{ steps.repo-cache.outputs.cache-hit }}
 
 runs:
   using: composite
@@ -60,8 +71,20 @@ runs:
     # Persist Bazel's repository cache (--repository_cache in .bazelrc) across
     # runs: external archives + bzlmod registry files download from upstream
     # only when MODULE.bazel.lock changes.
+    #
+    # restore-only, NOT `actions/cache@v4`: the combined action's post step
+    # saves only when the job SUCCEEDS, so a job that fails after fetching
+    # (flaky test, upstream outage on a later archive) throws its downloads
+    # away and re-fetches them from upstream on every retry — the exact
+    # dependence the cache exists to remove (2026-08-04: the lua.org outage
+    # kept the arm64 legs red because their evicted caches could never
+    # repopulate). A composite action cannot schedule an end-of-job step, so
+    # each CALLER pairs this with `actions/cache/save` guarded by
+    # `!cancelled()` as its last step, keyed via the `repo-cache-key` /
+    # `repo-cache-hit` outputs above.
     - name: Restore Bazel repository cache
-      uses: actions/cache@v4
+      id: repo-cache
+      uses: actions/cache/restore@v4
       with:
         path: ~/.cache/bazel-repo
         key: bazel-repo-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('MODULE.bazel.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,10 +176,10 @@ jobs:
       # ops-tf + infra repos) is the single Bazel backend. It serves the
       # Remote Cache + Remote Execution (the runner endpoint, mTLS).
       # http_archive downloads are cached client-side via --repository_cache
-      # (.bazelrc) + the actions/cache step inside `ci-setup`, not via a gRPC
-      # remote downloader — Bazel downloads FetchBlob digests from the
-      # --remote_cache CAS, so a downloader is only usable when it shares a
-      # CAS with the remote cache.
+      # (.bazelrc) + the restore (`ci-setup`) / end-of-job save cache steps,
+      # not via a gRPC remote downloader — Bazel downloads FetchBlob digests
+      # from the --remote_cache CAS, so a downloader is only usable when it
+      # shares a CAS with the remote cache.
       #
       # `ci-setup` writes the mTLS material (org secrets + variables
       # REMOTEBUILD_*) outside the checkout and emits the Bazel flag string
@@ -277,6 +277,15 @@ jobs:
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: scout-results.sarif
+
+      # Persist the repository cache even when the job fails — the paired
+      # save for ci-setup's restore-only cache step (rationale there).
+      - name: Save Bazel repository cache
+        if: ${{ !cancelled() && steps.setup.outputs.repo-cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/bazel-repo
+          key: ${{ steps.setup.outputs.repo-cache-key }}
 
   # ASan + UBSan on the full functional test pyramid, split into two parallel
   # path-gated jobs. Catches memory errors (buffer overflow, use-after-free,
@@ -378,6 +387,15 @@ jobs:
           name: sanitizer-reports
           retention-days: 30
           path: bazel-testlogs/**/test.outputs/asan-e2e.*
+
+      # Persist the repository cache even when the job fails — the paired
+      # save for ci-setup's restore-only cache step (rationale there).
+      - name: Save Bazel repository cache
+        if: ${{ !cancelled() && steps.setup.outputs.repo-cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/bazel-repo
+          key: ${{ steps.setup.outputs.repo-cache-key }}
 
   # Build documentation. Pure Python/MkDocs — standalone LFS handling (no
   # Bazel/RBE needed, so it doesn't use `ci-setup`).

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -74,3 +74,12 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: dasch-swiss/sipi
           files: bazel-out/_coverage/_coverage_report.dat
+
+      # Persist the repository cache even when the job fails — the paired
+      # save for ci-setup's restore-only cache step (rationale there).
+      - name: Save Bazel repository cache
+        if: ${{ !cancelled() && steps.setup.outputs.repo-cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/bazel-repo
+          key: ${{ steps.setup.outputs.repo-cache-key }}

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -161,3 +161,12 @@ jobs:
             timeout-*
             fuzz-output.log
             crash-summary.md
+
+      # Persist the repository cache even when the job fails — the paired
+      # save for ci-setup's restore-only cache step (rationale there).
+      - name: Save Bazel repository cache
+        if: ${{ !cancelled() && steps.setup.outputs.repo-cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/bazel-repo
+          key: ${{ steps.setup.outputs.repo-cache-key }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,6 +77,15 @@ jobs:
       - name: Run Docker smoke tests
         run: just bazel-test-smoke ${{ steps.setup.outputs.flags }}
 
+      # Persist the repository cache even when the job fails — the paired
+      # save for ci-setup's restore-only cache step (rationale there).
+      - name: Save Bazel repository cache
+        if: ${{ !cancelled() && steps.setup.outputs.repo-cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/bazel-repo
+          key: ${{ steps.setup.outputs.repo-cache-key }}
+
   release-gate:
     runs-on: ubuntu-latest
     needs: [validate-docker]
@@ -206,6 +215,15 @@ jobs:
             echo "Expected debug symbol file not found: ${{ matrix.debug_file }}"
             exit 1
           fi
+
+      # Persist the repository cache even when the job fails — the paired
+      # save for ci-setup's restore-only cache step (rationale there).
+      - name: Save Bazel repository cache
+        if: ${{ !cancelled() && steps.setup.outputs.repo-cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/bazel-repo
+          key: ${{ steps.setup.outputs.repo-cache-key }}
 
   manifest:
     runs-on: ubuntu-latest

--- a/bazel/downloader.cfg
+++ b/bazel/downloader.cfg
@@ -1,0 +1,38 @@
+# Bazel downloader URL rewrites (wired via `common --downloader_config` in
+# `.bazelrc`). Fans single-host upstream fetches out to byte-identical
+# mirrors so one distfile server's outage cannot fail CI: every candidate is
+# still verified against the checksum pinned in MODULE.bazel(.lock), so a
+# stale or compromised mirror can only fail a fetch, never alter its bytes.
+#
+# Semantics (Bazel UrlRewriter): patterns are regexes matched against the URL
+# WITHOUT its scheme; when any rewrite matches, the original URL is dropped
+# and ONLY the rewritten candidates are tried — hence the identity rewrites,
+# which keep each upstream itself in the candidate set. URLs that match no
+# rewrite pass through untouched.
+#
+# Every mirror below was verified byte-identical against the pinned sha256
+# at add time. GitHub-hosted upstreams are not mirrored here — their
+# availability is already the ceiling for the rest of the build.
+
+# lua-5.3.6.tar.gz (BCR `lua` module source): www.lua.org is a single
+# unmirrored host; an hours-long 503 outage on 2026-08-04 failed CI.
+rewrite (www\.lua\.org/ftp/.*) $1
+rewrite www\.lua\.org/ftp/(.*) distfiles.macports.org/lua/$1
+rewrite www\.lua\.org/ftp/(.*) cdn.netbsd.org/pub/pkgsrc/distfiles/$1
+rewrite www\.lua\.org/ftp/(.*) ftp.openbsd.org/pub/OpenBSD/distfiles/$1
+
+# jbigkit-2.1.tar.gz (@jbigkit, MODULE.bazel): a personal page on
+# www.cl.cam.ac.uk; timed out on 2026-08-04 in the same CI window as the
+# lua.org outage.
+rewrite (www\.cl\.cam\.ac\.uk/~mgk25/jbigkit/download/.*) $1
+rewrite www\.cl\.cam\.ac\.uk/~mgk25/jbigkit/download/(.*) distfiles.macports.org/jbigkit/$1
+rewrite www\.cl\.cam\.ac\.uk/~mgk25/jbigkit/download/(.*) cdn.netbsd.org/pub/pkgsrc/distfiles/$1
+rewrite www\.cl\.cam\.ac\.uk/~mgk25/jbigkit/download/(.*) ftp.openbsd.org/pub/OpenBSD/distfiles/$1
+
+# jansson-2.13.1.tar.gz (@jansson, MODULE.bazel): www.digip.org is the last
+# remaining single-host upstream; same class. The GitHub release asset is
+# byte-identical, so it leads the fallbacks.
+rewrite (www\.digip\.org/jansson/releases/.*) $1
+rewrite www\.digip\.org/jansson/releases/(.*) github.com/akheron/jansson/releases/download/v2.13.1/$1
+rewrite www\.digip\.org/jansson/releases/(.*) distfiles.macports.org/jansson/$1
+rewrite www\.digip\.org/jansson/releases/(.*) ftp.openbsd.org/pub/OpenBSD/distfiles/$1

--- a/bazel/mimalloc.BUILD.bazel
+++ b/bazel/mimalloc.BUILD.bazel
@@ -69,6 +69,14 @@ cc_library(
     local_defines = [
         "MI_MALLOC_OVERRIDE",
         "MI_STATIC_LIB",
+        # Binned-allocation accounting (`malloc_normal` in `mi_stats_get`) is
+        # compiled out at mimalloc's release default (`MI_STAT=0`, only
+        # os-level "essential" stats) — the `sipi.malloc.in_use_bytes` gauge
+        # would then count only >512 KiB "huge" blocks and silently
+        # underreport the heap. Level 1 is upstream's "maintain statistics"
+        # mode (one per-thread-heap counter update per malloc/free); the
+        # "costs some performance" fine-grained tracking is level 2.
+        "MI_STAT=1",
     ],
     target_compatible_with = ["@platforms//os:linux"],
 )

--- a/docs/adr/0019-mimalloc-production-allocator.md
+++ b/docs/adr/0019-mimalloc-production-allocator.md
@@ -85,10 +85,15 @@ probes a libc-internal allocation (`getcwd(NULL, 0)`) with
 `mi_is_in_heap_region` and aborts on mismatch rather than serving.
 
 **Allocator observability moves with the allocator.** `sipi::malloc_stats`
-stays allocator-agnostic: the final-link binary registers a stats reader
-(`mi_stats_get` prefix read) via `set_source`; without one, the library falls
-back to glibc `mallinfo2`. The `sipi.malloc.*` OTLP gauges therefore report
-the allocator that is actually serving the heap.
+stays allocator-agnostic: the final-link binary registers a stats reader via
+`set_source`; without one, the library falls back to glibc `mallinfo2`. The
+`sipi.malloc.*` OTLP gauges therefore report the allocator that is actually
+serving the heap. The reader calls `mi_stats_get` through a one-function C
+shim (`src/cli-rs/mi_stats_shim.c`) compiled against the vendored
+`mimalloc-stats.h`, never through a Rust `extern "C"` re-declaration: nothing
+verifies a hand-mirrored declaration against the header, and a drift from the
+pinned version is a SIGSEGV on the metrics thread at the first collection
+(SIPI-1R, the 6.3.0 ls-test crash loop) instead of a build error.
 
 **The C++ engine binary `//src/cli:sipi` stays on glibc**, deliberately: it is
 oracle-only (never deployed), and keeping it un-switched preserves an

--- a/src/cli-rs/BUILD.bazel
+++ b/src/cli-rs/BUILD.bazel
@@ -18,6 +18,7 @@ which keeps the production socket until the cutover renames this to the stock
 `sipi` entry point and switches the Docker entrypoint.
 """
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
 
 package(default_visibility = ["//visibility:public"])
@@ -104,8 +105,26 @@ config_setting(
     flag_values = {"@llvm//config:asan": "false"},
 )
 
+# The mimalloc stats read (`sipi.malloc.*` gauges) goes through this
+# one-function C shim, compiled against the vendored `mimalloc-stats.h` so the
+# `mi_stats_get` signature and `mi_stats_t` layout are compiler-checked against
+# the exact @mimalloc pin. Rust-side `extern "C"` re-declarations of mimalloc's
+# stats API are banned: nothing verifies them against the header, and a
+# declaration drifting from the pinned version segfaults the metrics thread at
+# the first collection (SIPI-1R) instead of failing the build.
+cc_library(
+    name = "mi_stats_shim",
+    srcs = ["mi_stats_shim.c"],
+    linkstatic = True,
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = ["@mimalloc//:mimalloc"],
+)
+
 _ALLOCATOR = select({
-    ":linux_sans_asan": ["@mimalloc//:mimalloc"],
+    ":linux_sans_asan": [
+        ":mi_stats_shim",
+        "@mimalloc//:mimalloc",
+    ],
     "//conditions:default": [],
 })
 

--- a/src/cli-rs/mi_stats_shim.c
+++ b/src/cli-rs/mi_stats_shim.c
@@ -1,0 +1,36 @@
+/* Reads mimalloc's allocator accounting for the `sipi.malloc.*` gauges.
+ *
+ * Deliberately a C translation unit compiled against the vendored
+ * `mimalloc-stats.h` (the same @mimalloc tree the allocator links from), so
+ * the `mi_stats_get` contract — signature, `mi_stats_t` layout, and the
+ * caller-filled `size`/`version` handshake — is checked by the C compiler
+ * instead of being hand-mirrored in Rust, where a declaration drifting from
+ * the pinned mimalloc version is a runtime SIGSEGV on the metrics thread
+ * (SIPI-1R), not a build error. A mimalloc bump that changes the stats API
+ * must break this file's compile, never production.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <mimalloc-stats.h>
+
+/* The three counters `sipi::malloc_stats::MallocStats` is derived from (the
+ * field mapping lives with the Rust caller). Returns false when
+ * `mi_stats_get` rejects the size/version handshake — impossible while shim
+ * and allocator compile from the same tree, but it is the documented
+ * contract, so surface it instead of returning zeros. */
+bool sipi_mi_stats_read(int64_t* malloc_normal_current,
+                        int64_t* malloc_huge_current,
+                        int64_t* committed_current) {
+  mi_stats_t stats;
+  stats.size = sizeof(mi_stats_t);
+  stats.version = MI_STAT_VERSION;
+  if (!mi_stats_get(&stats)) {
+    return false;
+  }
+  *malloc_normal_current = stats.malloc_normal.current;
+  *malloc_huge_current = stats.malloc_huge.current;
+  *committed_current = stats.committed.current;
+  return true;
+}

--- a/src/cli-rs/src/main.rs
+++ b/src/cli-rs/src/main.rs
@@ -114,41 +114,19 @@ mod allocator {
     extern "C" {
         fn mi_version() -> core::ffi::c_int;
         fn mi_is_in_heap_region(p: *const c_void) -> bool;
-        fn mi_stats_get(stats_size: usize, stats: *mut MiStatsPrefix);
+        // `mi_stats_shim.c` (`:mi_stats_shim` in BUILD.bazel). The mimalloc
+        // stats read lives in C, compiled against the vendored
+        // `mimalloc-stats.h`, so the `mi_stats_get` contract is checked by
+        // the C compiler. Never re-declare mimalloc's stats API in Rust:
+        // nothing verifies a hand-mirrored declaration against the header,
+        // and a drift from the pinned version is a SIGSEGV on the metrics
+        // thread (SIPI-1R), not a build error.
+        fn sipi_mi_stats_read(
+            malloc_normal_current: *mut i64,
+            malloc_huge_current: *mut i64,
+            committed_current: *mut i64,
+        ) -> bool;
     }
-
-    /// `mi_stat_count_t` from `mimalloc-stats.h`.
-    #[repr(C)]
-    #[derive(Clone, Copy, Default)]
-    struct MiStatCount {
-        total: i64,
-        peak: i64,
-        current: i64,
-    }
-
-    /// Leading fields of `mi_stats_t` (`mimalloc-stats.h`, `MI_STAT_VERSION`
-    /// 5 — the vendored v3 layout, where `reset`/`purged` are single-`i64`
-    /// counters), through the last field the gauges read. `mi_stats_get`
-    /// copies `min(stats_size, sizeof(mi_stats_t))` bytes, so a prefix read
-    /// is part of its contract — the trailing counters/bins are never copied.
-    #[repr(C)]
-    #[derive(Default)]
-    struct MiStatsPrefix {
-        version: i32,
-        pages: MiStatCount,
-        reserved: MiStatCount,
-        committed: MiStatCount,
-        reset: i64,
-        purged: i64,
-        page_committed: MiStatCount,
-        pages_abandoned: MiStatCount,
-        threads: MiStatCount,
-        malloc_normal: MiStatCount,
-        malloc_huge: MiStatCount,
-        malloc_requested: MiStatCount,
-    }
-
-    const MI_STAT_VERSION: i32 = 5;
 
     /// Verify interposition (abort on failure) and register the mimalloc
     /// stats reader with the library's allocator gauges.
@@ -201,27 +179,56 @@ mod allocator {
 
     /// Read mimalloc's accounting into the library's allocator-neutral
     /// [`sipi::malloc_stats::MallocStats`] shape (field mapping documented
-    /// there). `None` on a stats-version bump — wrong-layout numbers are
-    /// worse than no numbers.
+    /// there). `None` when the shim's size/version handshake with
+    /// `mi_stats_get` fails — wrong-layout numbers are worse than no numbers.
     fn stats() -> Option<sipi::malloc_stats::MallocStats> {
-        let mut prefix = MiStatsPrefix::default();
-        // SAFETY: `prefix` is a properly aligned #[repr(C)] prefix of
-        // `mi_stats_t`; `mi_stats_get` zeroes then copies at most
-        // `size_of::<MiStatsPrefix>()` bytes into it.
-        unsafe { mi_stats_get(std::mem::size_of::<MiStatsPrefix>(), &mut prefix) };
-        if prefix.version != MI_STAT_VERSION {
+        let mut malloc_normal: i64 = 0;
+        let mut malloc_huge: i64 = 0;
+        let mut committed: i64 = 0;
+        // SAFETY: the three out-pointers are valid and distinct; the shim
+        // writes all of them before returning true and touches nothing else.
+        let ok =
+            unsafe { sipi_mi_stats_read(&mut malloc_normal, &mut malloc_huge, &mut committed) };
+        if !ok {
             return None;
         }
-        let in_use = prefix
-            .malloc_normal
-            .current
-            .saturating_add(prefix.malloc_huge.current);
+        let in_use = malloc_normal.saturating_add(malloc_huge);
         Some(sipi::malloc_stats::MallocStats {
             in_use_bytes: in_use,
-            retained_bytes: prefix.committed.current.saturating_sub(in_use).max(0),
-            mmap_bytes: prefix.malloc_huge.current,
-            arena_bytes: prefix.committed.current,
+            retained_bytes: committed.saturating_sub(in_use).max(0),
+            mmap_bytes: malloc_huge,
+            arena_bytes: committed,
         })
+    }
+
+    #[cfg(test)]
+    mod tests {
+        /// The reader must survive a real `mi_stats_get` round-trip against
+        /// the linked mimalloc and report live allocations.
+        /// `//src/cli-rs:sipi_unit_test` links mimalloc exactly like the
+        /// binary, so this is the in-CI execution of the stats FFI that was
+        /// missing when 6.3.0's mis-declared `mi_stats_get` shipped and
+        /// segfaulted the first OTel metrics collection (SIPI-1R).
+        #[test]
+        fn stats_reads_live_mimalloc_accounting() {
+            // Hold 1 MiB of small binned blocks — the `malloc_normal` class.
+            // A single large Vec would land in `malloc_huge` (> 512 KiB),
+            // which mimalloc tracks even with binned accounting compiled out
+            // (`MI_STAT=0`), and would miss a stats-level regression in
+            // bazel/mimalloc.BUILD.bazel's `MI_STAT=1` define.
+            let held: Vec<Vec<u8>> = (0..256).map(|_| vec![0u8; 4096]).collect();
+            let held_bytes: i64 = held.iter().map(|b| b.len() as i64).sum();
+            let stats = super::stats().expect("mi_stats_get size/version handshake");
+            assert!(
+                stats.in_use_bytes >= held_bytes,
+                "in_use ({}) must cover {held_bytes} B of live binned allocations",
+                stats.in_use_bytes
+            );
+            assert!(stats.arena_bytes > 0, "committed memory backs the heap");
+            assert!(stats.retained_bytes >= 0);
+            assert!(stats.mmap_bytes >= 0);
+            drop(std::hint::black_box(held));
+        }
     }
 }
 

--- a/test/e2e/BUILD.bazel
+++ b/test/e2e/BUILD.bazel
@@ -9,12 +9,12 @@ Layout:
   * `:sipi_e2e`        `rust_library` exposing the shared helpers
                        (`SipiServer`, `repo_root`, `http_client`, …)
                        consumed by every test binary.
-  * 28 × `rust_test`   one target per non-docker `tests/<name>.rs`,
+  * 29 × `rust_test`   one target per non-docker `tests/<name>.rs`,
                        defined via `sipi_e2e_test()` (see
                        `sipi_e2e_test.bzl`). The macro injects the
                        shared `data`/`env`/`args`/`tags` so the
                        contracts can't drift across targets.
-  * `:differential`    a 25th `sipi_e2e_test()` target that also spawns
+  * `:differential`    an additional `sipi_e2e_test()` target that also spawns
                        the C++ oracle (`SIPI_BIN_REF`) and diffs it
                        against the Rust shell. `manual`-tagged, so it is
                        kept OUT of `:all_e2e` and the `//test/e2e/...`
@@ -23,7 +23,7 @@ Layout:
   * `:docker_smoke`    inline `rust_test` — its data shape (OCI image
                        tarball) and tags (`requires-docker`) diverge
                        from the macro's defaults.
-  * `:all_e2e`         `test_suite` aggregating the 28 non-docker
+  * `:all_e2e`         `test_suite` aggregating the 29 non-docker
                        targets (not `:differential` / `:docker_smoke`).
                        `just bazel-test-e2e` wraps `bazel test
                        //test/e2e:all_e2e`.
@@ -144,6 +144,16 @@ sipi_e2e_test(name = "latency", deps = _e2e_test_deps)
 
 sipi_e2e_test(name = "memory_budget", deps = _e2e_test_deps)
 
+# SIPI-1R regression gate: several OTel metric collections — the path that
+# segfaulted 6.3.0's mis-declared `mi_stats_get` FFI — must run without
+# killing the server. `no-sanitizer` because it activates the OTLP exporter
+# (see `tracing` below for the ASan thread-registry rationale).
+sipi_e2e_test(
+    name = "metrics_export",
+    deps = _e2e_test_deps,
+    extra_tags = ["no-sanitizer"],
+)
+
 sipi_e2e_test(name = "option_matrix", deps = _e2e_test_deps)
 
 sipi_e2e_test(name = "preflight_cache", deps = _e2e_test_deps)
@@ -166,7 +176,7 @@ sipi_e2e_test(name = "smoke", deps = _e2e_test_deps)
 
 sipi_e2e_test(name = "toml_config", deps = _e2e_test_deps)
 
-# `no-sanitizer`: the only e2e test that activates the OTLP exporter (it sets
+# `no-sanitizer`: activates the OTLP exporter (sets
 # `OTEL_EXPORTER_OTLP_ENDPOINT` so the shell produces span contexts to propagate).
 # Under ASan the exporter's tonic/tokio background threads trip the known
 # thread-registry false positive (`sanitizer_thread_arg_retval.cpp` CHECK), which
@@ -308,6 +318,7 @@ test_suite(
         ":input_validation",
         ":latency",
         ":memory_budget",
+        ":metrics_export",
         ":option_matrix",
         ":preflight_cache",
         ":proptest_iiif_uri",

--- a/test/e2e/tests/metrics_export.rs
+++ b/test/e2e/tests/metrics_export.rs
@@ -1,0 +1,69 @@
+//! Metrics collection must not kill the server (SIPI-1R regression gate).
+//!
+//! Release 6.3.0 crash-looped on ls-test: the OTel periodic reader's first
+//! collection invoked the `sipi.malloc.*` gauge callbacks, whose mis-declared
+//! `mi_stats_get` FFI segfaulted inside mimalloc ~60s after every boot. No
+//! test executed that path — telemetry is fail-open (without
+//! `OTEL_EXPORTER_OTLP_ENDPOINT` the meter provider is never installed and
+//! the callbacks never registered), and the one e2e that does set the
+//! endpoint (`tracing.rs`) never outlives the 60-second default export
+//! interval.
+//!
+//! This closes the gap end-to-end: enable the metrics pipeline against a
+//! dead OTLP endpoint (export failures are fail-open and dropped), shrink
+//! the export interval via the standard `OTEL_METRIC_EXPORT_INTERVAL` so
+//! collections fire inside the test window, serve a real request, sit
+//! through several collection cycles — each one invokes every observable
+//! callback, including the allocator stats reader — and assert the server
+//! is still alive and serving.
+//!
+//! Non-replayable for the differential gate (env-driven lifecycle/timing:
+//! the subject is spawned with OTel env and the assertion is
+//! survival-over-time, not a response); its GET requests are standard
+//! corpus material already.
+
+use std::time::Duration;
+
+use sipi_e2e::{http_client, test_data_dir, SipiServer};
+
+#[test]
+fn metrics_collection_does_not_kill_the_server() {
+    let test_data = test_data_dir();
+    let srv = SipiServer::start_env(
+        "config/sipi.e2e-test-config.lua",
+        &test_data,
+        &[],
+        &[
+            ("OTEL_EXPORTER_OTLP_ENDPOINT", "http://127.0.0.1:1"),
+            // Milliseconds (OTel spec). Several collections per test run
+            // instead of the 60s default that outlives every test.
+            ("OTEL_METRIC_EXPORT_INTERVAL", "250"),
+        ],
+    );
+    let client = http_client();
+
+    // One real decode request so the engine-side counters the gauges
+    // snapshot (cache, decode memory, pool permits) are warm.
+    let resp = client
+        .get(format!(
+            "{}/unit/lena512.jp2/full/256,/0/default.jpg",
+            srv.base_url
+        ))
+        .send()
+        .expect("image request to sipi");
+    assert_eq!(resp.status().as_u16(), 200, "decode request must succeed");
+
+    // Sit through several collection cycles.
+    std::thread::sleep(Duration::from_millis(1500));
+
+    // The server must have survived collection: still up, still serving.
+    let health = client
+        .get(format!("{}/health", srv.base_url))
+        .send()
+        .expect("server still accepts connections after metrics collections");
+    assert_eq!(
+        health.status().as_u16(),
+        200,
+        "healthy after metrics collections"
+    );
+}

--- a/tools/differential_coverage_check.sh
+++ b/tools/differential_coverage_check.sh
@@ -20,7 +20,7 @@ cd "$(dirname "$0")/.."
 # Baseline: #[test] + #[tokio::test] across test/e2e/tests/*.rs EXCLUDING the
 # differential corpus file itself. Bump this (with a corpus update) whenever an
 # e2e test is added or removed.
-EXPECTED_E2E_TESTS=276
+EXPECTED_E2E_TESTS=277
 
 # Count via awk on a concatenated stream with literal `[ \t]` + exact string
 # compare — deterministic across awk/grep implementations. (Earlier a


### PR DESCRIPTION
The 6.3.0 allocator-gauge reader declared mimalloc's early-v3 stats API
in Rust — mi_stats_get(stats_size, stats) with a version-first prefix
struct — but the vendored mimalloc 3.4.3 exports
bool mi_stats_get(mi_stats_t*) with a caller-filled size/version
handshake. The callee read the size argument as the stats pointer and
dereferenced the null page, so the first OTel metrics collection
segfaulted the server ~60s after boot: a crash loop on every deployment
with an OTLP endpoint configured, dying before the first metric batch
ever exported (dsp-ls-test-01, ~66s cadence, 1000+ minidumps). No test
executed the path: telemetry is fail-open, so without
OTEL_EXPORTER_OTLP_ENDPOINT the gauge callbacks are never registered,
and the one e2e that sets the endpoint never outlives the 60s default
export interval.

Route the read through a one-function C shim compiled against the
vendored mimalloc-stats.h, so the signature and mi_stats_t layout are
compiler-checked against the exact pin — an API change on a future
mimalloc bump becomes a build error instead of a SIGSEGV on the metrics
thread. Rust-side extern re-declarations of mimalloc's stats API are
banned (nothing verifies them against the header).

Also define MI_STAT=1 for the vendored build: mimalloc's release
default (MI_STAT=0) compiles out binned-allocation accounting, leaving
malloc_normal permanently zero — sipi.malloc.in_use_bytes would count
only >512 KiB huge blocks and silently underreport the heap, defeating
the leak-vs-retention split the gauges exist for.

Tests, closing the gap that let this ship:

- a unit test in the allocator module runs the real mi_stats_get
  round-trip in //src/cli-rs:sipi_unit_test (which links mimalloc like
  the binary) and pins binned accounting with small held allocations;
- a metrics_export e2e enables the metrics pipeline against a dead
  OTLP endpoint, shrinks OTEL_METRIC_EXPORT_INTERVAL so collections
  fire inside the test window, and asserts the server survives them.

Fixes SIPI-1R

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NQmKNUg3bujd7NAyBocZ5s