### PR TITLE
fix(ci): gate the Claude workflow to org members (DEV-6884)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,12 +11,23 @@ on:
     types: [submitted]
 
 jobs:
+  # Gate on author_association (DEV-6884): comment-triggered workflows always run from the
+  # default branch with secrets available, and "Require approval for all external
+  # contributors" covers only fork pull_request events — without this gate any GitHub
+  # account able to comment could spend the org's API key. The check sits inside each
+  # trigger arm because issue_comment payloads also carry issue.author_association, so a
+  # single AND-ed check would pass a stranger's comment on any issue or PR a member opened.
+  # A blocked trigger skips silently, like a non-matching comment.
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
[DEV-6884](https://linear.app/dasch/issue/DEV-6884)

## Summary
- Same org-wide gap as dasch-swiss/dsp-app#3337: this Claude workflow inherited the Anthropic quickstart without an author check, and comment-triggered workflows always run from the default branch with secrets available — so any GitHub account able to comment could fire the job and spend the org's `ANTHROPIC_API_KEY`.
- The triggering author must now be `OWNER`, `MEMBER` or `COLLABORATOR`; anything else (including `CONTRIBUTOR`, per the decision in DEV-6884) skips silently, exactly like a non-matching comment.

## Changes
- The allowlist check sits inside each trigger arm: `issue_comment` payloads also carry `issue.author_association` (the issue/PR author's), so a single OR-ed check would pass a stranger's comment on any issue or PR a member opened.
- Exposure here was larger than dsp-app's: the job runs with `contents: write`.

## Test Plan
- YAML parse validated locally; `contains(fromJSON('[...]'), ...author_association)` is the documented GitHub Actions idiom.
- Live verification (a member's trigger still fires) is only possible after merge — comment-event workflows run the workflow file from the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)