### PR TITLE
fix(logging): correct the CRIT/ALERT/EMERG level labels

### DIFF
--- a/src/formats/SipiIOJ2k.cpp
+++ b/src/formats/SipiIOJ2k.cpp
@@ -447,12 +447,6 @@ bool SipiIOJ2k::read(SipiImage *img,
   siz->get(Ssize, 0, 0, __ny);
   siz->get(Ssize, 0, 1, __nx);
 
-  /*
-  int __clayers;
-  __clayers = codestream.get_min_dwt_levels( );
-  std::cerr << "Clayers=" << __clayers << std::endl;
-  */
-
   //
   // is there a region of interest defined ? If yes, get the cropping parameters...
   //
@@ -755,15 +749,12 @@ bool SipiIOJ2k::read(SipiImage *img,
     switch (scaling_quality.jk2) {
     case ScalingMethod::HIGH:
       img->scale(nnx, nny);
-      // std::cerr << "===>HIGH SCALING to nnx=" << nnx << " nny=" << nny << std::endl;
       break;
     case ScalingMethod::MEDIUM:
       img->scaleMedium(nnx, nny);
-      // std::cerr << "===>MEDIUM SCALING to nnx=" << nnx << " nny=" << nny << std::endl;
       break;
     case ScalingMethod::LOW:
       img->scaleFast(nnx, nny);
-      // std::cerr << "===>FAST SCALING to nnx=" << nnx << " nny=" << nny << std::endl;
       break;
     }
   }

--- a/src/formats/SipiIOJpeg.cpp
+++ b/src/formats/SipiIOJpeg.cpp
@@ -672,9 +672,6 @@ bool SipiIOJpeg::read(SipiImage *img,
       if (marker->data_length >= 12 && memcmp(marker->data, "Adobe", 5) == 0) {
         img->app14_transform = static_cast<uint8_t>(marker->data[11]);
       }
-    } else {
-      // fprintf(stderr, "4) MARKER= %d, %d Bytes, ==> %s\n\n", marker->marker - JPEG_APP0, marker->data_length,
-      // marker->data);
     }
     marker = marker->next;
   }

--- a/src/iiifparser/cpp/classifier/iiif_handler.cpp
+++ b/src/iiifparser/cpp/classifier/iiif_handler.cpp
@@ -113,18 +113,6 @@ namespace {
 
 }// namespace
 
-template<typename T> std::string vector_to_string(const std::vector<T> &vec)
-{
-  std::ostringstream oss;
-  oss << "[";
-  for (size_t i = 0; i < vec.size(); ++i) {
-    if (i > 0) { oss << ", "; }
-    oss << vec[i];
-  }
-  oss << "]";
-  return oss.str();
-}
-
 static auto make_parse_error(std::string msg) -> std::expected<IIIFUriParseResult, std::string>
 {
   return std::expected<IIIFUriParseResult, std::string>(std::unexpect, std::move(msg));
@@ -146,9 +134,6 @@ static auto make_parse_error(std::string msg) -> std::expected<IIIFUriParseResul
  */
 [[nodiscard]] auto parse_iiif_uri(const std::string &uri) noexcept -> std::expected<IIIFUriParseResult, std::string>
 {
-
-  // std::cout << ">> parsing IIIF URI: " << uri << std::endl;
-
   RequestType request_type{ UNDEFINED };
 
   std::vector<std::string> parts;
@@ -175,8 +160,6 @@ static auto make_parse_error(std::string msg) -> std::expected<IIIFUriParseResul
   if (old_pos != uri.length()) { parts.push_back(shttps::urldecode(uri.substr(old_pos, std::string::npos))); }
 
   if (parts.empty()) { return make_parse_error("No parameters/path given"); }
-
-  // std::cout << ">> parts found: " << vector_to_string(parts) << std::endl;
 
   std::vector<std::string> params;
 

--- a/src/logging/logger.cpp
+++ b/src/logging/logger.cpp
@@ -164,11 +164,11 @@ inline const char *LogLevelToString(LogLevel ll)
   case LL_ERR:
     return "ERROR";
   case LL_CRIT:
-    return "ALERT";
+    return "CRIT";
   case LL_ALERT:
-    return "EMERG";
+    return "ALERT";
   case LL_EMERG:
-    return "ERROR";
+    return "EMERG";
   default:
     return "Missing";
   }

--- a/src/logging/logger_test.cpp
+++ b/src/logging/logger_test.cpp
@@ -111,9 +111,9 @@ TEST_F(LoggerTest, SformatAllLevels)
     {LL_NOTICE, "NOTICE"},
     {LL_WARNING, "WARN"},
     {LL_ERR, "ERROR"},
-    {LL_CRIT, "ALERT"},
-    {LL_ALERT, "EMERG"},
-    {LL_EMERG, "ERROR"},
+    {LL_CRIT, "CRIT"},
+    {LL_ALERT, "ALERT"},
+    {LL_EMERG, "EMERG"},
   };
 
   for (auto &tc : cases) {


### PR DESCRIPTION
Part of DEV-5203

## Motivation
`LogLevelToString` shifted the high syslog levels by one: `LL_CRIT` rendered as `"ALERT"`, `LL_ALERT` as `"EMERG"`, and `LL_EMERG` fell through to `"ERROR"`. These levels are reachable from Lua via `server.log(msg, server.loglevel.LOG_CRIT/ALERT/EMERG)`, so a script logging at CRIT produced a mislabeled JSON line in Grafana. Also sweeps out the remaining commented-out debug prints (DEV-5203 item 2).

## Summary
- `LL_CRIT`/`LL_ALERT`/`LL_EMERG` now emit their own names, symmetric with `parse_log_level`.
- Deleted the leftover commented-out `std::cerr`/`std::cout`/`fprintf` debug lines in `SipiIOJ2k`, `SipiIOJpeg`, and the IIIF URI classifier, plus the `vector_to_string` helper whose only caller was one of the deleted comments.

## Key Changes
### Level labels (`src/logging/logger.cpp`)
- Fixed the three-case mislabeling in `LogLevelToString`; updated the `SformatAllLevels` characterization test that had locked in the wrong labels.

### Comment debris
- `src/formats/SipiIOJ2k.cpp`: Clayers block comment + three commented scaling prints.
- `src/formats/SipiIOJpeg.cpp`: commented marker-dump `fprintf` (and the now-empty `else` branch).
- `src/iiifparser/cpp/classifier/iiif_handler.cpp`: two commented URI-parse prints + the dead `vector_to_string` template.

## Challenges and Decisions
- Kept honest syslog labels rather than clamping CRIT/ALERT/EMERG to `ERROR`: they mirror `parse_log_level`'s accepted names, and no shipped script or config uses these levels today. The Rust shell is unaffected — `tracing` tops out at ERROR and both loggers emit independent JSON lines with the shared `{level, message, trace_id?, span_id?}` schema.

## Gotchas
- Loki level detection may classify `NOTICE`/`CRIT`/`ALERT`/`EMERG` as `unknown`. If that ever matters operationally, clamp them at emission — tracked in DEV-5203 item 5.

## Test Plan
- [x] `//src/logging:logger_test` passes with the corrected expectations
- [x] `just bazel-build` + `just bazel-test-unit` green (27/27)

🤖 Generated with [Claude Code](https://claude.com/claude-code)