### PR TITLE
chore(ci): wave-2 Phase 12 bookkeeping and stale fuzz.yml Darwin note

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -42,9 +42,11 @@
 # Kakadu hang class is known and contained at the seam, so a fresh instance is
 # recorded as a `timeout-*` artifact, not a red leg.
 #
-# Linux-amd64 only: `--config=fuzz` cannot link the libFuzzer runtime on
-# darwin (`.bazelrc` §Fuzzing), exactly like the sanitizer gate. macOS gets the
-# corpus-replay tests, which ride along in the ordinary `//src/...` sweeps.
+# Linux-amd64 only. `--config=fuzz` links on macOS too since hermetic-llvm
+# 0.8.18 (`.bazelrc` §Fuzzing; `just fuzz` runs the loop locally on darwin),
+# but phase 5's `--config=fuzz --config=asan` pairing is still Linux-only, so
+# one Linux leg carries both passes. macOS gets the corpus-replay tests, which
+# ride along in the ordinary `//src/...` sweeps.
 #
 # Every Bazel step invokes `just <recipe>` — no inline bazel calls (CLAUDE.md's
 # build-reproducibility invariant). The fuzz loop itself is not a Bazel

--- a/docs/specs/2026-09-04-01-fix-sipi-security-hardening-wave-2-plan.md
+++ b/docs/specs/2026-09-04-01-fix-sipi-security-hardening-wave-2-plan.md
@@ -537,13 +537,13 @@ _Execution: sonnet, low (proposed diffs only; every change is applied by the mai
 
 _Execution: haiku, low (dispositions are listed here; the work is bookkeeping)._
 
-- [ ] Close DEV-6072 with the disposition recorded in the wave-1 plan (S16 fixed, S25 gone, S15 accepted) (S2-44)
-- [ ] Close DEV-6075 as superseded: realloc-null fixed, strncpy absent, MEMTIFF unreachable, J2K cast = S2-02/03 (Phase 1)
-- [ ] Close DEV-6368 and DEV-6369 (duplicate pair; libjwt fork died with shttps, JWT is `jsonwebtoken`)
-- [ ] Close DEV-6117 (2025 report against the removed C++ server) or re-triage against the Rust shell with a reproduction request
-- [ ] Verify DEV-6640 against PR #795 (hermetic-llvm 0.8.18 unlocked macOS libFuzzer) and close if done
-- [ ] Verify DEV-7079 status against commit `dc12a6d1` (PNG eXIf fix) and close
-- [ ] Verify DEV-7132 to DEV-7147 are children of DEV-7131 with the finding IDs in each description and that their blocking edges match the dependencies stated in this plan (created 2026-09-04; keep them in sync when the plan changes)
+- [x] Close DEV-6072 with the disposition recorded in the wave-1 plan (S16 fixed, S25 gone, S15 accepted) (S2-44)
+- [x] Close DEV-6075 as superseded: realloc-null fixed, strncpy absent, MEMTIFF unreachable, J2K cast = S2-02/03 (Phase 1)
+- [x] Close DEV-6368 and DEV-6369 (duplicate pair; libjwt fork died with shttps, JWT is `jsonwebtoken`)
+- [x] Close DEV-6117 (2025 report against the removed C++ server) or re-triage against the Rust shell with a reproduction request
+- [x] Verify DEV-6640 against PR #795 (hermetic-llvm 0.8.18 unlocked macOS libFuzzer) and close if done
+- [x] Verify DEV-7079 status against commit `dc12a6d1` (PNG eXIf fix) and close
+- [x] Verify DEV-7132 to DEV-7147 are children of DEV-7131 with the finding IDs in each description and that their blocking edges match the dependencies stated in this plan (created 2026-09-04; keep them in sync when the plan changes)
 
 #### Phase 13: Security release and rollout (after the one PR merges) (DEV-7147)
 


### PR DESCRIPTION
Part of DEV-7131 (DEV-7146 is already Done in Linear; this PR records it in the plan)

## Motivation
Wave-2 Phase 12 (Linear reconciliation) was executed in Linear but the plan file still showed its checkboxes open. Separately, the `fuzz.yml` header still claimed `--config=fuzz` cannot link the libFuzzer runtime on Darwin, which stopped being true with hermetic-llvm 0.8.18 (PR #795) and contradicts `.bazelrc` §Fuzzing.

## Summary
- No user-visible change. Spec bookkeeping and a workflow comment only.

## Key Changes
### Plan
- Tick the seven Phase 12 checkboxes in `docs/specs/2026-09-04-01-fix-sipi-security-hardening-wave-2-plan.md`. Dispositions live on DEV-6072, DEV-6075, DEV-6117, DEV-6368, DEV-6369, DEV-6640 and DEV-7079; DEV-7132..DEV-7147 were verified as children of DEV-7131 with blocking edges matching the plan.

### Fuzz workflow comment
- Replace the "Linux-amd64 only: cannot link on darwin" paragraph. The nightly stays Linux-amd64 because phase 5's `--config=fuzz --config=asan` pairing is still Linux-only, not because the plain fuzz config fails to link on macOS.

## Challenges and Decisions
None. Two independent commits (spec vs. CI comment), no logic change.

## Gotchas
When a toolchain bump lifts a platform restriction, grep the workflow headers too, not only `.bazelrc`; the two drifted here for two weeks.

## Test Plan
- [x] `just commit-lint` green
- [x] No build or test impact: comment and Markdown edits only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7XjMFvSzWnymRABXCTKqL
