### PR TITLE
docs(learnings): four learnings from the fuzz-nightly triage (PR #804)

### DIFF
--- a/docs/learnings/architecture/kakadu-teardown-order-and-pod-templates-accepting-std-string.md
+++ b/docs/learnings/architecture/kakadu-teardown-order-and-pod-templates-accepting-std-string.md
@@ -1,0 +1,155 @@
+---
+title: "Two codec-boundary gotchas: destroy a Kakadu codestream before its target unwinds, and never read a class type through `&val, sizeof(T)`"
+date: 2026-09-08
+category: "architecture"
+component: "cpp_module"
+module: "`SipiIOJ2k::write` (Kakadu `kdu_codestream` / `jpx_target` lifetimes), `Exif::addKeyVal<T>` in `src/metadata/cpp/exif.h`"
+problem_type: "resource-lifetime-and-generic-template-misuse"
+severity: "high"
+symptoms: "(1) `sipi convert <tif> out.jpx` segfaulted (exit 139) on a 1x1 MinIsBlack TIFF with three samples per pixel; ASan: heap-use-after-free in `kd_compressed_output::flush_buf` called from `kdu_codestream::destroy()` in the catch of `SipiIOJ2k::write`, freed by `~jpx_target`. (2) Every EXIF ASCII tag read from a TIFF EXIF IFD (DateTimeOriginal, LensMake, LensModel, …) came out as 24 bytes of garbage; a 2025 test comment had blamed 'platform-dependent Exiv2 typing'; ASan flagged the read as container-overflow on the short-string buffer."
+root_cause: "(1) The JPX target was a local inside the `try`; on a Kakadu error, unwinding destroyed it (freeing the codestream's output) before the `catch` destroyed the codestream that flushes into it. (2) A generic `addKeyVal<T>` fed every value to Exiv2 as `(unsigned char *)&val, sizeof(T)`, which is only meaningful for scalar T; for `std::string` it serialises the 24-byte string object."
+tags: [kakadu, kdu_codestream, jpx_target, raii, destructor-order, use-after-free, exiv2, addKeyVal, sizeof, template, std::string, exif, format_handlers, metadata, sipi, cpp]
+related:
+  - ../debugging/fuzz-leg-reports-one-finding-at-a-time.md
+issue: "DEV-7080"
+---
+
+# Two codec-boundary gotchas: destroy a Kakadu codestream before its target unwinds, and never read a class type through `&val, sizeof(T)`
+
+Both from the SIPI fuzz-nightly triage of 2026-09-08 (PR #804). They are unrelated in mechanism
+and share one lesson: **a vendor API's ownership and type contracts are not visible in our code,
+so they must be made explicit where our code crosses into the vendor.** Both bugs were old, both
+were reachable from ordinary inputs, and both were found only because a fuzz leg happened to get
+past a shallower finding.
+
+## Problem
+
+**Gotcha 1 — Kakadu teardown order.** `SipiIOJ2k::write` looked like this (simplified):
+
+```cpp
+kdu_codestream codestream;              // outside the try "so the catch can destroy it"
+try {
+  jp2_family_tgt jp2_ultimate_tgt;
+  jpx_target jpx_out;                    // inside the try
+  jpx_out.open(&jp2_ultimate_tgt, &membroker);
+  jpx_codestream_target jpx_stream = jpx_out.add_codestream();
+  ...
+  codestream.create(&siz, output, ...);  // output is jpx_stream's box
+  ... encode ...
+  codestream.destroy();
+  jpx_out.close();
+} catch (kdu_exception e) {
+  if (codestream.exists()) { codestream.destroy(); }   // ← runs AFTER ~jpx_target
+  return std::unexpected(...kWriteFailed...);
+}
+```
+
+When Kakadu raised mid-write (here: a MinIsBlack image with three channels, "`jp2_channels`
+indicates more colour channels than the colour space has"), the stack unwound `jpx_out` first.
+`~jpx_target` → `close()` → `~jx_target` → `jx_codestream_target::destroy()` freed the codestream
+target. Then the catch ran `codestream.destroy()`, whose `kd_compressed_output::flush_buf()` read
+the freed target. A comment on the declaration said the JPX target was "deliberately NOT closed on
+the error path", which was true of the explicit `close()` and false of the destructor.
+
+**Gotcha 2 — a POD-shaped template accepting a class.** `Exif::addKeyVal` (since 2016):
+
+```cpp
+template<class T> void addKeyVal(uint16_t tag, const std::string &groupName, const T &val)
+{
+  ...
+  if (typeid(T) == typeid(std::string)) v = Exiv2::Value::create(Exiv2::asciiString);
+  else if (typeid(T) == typeid(uint16_t)) ...
+  v->read((unsigned char *)&val, sizeof(T), Exiv2::littleEndian);   // ← 24 bytes of a std::string object
+  exifData.add(key, v.get());
+}
+```
+
+The `typeid` chain *knew* about `std::string` and still fed it through the scalar path. Every
+`EXIF_DT_STRING` tag in `SipiIOTiff::readExif` (DateTimeOriginal, SubSecTime, LensMake, LensModel,
+ImageUniqueID, …) was stored as the libc++ string object's bytes. A test comment from an earlier fix
+had observed the garbage and attributed it to "Exiv2 reports the values as `unsignedByte` rather
+than `asciiString`" — a plausible story that nobody checked against the code.
+
+## Root Cause
+
+1. **Reverse-destruction order across an ownership edge the compiler cannot see.** Kakadu's
+   `kdu_codestream` is an interface object with explicit `create`/`destroy`; `jpx_target` is RAII.
+   Mixing an explicit-lifetime object declared *outside* a scope with an RAII object declared
+   *inside* it inverts the dependency order on the exceptional path only, which is why the success
+   path (explicit `destroy()` then `close()`) never showed it.
+2. **`sizeof(T)` is a statement about the object's storage, not its value.** A template that
+   reinterprets `&val` is correct exactly for trivially-copyable scalar `T`; a branch that
+   recognises `std::string` by `typeid` and then falls through to the same `read` is a bug the
+   type system would have caught with `if constexpr`.
+
+## Solution
+
+**Gotcha 1** (`6cd46ff0`): an RAII guard declared **after** `jpx_out`, so it is destroyed before it:
+
+```cpp
+    jpx_target jpx_out;
+    jpx_out.open(&jp2_ultimate_tgt, &membroker);
+    jpx_codestream_target jpx_stream = jpx_out.add_codestream();
+    jpx_layer_target jpx_layer = jpx_out.add_layer();
+
+    struct CodestreamGuard
+    {
+      kdu_codestream &cs;
+      ~CodestreamGuard()
+      {
+        if (cs.exists()) { cs.destroy(); }
+      }
+    } codestream_guard{ codestream };
+```
+
+The success path still destroys the codestream itself (the guard then finds none); the catch no
+longer touches it. `sipi convert` on the reproducer now fails with Kakadu's channel-count error
+and `kWriteFailed` instead of SIGSEGV. Fixture `tiff_minisblack_three_channel.tif`, test
+`MalformedTiff.MinIsBlackThreeChannelJpxWriteFailsCleanly`.
+
+**Gotcha 2** (`d9c7704d`): branch on the type at compile time and use Exiv2's string overload:
+
+```cpp
+    if constexpr (std::is_same_v<T, std::string>) {
+      v = Exiv2::Value::create(Exiv2::asciiString);
+      v->read(val);
+      exifData.add(key, v.get());
+      return;
+    }
+    // scalar T: typeid chain + v->read((unsigned char *)&val, sizeof(T), littleEndian)
+```
+
+`ExifRationalRegression.LensStringTagsRoundTrip` asserts `LensMake == "Nikon"` and the full
+`LensModel` string from the existing `exif_lens_specification.tif` fixture. Red without the fix
+(LensModel came back as two garbage bytes), green with it, approval goldens byte-identical.
+
+## Prevention
+
+- **When a vendor object is created explicitly and another is RAII, put an RAII guard for the
+  explicit one *after* the RAII one in the same scope.** Reverse destruction then encodes the
+  dependency on every exit path, including exceptions. `SipiIOJ2k::read_shape` already does this
+  with its `kdu_teardown` struct; `write` now matches. Any new Kakadu `create()` needs the same
+  treatment.
+- **A comment that says "deliberately not closed on the error path" is a claim about explicit
+  calls, not about destructors.** Read the destructor of the type before trusting such a comment.
+- **Never write `(unsigned char *)&val, sizeof(T)` in a template without a
+  `static_assert(std::is_trivially_copyable_v<T>)` or an `if constexpr` branch for the class
+  types you accept.** The `typeid` chain in `addKeyVal` is the anti-pattern: runtime type
+  recognition followed by a type-blind byte copy.
+- **A test comment that explains away wrong output is a bug report.** "Platform-dependent Exiv2
+  typing" was the previous author's hypothesis for exactly this symptom. Turn such comments into
+  failing assertions rather than leaving them as prose.
+- **Sanitizer reports on our own metadata code are real** even when they arrive alongside false
+  positives from the fuzz link (see the container-overflow learning): this one was a
+  container-overflow too, but on a stack `std::string` our code built, and it reproduced without
+  ASan.
+
+## References
+
+- PR #804, merged 2026-09-08; commits `6cd46ff0` (JPX write guard), `d9c7704d` (EXIF strings).
+- `src/format_handlers/cpp/SipiIOJ2k.cpp` (`CodestreamGuard`, and the `kdu_teardown` precedent in
+  `read_shape`), `src/metadata/cpp/exif.h` (`addKeyVal`).
+- Fixtures: `test/_test_data/images/malformed/tiff_minisblack_three_channel.tif`,
+  `test/_test_data/images/unit/exif_lens_specification.tif`.
+- Kakadu: `jpx_target::close()` → `jx_codestream_target::destroy()` (`apps/jp2/jpx.cpp`,
+  `jpx_local.h`), `kd_compressed_output::flush_buf()` (`coresys/compressed/compressed_local.h`).

--- a/docs/learnings/debugging/asan-container-overflow-in-fuzz-binaries-is-a-link-artifact.md
+++ b/docs/learnings/debugging/asan-container-overflow-in-fuzz-binaries-is-a-link-artifact.md
@@ -1,0 +1,140 @@
+---
+title: "An ASan container-overflow report from a fuzz binary is a link artifact until a non-fuzz ASan build reproduces it"
+date: 2026-09-08
+category: "debugging"
+component: "fuzzing"
+module: "fuzz.yml ASan pass (`--config=fuzz --config=asan`), libFuzzer runtime from hermetic-llvm, libc++ container annotations"
+problem_type: "sanitizer-false-positive"
+severity: "medium"
+symptoms: "The `tiff_roundtrip` fuzz leg failed under ASan with `container-overflow` WRITE in `Exiv2::append` on the memcpy immediately after `blob.resize()`. Later the same detector killed both `j2k` ASan legs at startup inside libFuzzer's own fork driver (`fuzzer::DirPlusFile` → `basic_string::append`) with zero inputs executed. Earlier, the `parse_request` leg had the same report class (DEV-7081)."
+root_cause: "hermetic-llvm builds the libFuzzer runtime through `cc_unsanitized_library` (a transition that forces `//config:asan` off) against the same libc++ headers the instrumented code uses. libc++'s container annotations are then updated by some objects in the link and checked by others — the documented false-positive shape for this one ASan detector. No defect existed behind any of the three reports."
+tags: [asan, container-overflow, false-positive, libfuzzer, fork-mode, libc++, annotations, hermetic-llvm, cc_unsanitized_library, exiv2, fuzzing, sipi, primary-evidence]
+related:
+  - ./parallel-e2e-shared-state-and-primary-evidence.md
+  - ./fuzz-leg-reports-one-finding-at-a-time.md
+  - ../testing/seam-mitigation-does-not-green-a-codec-fuzz-leg.md
+issue: "DEV-7080"
+---
+
+# An ASan container-overflow report from a fuzz binary is a link artifact until a non-fuzz ASan build reproduces it
+
+From the SIPI fuzz-nightly triage of 2026-09-08 (PR #804). The `fuzz.yml` nightly had been red
+since 2026-08-31, and one of the reasons was an ASan `container-overflow` inside `Exiv2::append`
+that contradicted the code it pointed at. Settling it took one deliberately designed CI
+experiment, after which two more reports of the same detector appeared and confirmed the
+mechanism. The transferable lesson: **ASan's container-overflow detector has a precondition that
+the fuzz binaries in this repo do not meet, so its reports from them are not evidence of a bug.**
+
+## Problem
+
+The `tiff_roundtrip` ASan leg reported:
+
+```
+ERROR: AddressSanitizer: container-overflow on address 0x7ef0c6010800
+WRITE of size 26 at 0x7ef0c6010800 thread T0
+    #0 __asan_memcpy
+    #1 Exiv2::append(std::vector<unsigned char>&, unsigned char const*, unsigned long) image.cpp:894
+    #2 Exiv2::ExifParser::encode(...) exif.cpp:571
+    #3 Sipi::Exif::exifBytes() src/metadata/cpp/exif.cpp:174
+    #4 Sipi::SipiIOJ2k::write(...)
+0x7ef0c6010800 is located 0 bytes inside of 65536-byte region  (allocated by blob.reserve in append)
+```
+
+exiv2 0.28.9's `append` is standards-correct:
+
+```cpp
+void append(Blob& blob, const byte* buf, size_t len) {
+  if (len != 0) {
+    Blob::size_type size = blob.size();
+    if (blob.capacity() - size < len) blob.reserve(size + 65536);
+    blob.resize(size + len);
+    std::memcpy(&blob[size], buf, len);
+  }
+}
+```
+
+The shadow bytes said `[0, 26)` was still poisoned *after* `resize(26)`. Either libc++'s `resize`
+did not update the annotation, or the report was wrong. The same 161-byte input converted to all
+four output formats cleanly with the production binary.
+
+## Investigation
+
+1. **Read the code the report pointed at**, at the exact pinned version (upstream
+   `v0.28.9/src/image.cpp`, not the possibly stale copy in the local Bazel output base — the two
+   differed by 25 lines because the branch had bumped exiv2). Standards-correct; the report could
+   not be true as stated.
+2. **Ran the reproducer outside the fuzz binary** (`sipi convert repro.tif out.jp2` and three other
+   formats). Clean. So whatever it was, the fuzz *link* was a variable.
+3. **Checked how the fuzz link differs**: `--config=fuzz` links the libFuzzer runtime. In the
+   hermetic-llvm module, `compiler-rt/BUILD.bazel` builds it via `cc_unsanitized_library`, whose
+   `_reset_sanitizers` transition forces `//config:asan` (and every other sanitizer) to `False`,
+   with `-O3` and `-fvisibility=hidden`, against the shared `:libcxx_headers`. libc++'s
+   `__config_site` there carries `_LIBCPP_INSTRUMENTED_WITH_ASAN __has_feature(address_sanitizer)`,
+   i.e. per-TU. That is precisely the "container used from code compiled without ASan" condition
+   the sanitizer wiki names as the false-positive cause for this detector.
+4. **Designed a decisive experiment instead of suppressing**: pinned the verbatim reproducer as a
+   fixture (`tiff_exif_make_jp2_roundtrip.tif`), added a `formats_test` case that runs the exact
+   decode-then-JP2-write path, and let the CI `asan-ubsan` job — which builds the same code under
+   ASan but links **no libFuzzer** — be the arbiter. Green there plus red on the fuzz leg would mean
+   link artifact; red there would mean a real defect.
+5. **Outcome**: `asan-ubsan / amd64` green with the new test (PR #804 run 34203828500). The
+   dispatched fuzz run (34203829133) then reproduced the same `Exiv2::append` report on a *second*
+   input, and additionally killed both `j2k` ASan legs at startup with a `container-overflow` inside
+   libFuzzer's own fork driver (`fuzzer::DirPlusFile` → `std::basic_string::append`), reported with
+   `number_of_executed_units: 0`. Our code was not on that stack at all. Three reports, one
+   detector, one mechanism, zero defects.
+
+## Root Cause
+
+ASan's container-overflow detector relies on libc++ calling `__sanitizer_annotate_contiguous_container`
+from every code path that changes a container's `[size, capacity)` boundary. That only holds when
+**every object in the link** that touches the container was compiled with ASan. The fuzz binaries
+link the libFuzzer runtime unsanitized (by design of the toolchain — the fuzzer must not be
+instrumented), sharing libc++ with the instrumented code. Annotations are then updated by some
+objects and checked by others, and the detector fires on perfectly valid accesses. This is not
+specific to exiv2 or to any SIPI code; the third report came from libFuzzer's own string handling.
+
+## Solution
+
+`chore(ci): keep the nightly fuzz legs green on known non-defects` (`8bb3b431`), the
+container-overflow half:
+
+- The `Fuzz under ASan (300s)` step composes `ASAN_OPTIONS` in the shell with
+  `detect_container_overflow=0` for **every** leg, then appends the matrix `asan_options`
+  (`detect_leaks=0` for the libjpeg/libpng legs). The earlier per-leg suppression on
+  `parse_request` (DEV-7081) is folded into it.
+- Heap, stack, and global overflow detection are unaffected. The container detector stays **on**
+  for the `asan-ubsan` CI job's unit and e2e tests, which cover the same code without libFuzzer.
+- The reproducer stays as fixture + `MalformedTiff.ExifMakeTiffEncodesToJp2Cleanly`, so the
+  non-fuzz ASan job keeps proving the path clean, and `fuzzing.md` § Nightly CI records the
+  reasoning.
+
+## Prevention
+
+- **Do not triage a `container-overflow` from a fuzz binary as a bug.** First run the reproducer
+  through a non-fuzz ASan build (in this repo: pin it as a fixture, add a unit test on the same
+  path, read the `asan-ubsan` job). Only a report that reproduces there is a defect. Every other
+  ASan report class (heap/stack/global overflow, use-after-free) from the fuzz legs is real and
+  has been in this same triage: two of them were.
+- **When a report contradicts the code, suspect the instrumentation contract before the code.** The
+  container detector, LSan (setjmp/longjmp libraries), and ASan's thread registry (short-lived
+  threads in the Rust shell) all have documented false-positive shapes that this repo has now hit.
+- **Read the vendor source at the pinned version.** The local Bazel output base may hold an
+  earlier fetch; the ASan line numbers only matched upstream `v0.28.9`.
+- **Prefer a decisive experiment over a suppression.** A suppression with no evidence behind it is
+  a guess; a suppression with a green non-fuzz ASan test behind it is a documented decision, and the
+  test keeps guarding the path.
+
+## References
+
+- PR #804 (`fix(metadata,cli,format_handlers): the four bugs behind the red fuzz nightly (DEV-7080)`),
+  merged 2026-09-08.
+- CI evidence: `asan-ubsan / amd64` green with the new test, run 34203828500; fuzz dispatch run
+  34203829133 (second `Exiv2::append` instance and the j2k fork-driver instance); final green
+  dispatch 34211319181.
+- Fixture: `test/_test_data/images/malformed/tiff_exif_make_jp2_roundtrip.tif` (README row explains
+  the outcome).
+- Toolchain: hermetic-llvm `toolchain/runtimes/cc_unsanitized_library.bzl` (`_reset_sanitizers`),
+  `compiler-rt/BUILD.bazel` `cc_library(name = "fuzzer", copts = FUZZER_CFLAGS)`.
+- Sanitizer wiki: AddressSanitizerContainerOverflow (false positives when not all code is
+  instrumented).

--- a/docs/learnings/debugging/fuzz-leg-reports-one-finding-at-a-time.md
+++ b/docs/learnings/debugging/fuzz-leg-reports-one-finding-at-a-time.md
@@ -1,0 +1,118 @@
+---
+title: "A red fuzz leg reports one finding at a time — fix it, re-dispatch, and expect the next one behind it"
+date: 2026-09-08
+category: "debugging"
+component: "fuzzing"
+module: "fuzz.yml (libFuzzer stops at the first crash per leg), `SipiIOTiff::readExif` / `read_tiled_data`, `SipiIOJ2k::write`"
+problem_type: "triage-process"
+severity: "high"
+symptoms: "A single red `tiff` / `tiff_roundtrip` fuzz leg was read as one bug each. Fixing the visible finding and re-dispatching surfaced a different, more severe finding on the same leg twice in a row: behind 24 bytes of EXIF garbage sat a heap over-read in tiled TIFF decode; behind an ASan false positive sat a heap use-after-free that segfaults the production `sipi convert`."
+root_cause: "libFuzzer aborts the leg on its first crash, so one nightly run can only ever show the shallowest finding per leg. A red leg is a queue, not a single defect, and the queue is only visible one element at a time. The triage loop must be fix → dispatch → read the next artifact, until the leg is green."
+tags: [fuzzing, libfuzzer, triage, workflow_dispatch, crash-artifacts, asan, heap-use-after-free, heap-buffer-overflow, exif, tiff, kakadu, sipi, primary-evidence]
+related:
+  - ./asan-container-overflow-in-fuzz-binaries-is-a-link-artifact.md
+  - ../testing/seam-mitigation-does-not-green-a-codec-fuzz-leg.md
+  - ../architecture/kakadu-teardown-order-and-pod-templates-accepting-std-string.md
+issue: "DEV-7080"
+---
+
+# A red fuzz leg reports one finding at a time — fix it, re-dispatch, and expect the next one
+
+From the SIPI fuzz-nightly triage of 2026-09-08 (PR #804). The nightly had been red for nine
+days. The initial triage found four causes across four legs. Three `workflow_dispatch` runs later,
+the branch had fixed **four real bugs**, two of which were invisible in the initial artifacts
+because a shallower finding on the same leg had stopped the fuzzer first.
+
+## Problem
+
+The 2026-09-08 nightly (run 34183871288) showed:
+
+| Leg | Step | Finding |
+|---|---|---|
+| `tiff` | ASan | container-overflow in `Exif::addKeyVal<std::string>` via `SipiIOTiff::readExif` |
+| `tiff_roundtrip` | ASan | container-overflow in `Exiv2::append` (a false positive, see the related learning) |
+| `j2k`, `j2k_roundtrip` | libFuzzer | timeout in Kakadu's box parser (known class) |
+
+After fixing the EXIF bug and neutralising the false-positive class, the first dispatch
+(34203829133) turned the `tiff` leg into a **heap-buffer-overflow READ in `read_tiled_data`**.
+After fixing that, the second dispatch (34208084507) turned `tiff_roundtrip` into a
+**heap-use-after-free in `SipiIOJ2k::write`** that also segfaults the production CLI. Neither had
+appeared in any earlier artifact.
+
+## Investigation
+
+Each round followed the same shape; the value was in doing it quickly and not stopping early:
+
+1. **Get the artifact, not the log stream.** `gh run view --log` on these runs hits GitHub
+   `stream error: CANCEL` roughly half the time. `gh run download <run> --name fuzz-crashes-<leg>`
+   is reliable and contains the reproducers plus `libfuzzer.log` / `libfuzzer-asan.log` /
+   `merge.log`. Artifacts expire after 30 days.
+2. **Read the `SUMMARY:` lines, all of them.** The ASan logs also carry recoverable UBSan
+   `runtime error:` lines from vendor code (Kakadu AVX2 alignment, lcms2 function-pointer types)
+   that print and continue; the line that failed the step was further down. `grep -n 'SUMMARY\|ERROR: AddressSanitizer\|ERROR: libFuzzer'`
+   first, then read around the right one.
+3. **Reproduce with the production binary before reading code.** Every real finding here reproduced
+   with `./bazel-bin/src/cli/sipi query|convert <artifact>` on macOS without any sanitizer: EXIF
+   garbage visible in `query` output (`LensMake Ascii 24 <garbage>`), the tiled TIFF decoding to
+   nonsense, the JPX write exiting 139. The false positive did not reproduce, which is what marked
+   it as one.
+4. **Fix, pin the verbatim reproducer as a fixture + seed + test, dispatch again.** Each round
+   took roughly 40 minutes of CI. Three rounds: 4 legs red → 4 legs red (different reasons) →
+   4 legs red (different reasons again) → 9 legs green.
+
+## Root Cause
+
+libFuzzer exits the process on the first crash or sanitizer report per leg, and the nightly runs
+each leg once. So a leg's artifact shows exactly one finding, the one the mutator reached first,
+which is usually the *shallowest* one on that leg's code paths. Fixing it does not make the leg
+green; it makes the next finding reachable. Reading the initial red nightly as "four bugs" was
+correct for that morning and wrong as a plan: the true count was six, two of them severe.
+
+The four real bugs, for the record (all fixed in PR #804):
+
+| Commit | Bug | Age |
+|---|---|---|
+| `d9c7704d` fix(metadata) | `Exif::addKeyVal<T>` read `&val, sizeof(T)` for `T = std::string`, storing the 24-byte string object as every TIFF EXIF ASCII tag | since 2016 |
+| `ac3bf789` fix(cli) | offline verbs had no decode deadline; `sipi query/convert` on a hostile JP2 hung forever | since the watchdog landed |
+| `1de76df9` fix(format_handlers) | `read_tiled_data` copied `TileWidth * TileLength * SamplesPerPixel` elements out of a `TIFFTileSize()`-sized buffer (32 bytes on the reproducer) | old |
+| `6cd46ff0` fix(format_handlers) | `SipiIOJ2k::write` destroyed the codestream after `~jpx_target` freed its output on a Kakadu error → UAF, SIGSEGV in `convert` | old |
+
+## Solution
+
+Process, not code:
+
+- Treat a red fuzz leg as a **queue**. Budget for at least two or three fix-and-dispatch rounds
+  before declaring the nightly green, and say so in the plan or PR.
+- **Dispatch on the branch after every fix** (`gh workflow run fuzz.yml --ref <branch>`), do not
+  wait for the nightly. Each dispatch is ~40 min wall-clock and answers the question "what is
+  behind this one".
+- **Pin every reproducer** as `test/_test_data/images/malformed/<defect>.tif` + README row +
+  `fuzz_seeds_<fmt>` entry + a `malformed_*_test.cpp` case asserting the clean rejection. The seed
+  makes the next dispatch deterministic on that input; the test keeps the fix honest under the
+  non-fuzz ASan job.
+- Keep the **PR description** as the journal of what each round found (the commits carry only the
+  fixes).
+
+## Prevention
+
+- **Never read a fuzz artifact as the complete list of defects on a leg.** It is the first one.
+- **A green plain loop with a red ASan pass is normal**, not a contradiction: the ASan build is
+  slower and catches classes the plain build cannot. Read the ASan artifact separately.
+- **Reproduce with the production binary first.** Five minutes with `bazel-bin/src/cli/sipi`
+  separates real defects from sanitizer artifacts before any code is read, and gives the exact
+  user-visible symptom for the commit message.
+- **Watch for shadowing between findings.** The `tiff_roundtrip` UAF sat behind a false positive
+  for at least two nightlies; a suppression applied *without* re-dispatching would have shipped
+  the UAF as "resolved".
+- **Corollary for reviewers:** a fuzz-triage PR that fixes exactly the findings visible in the
+  first red run, with no re-dispatch evidence, is probably incomplete.
+
+## References
+
+- PR #804, merged 2026-09-08. Fuzz runs: 34183871288 (nightly, initial triage), 34203829133
+  (dispatch 1: tiled over-read + false-positive confirmation), 34208084507 (dispatch 2: JPX write
+  UAF, fork-mode exit code, encode throughput), 34211319181 (dispatch 3: nine legs green).
+- Fixtures: `tiff_tile_undersized.tif`, `tiff_minisblack_three_channel.tif`,
+  `tiff_exif_make_jp2_roundtrip.tif` under `test/_test_data/images/malformed/`.
+- Precedent from wave-2: `tiff_scanline_undersized.tif` (S2-08), the same class as the tiled
+  over-read one strip-vs-tile away.

--- a/docs/learnings/testing/seam-mitigation-does-not-green-a-codec-fuzz-leg.md
+++ b/docs/learnings/testing/seam-mitigation-does-not-green-a-codec-fuzz-leg.md
@@ -1,0 +1,120 @@
+---
+title: "A mitigation at the FFI seam does not make a codec-level fuzz leg green — the harness runs below the seam, so tolerate the known class in fork mode"
+date: 2026-09-08
+category: "testing"
+component: "fuzzing"
+module: "fuzz.yml j2k / j2k_roundtrip legs, `codec_fuzz_harness.h`, `run_with_deadline` in `serve_image.cpp` / `decode_guard.h`"
+problem_type: "fuzz-gate-design"
+severity: "medium"
+symptoms: "Every fuzz.yml nightly from 2026-08-31 to 2026-09-08 was red on the j2k legs with `libFuzzer: timeout` inside Kakadu `jp2_input_box::read_box_header`, although the DEV-7080 decode-hang watchdog had landed and the design note said the leg would go green once it did. After switching to fork mode, the legs still exited 70 with zero crashes; and the jpeg_roundtrip leg timed out on a 621-byte input."
+root_cause: "The watchdog is a wall-clock deadline at the FFI seam. The codec fuzz harness calls `SipiIOJ2k::read_shape` directly, below that seam, so every fresh instance of the unpatchable Kakadu hang class still hits libFuzzer's per-input timeout. Fork mode tolerates timeouts but the parent exits with its last child's exit code. Tiny inputs can declare huge frames, so re-encoding under ASan blows the per-input budget on throughput alone."
+tags: [fuzzing, libfuzzer, fork-mode, ignore_timeouts, timeout_exitcode, kakadu, hang, watchdog, seam, deadline, harness, encode-budget, ci, sipi]
+related:
+  - ../debugging/asan-container-overflow-in-fuzz-binaries-is-a-link-artifact.md
+  - ../debugging/fuzz-leg-reports-one-finding-at-a-time.md
+issue: "DEV-7080"
+---
+
+# A mitigation at the FFI seam does not make a codec-level fuzz leg green
+
+From the SIPI fuzz-nightly triage of 2026-09-08 (PR #804). The security-hardening wave-2 work had
+"fixed" the DEV-7080 JP2 decode hang and removed the `continue-on-error` from the j2k fuzz leg,
+expecting it to go green. It could not: the fix and the fuzz harness live on different sides of a
+boundary. Three concrete things follow, all of which are now encoded in `fuzz.yml` and
+`docs/src/development/fuzzing.md`.
+
+## Problem
+
+Nightly `fuzz.yml` runs 34354275318 (2026-08-31) through 34183871288 (2026-09-08) all failed the
+`j2k` leg (and `j2k_roundtrip` once it existed) in the plain libFuzzer step:
+
+```
+==NNN== ERROR: libFuzzer: timeout after 25 seconds
+    #7  kdu_supp::jp2_input_box::read(unsigned char*, int)
+    #8  kdu_supp::jp2_input_box::read_box_header(bool)
+    #10 kd_supp_local::jx_source::finish_jp2_header_box()
+    #13 kdu_supp::jpx_source::access_codestream(int, bool)
+    #14 Sipi::SipiIOJ2k::read_shape(std::string const&)
+    #15 sipi::fuzz::run_decode<Sipi::SipiIOJ2k>(...)
+```
+
+Each night produced a fresh `timeout-*` reproducer of the same class already pinned in
+`test/_test_data/images/hang/`. `sipi query` on any of them burns CPU until killed (reproduced
+locally at 20 s and, after the CLI fix, at exactly the 120 s deadline).
+
+## Root Cause
+
+Three separate facts, discovered in sequence:
+
+1. **The mitigation is at the seam; the harness is below it.** `run_with_deadline` (now in
+   `src/ffi/cpp/decode_guard.h`) bounds `read_shape`/`read` for requests that enter through
+   `serve_image.cpp` (and, after PR #804, for the offline CLI verbs through
+   `cli/commands/decode_deadline.h`). `codec_fuzz_harness.h` constructs the handler and calls
+   `handler.read_shape(path)` directly. No deadline exists on that path, by design: the harness is
+   meant to exercise the codec, not the seam. Kakadu is licence-gated and cannot be patched, so the
+   hang class itself is permanent. The design note's "leg goes green once the deadline lands" was
+   a category error.
+2. **libFuzzer fork mode exits with its last child's code.** `-fork=1 -ignore_timeouts=1` made the
+   parent keep fuzzing past timed-out children (`FuzzerFork.cpp`: `if (Options.IgnoreTimeouts &&
+   ExitCode == Options.TimeoutExitCode) Env.NumTimeouts++;`), but at the end it does
+   `exit(ExitCode)` where `ExitCode` is whatever the *last* job returned. When the final child had
+   timed out, the step failed with 70 despite `oom/timeout/crash: 0/8/0`. Dispatch run 34208084507
+   showed this on both j2k legs.
+3. **A few hundred bytes can declare a 50 MB frame.** A 621-byte JPEG with a 65056x255 header
+   decodes in milliseconds into ~50 MB of pixels. The round-trip harness then re-encodes to tif,
+   jpx, png and jpg; under the `-c dbg` ASan build those four encodes exceed `-timeout=25`. On the
+   optimised production binary the same four conversions take 0.5–1.8 s each. Not a hang, a
+   throughput budget.
+
+## Solution / the pattern
+
+`chore(ci): keep the nightly fuzz legs green on known non-defects` (`8bb3b431`) and
+`test(format_handlers): cap the round-trip fuzz harness re-encode at 16 MiB of pixels` (`499523fd`):
+
+- **Fork mode, timeouts tolerated, on the j2k legs only.** Matrix column `libfuzzer_extra` set to
+  `-fork=1 -ignore_timeouts=1 -ignore_ooms=0 -timeout_exitcode=0` for `j2k` and `j2k_roundtrip`,
+  applied to both the plain and the ASan loop. The timed-out child still runs
+  `DumpCurrentUnit("timeout-")` before `_Exit(Options.TimeoutExitCode)`, so every instance is
+  recorded in the `fuzz-crashes-<target>` artifact of a **green** leg. Crashes (`-ignore_crashes`
+  stays 0) and OOMs still fail. The other seven legs keep the strict per-input timeout: a hang in
+  libtiff/libjpeg/libpng or in SIPI's own code is a fixable finding.
+- **`-timeout_exitcode=0`** on top of `-ignore_timeouts=1`, because of fact 2. Confirmed by reading
+  `FuzzerFork.cpp` and `FuzzerLoop.cpp::AlarmCallback` in the vendored llvm-project, not assumed.
+- **`kMaxRoundtripEncodeBytes = 16 MiB`** in `codec_fuzz_harness.h`: `run_roundtrip` skips its four
+  re-encodes when `nx * ny * nc * bytes_per_sample` exceeds it, mirroring the existing
+  `kMaxHarnessDecodeBytes` budget. The round-trip legs hunt encoder header/marker/metadata bugs
+  (S2-02, S2-14), which do not need bulk pixel volume.
+
+Verified: dispatch 34211319181 — all nine legs green, plain and ASan; the j2k plain loops recorded
+their tolerated timeouts as artifacts.
+
+## Prevention
+
+- **Ask where the fix lives relative to the test that is red.** A seam-level guard (deadline,
+  memory budget, admission control) protects requests, not the codec entry points a unit test or
+  fuzz harness calls directly. Before writing "leg goes green once X lands" into a plan, check that
+  the leg's call path actually passes through X.
+- **A known, unfixable hang class needs an explicit policy in the gate, not a red badge.** Options
+  were: tolerate at the harness (hides hangs in *our* JP2 code too, duplicates the seam mechanism),
+  keep red (zero signal), or fork mode with tolerated timeouts (records instances, still fails on
+  crashes). The third is the only one that keeps the leg informative.
+- **Read the fuzzer's exit-code semantics from the source you build.** libFuzzer's flags have
+  interactions (`ignore_timeouts` vs the parent's final `exit(ExitCode)`) that the flag help does
+  not spell out. The vendored `compiler-rt/lib/fuzzer/` under the Bazel output base is the primary
+  source.
+- **Budget the harness by decoded volume, not input size.** Fuzz inputs are small by construction;
+  what they *declare* is not. Any encode/transform step in a harness needs a cap derived from the
+  decoded geometry.
+- **Keep hang fixtures out of every corpus.** `test/_test_data/images/hang/` is loaded by no
+  corpus-replay target; seeding one there would hang `bazel test //src/...`.
+
+## References
+
+- PR #804, merged 2026-09-08; commits `8bb3b431` (ci), `499523fd` (harness cap).
+- `docs/src/development/fuzzing.md` § Nightly CI (fork-mode and encode-budget paragraphs).
+- `docs/specs/2026-09-04-02-jp2-decode-watchdog-design.md` — the seam deadline design whose
+  "Follow-through" expected the j2k leg to go green.
+- Fuzz runs: last green nightly before the fix 33290462514 (2026-08-30); first red 33354275318;
+  fork-mode exit-code failure 34208084507; first fully green dispatch 34211319181.
+- libFuzzer: `FuzzerFork.cpp` (`exit(ExitCode)` after the job loop), `FuzzerFlags.def`
+  (`ignore_timeouts` default 1 in fork mode, `timeout_exitcode` default 70).


### PR DESCRIPTION
Part of DEV-7080

## Summary
- Adds four documents under `docs/learnings/`, extracted from PR #804 (`fix(metadata,cli,format_handlers): the four bugs behind the red fuzz nightly`), merged 2026-09-08.

## Learnings Documented
- **debugging/asan-container-overflow-in-fuzz-binaries-is-a-link-artifact.md** — the fuzz binaries link an unsanitized libFuzzer runtime sharing libc++ with instrumented code, so ASan's container-overflow detector fires on valid accesses; verify in the non-fuzz `asan-ubsan` job before treating one as a bug. Three reports, one mechanism, zero defects.
- **testing/seam-mitigation-does-not-green-a-codec-fuzz-leg.md** — the DEV-7080 watchdog lives at the FFI seam; the codec harness runs below it. Fork mode with tolerated timeouts on the j2k legs, `-timeout_exitcode=0` because the fork parent exits with its last child's code, and a 16 MiB re-encode budget for the round-trip harness.
- **debugging/fuzz-leg-reports-one-finding-at-a-time.md** — libFuzzer stops at the first crash per leg; a red leg is a queue. Three fix-and-dispatch rounds turned "four bugs" into six findings, two of them severe and invisible in the first artifacts.
- **architecture/kakadu-teardown-order-and-pod-templates-accepting-std-string.md** — destroy a Kakadu codestream before the JPX target unwinds (RAII guard after the target), and never read a class type through `&val, sizeof(T)` (the 2016 `addKeyVal<std::string>` bug).

## Test plan
- Documentation only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)