### PR TITLE
chore(build): RBE load test — temporary cache-bust (DO NOT MERGE)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,6 +9,12 @@
 # Bazel's cache keys across CI runs.
 build --incompatible_strict_action_env
 
+# TEMPORARY — RBE load test (2026-08-20). Injecting a fresh env var into the
+# strict action environment changes the cache key of every action (C++, Rust,
+# links, tests), forcing a full cold rebuild on the NativeLink backend. Delete
+# this line and the branch/PR once the load test is complete.
+build --action_env=RBE_LOAD_TEST_20260820=1
+
 # Force the resolved toolchain (the hermetic `llvm` toolchain in MODULE.bazel)
 # instead of Bazel's autodetected host C++ toolchain. Without this, Bazel can
 # fall back to the host clang/gcc when toolchain resolution misfires, which

--- a/.bazelrc
+++ b/.bazelrc
@@ -13,7 +13,7 @@ build --incompatible_strict_action_env
 # strict action environment changes the cache key of every action (C++, Rust,
 # links, tests), forcing a full cold rebuild on the NativeLink backend. Delete
 # this line and the branch/PR once the load test is complete.
-build --action_env=RBE_LOAD_TEST_20260820=1
+build --action_env=RBE_LOAD_TEST_20260820=2
 
 # Force the resolved toolchain (the hermetic `llvm` toolchain in MODULE.bazel)
 # instead of Bazel's autodetected host C++ toolchain. Without this, Bazel can


### PR DESCRIPTION
## Purpose

**Temporary PR to put the NativeLink RBE backend under load.** Do not merge.

Adds a single `--action_env=RBE_LOAD_TEST_20260820=1` line to `.bazelrc`. Under `--incompatible_strict_action_env`, injecting a fresh env var into the action environment changes the cache key of **every** Bazel action (C++ compiles, Rust compiles, links, tests). CI therefore runs a full cold rebuild against the remote executor + cache instead of hitting the warm cache — driving the intended RBE load.

## Cleanup

The branch and this PR will be deleted once the load test is complete. Nothing here is meant to land on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)