### PR TITLE
test(format_handlers): size the codec fuzz decode budget for the ASan -O0 pass

### DIFF
--- a/src/format_handlers/fuzz/codec_fuzz_harness.h
+++ b/src/format_handlers/fuzz/codec_fuzz_harness.h
@@ -128,7 +128,16 @@ inline std::uint16_t read_u16le(const uint8_t *data, std::size_t offset)
 // is where the container/header parsing coverage lives — only the second,
 // full `read` step is skipped once the probe's geometry implies a buffer
 // above this budget.
-inline constexpr std::uint64_t kMaxHarnessDecodeBytes = 512ULL * 1024 * 1024;
+//
+// Sized for the slowest configuration that runs this harness, not for RSS.
+// The ASan-paired fuzz pass builds at `-O0` (`build:asan` forces
+// `--compilation_mode=dbg`), where libc++ destroys a byte vector with one
+// non-inlined call per element and the TIFF handler holds two full-size
+// pixel buffers at once — so an admitted decode costs roughly 60 ms per MB
+// of geometry even when libtiff rejects the first scanline. libFuzzer's
+// per-input timeout is 25 s (`fuzz.yml`); 64 MiB keeps the worst case near
+// 4 s. Larger geometries add no coverage: more scanlines run the same code.
+inline constexpr std::uint64_t kMaxHarnessDecodeBytes = 64ULL * 1024 * 1024;
 
 // Encode budget for `run_roundtrip`'s four re-encodes (rationale at the use
 // site): a decoded image above this many bytes is not re-encoded.


### PR DESCRIPTION
## Motivation
The nightly `fuzz.yml` run of 2026-09-10 (run 34433730587) failed on the `tiff` leg, step "Fuzz under ASan (300s)", with `libFuzzer: timeout` and no sanitizer finding. The other eight legs were green and the plain `-c opt` pass on the same leg ran 492k inputs with a slowest unit of 0 s. The red leg had no codec bug behind it; the harness admitted a decode that the ASan build cannot finish inside the 25 s per-input timeout.

## Summary
- Lower the codec fuzz harness's decode-size budget (`kMaxHarnessDecodeBytes`) from 512 MiB to 64 MiB.
- Document that the budget is sized for the slowest configuration running the harness (ASan at `-O0`), not for RSS.

## Key Changes
### `src/format_handlers/fuzz/codec_fuzz_harness.h`
- `kMaxHarnessDecodeBytes` 512 MiB → 64 MiB, with the sizing rationale in the adjacent comment.

## Challenges and Decisions
### Why the timeout only shows under ASan
**Problem:** The reproducer (`timeout-da86bf31…`, 495 bytes) is an uncompressed TIFF declaring 65535 x 7937 pixels, no `SamplesPerPixel` (defaults to 1), and a garbage strip table. The shape probe estimated 520 MB, 3 percent under the 512 MiB budget, so the full `read` ran. `read()` allocates a 520 MB `inbuf`, `read_standard_data` allocates a second one, libtiff rejects strip 0 on the first scanline, and the function unwinds. Under `build:asan` (`--compilation_mode=dbg`, so `-O0`) libc++ destroys a byte vector with one non-inlined call per element, which is where the libFuzzer alarm fired (`__base_destruct_at_end` in the stack). Locally the fastbuild `sipi query` on this file takes 7.9 s at `-O0` without ASan; with ASan's ~2.6x overhead on a GHA runner that clears 25 s.
**Tried:** Nothing else was applied. Raising `-timeout` for the ASan pass would mask genuine hangs. Building the ASan-paired pass at `-c opt` would change the shared `asan` config the `asan-ubsan` CI job depends on.
**Solution:** Size the budget for the slowest configuration. At ~60 ms/MB the worst admitted decode stays near 4 s. Coverage is unaffected: more scanlines of a zero-filled image run the same code as fewer.

## Gotchas
- The harness budget comment previously justified 512 MiB against OOM only. Any budget that runs under `--config=asan` must also be checked against the per-input timeout at `-O0`, because the destructor cost is linear in the buffer size there.
- The TIFF read path holds two full-size pixel buffers at once (the caller's `inbuf` plus the one `read_standard_data` returns), so the real peak is 2x the geometry estimate. Not changed here; noted for the production memory-budget estimate.

## Test Plan
- [x] `bazel test //src/format_handlers/fuzz/...` on macOS: 8 of 8 corpus-replay tests pass.
- [x] `just commit-lint` OK.
- [x] `workflow_dispatch` of `fuzz.yml` on this branch ([run 34535972843](https://github.com/dasch-swiss/sipi/actions/runs/34535972843)): all nine legs green, including `fuzz / tiff / linux-amd64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXsRmd3uNx3CKrKj6A5vw3

