### PR TITLE
chore(claude): drop unresolved my-eng plugin from enabled plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,7 +24,6 @@
     "eng@dasch-claude-plugins": true,
     "linear@claude-plugins-official": true,
     "sentry@claude-plugins-official": true,
-    "my-eng@subotic-claude-plugins": true,
     "misc@dasch-claude-plugins": true
   }
 }


### PR DESCRIPTION
## What

Removes `my-eng@subotic-claude-plugins` from `enabledPlugins` in `.claude/settings.json`.

## Why

This got my Claude extremely confused; if it's really needed, could it be added to your local settings?

🤖 Generated with [Claude Code](https://claude.com/claude-code)